### PR TITLE
feat(dashboard): my tickets timeline

### DIFF
--- a/buzz/test_permissions.py
+++ b/buzz/test_permissions.py
@@ -81,7 +81,11 @@ def create_booking(event: str, user: str, owner: str | None = None) -> str:
 
 
 def create_ticket(
-	event: str, owner: str, attendee_email: str | None = None, booking: str | None = None
+	event: str,
+	owner: str,
+	attendee_email: str | None = None,
+	booking: str | None = None,
+	submit: bool = False,
 ) -> str:
 	ticket = frappe.get_doc(
 		{
@@ -93,6 +97,8 @@ def create_ticket(
 			"booking": booking,
 		}
 	).insert(ignore_permissions=True)
+	if submit:
+		ticket.submit()
 	frappe.db.set_value("Event Ticket", ticket.name, "owner", owner, update_modified=False)
 	return ticket.name
 
@@ -454,6 +460,91 @@ class TestNonMemberCarveOuts(TeamPermissionTestCase):
 
 	def test_guest_event_reads_are_never_narrowed(self):
 		self.assertIsNone(team_query_conditions(user="Guest", doctype="Buzz Event"))
+
+
+class TicketHolderTestCase(TeamPermissionTestCase):
+	"""A ticket is owned by whoever booked it, which is rarely the attendee holding it."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.booker = create_user("perm-booker@example.com", "Booker")
+		cls.holder = create_user("perm-holder@example.com", "Holder")
+		cls.stranger = create_user("perm-stranger@example.com", "Stranger")
+		cls.viewer = create_user("perm-viewer@example.com", "Viewer")
+		add_member(cls.team_b, cls.viewer, "Viewer")
+
+	def listed_tickets(self, user: str) -> list[str]:
+		self.as_user(user)
+		return frappe.get_list("Event Ticket", pluck="name")
+
+	def held_ticket(self, owner: str | None = None) -> str:
+		return create_ticket(self.event_b, owner or self.booker, attendee_email=self.holder, submit=True)
+
+
+class TestTicketHolderVisibility(TicketHolderTestCase):
+	def test_holder_sees_a_guest_booked_ticket(self):
+		ticket = self.held_ticket(owner="Guest")
+
+		self.assertIn(ticket, self.listed_tickets(self.holder))
+
+	def test_booker_still_sees_the_tickets_they_created(self):
+		ticket = self.held_ticket()
+
+		self.assertIn(ticket, self.listed_tickets(self.booker))
+
+	def test_team_member_reads_every_ticket_for_their_event(self):
+		ticket = self.held_ticket()
+
+		self.as_user(self.bob)
+		self.assertTrue(frappe.has_permission("Event Ticket", "read", doc=ticket))
+
+	def test_viewer_sees_their_teams_tickets(self):
+		ticket = self.held_ticket()
+
+		self.assertIn(ticket, self.listed_tickets(self.viewer))
+
+
+class TestTicketImmutability(TicketHolderTestCase):
+	"""Reading a ticket you hold is a carve-out. Changing one is not."""
+
+	def test_holder_cannot_cancel_or_delete_their_ticket(self):
+		ticket = self.held_ticket()
+
+		self.as_user(self.holder)
+		self.assertFalse(frappe.has_permission("Event Ticket", "cancel", doc=ticket))
+		self.assertFalse(frappe.has_permission("Event Ticket", "delete", doc=ticket))
+
+	def test_holder_saving_their_ticket_is_refused(self):
+		ticket = create_ticket(self.event_b, self.booker, attendee_email=self.holder)
+
+		self.as_user(self.holder)
+		doc = frappe.get_doc("Event Ticket", ticket)
+		doc.attendee_name = "Renamed"
+
+		with self.assertRaises(frappe.PermissionError):
+			doc.save()
+
+	def test_stranger_cannot_write_another_persons_ticket(self):
+		ticket = self.held_ticket()
+
+		self.as_user(self.stranger)
+		self.assertFalse(frappe.has_permission("Event Ticket", "write", doc=ticket))
+
+	def test_submitted_ticket_is_frozen_even_for_administrator(self):
+		doc = frappe.get_doc("Event Ticket", self.held_ticket())
+		doc.event = self.event_a
+
+		with self.assertRaises(frappe.UpdateAfterSubmitError):
+			doc.save()
+
+	def test_only_the_transfer_fields_stay_editable_after_submit(self):
+		editable = {
+			field.fieldname for field in frappe.get_meta("Event Ticket").fields if field.allow_on_submit
+		}
+
+		# The ticket transfer flow needs these four and nothing else.
+		self.assertEqual(editable, {"first_name", "last_name", "attendee_name", "attendee_email"})
 
 
 class TestTeamSettingsPermissions(TeamPermissionTestCase):

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -37,6 +37,7 @@ declare module 'vue' {
     OfflinePaymentDialog: typeof import('./src/components/OfflinePaymentDialog.vue')['default']
     PaymentGatewayDialog: typeof import('./src/components/PaymentGatewayDialog.vue')['default']
     PhoneInput: typeof import('./src/components/PhoneInput.vue')['default']
+    PrintedTicket: typeof import('./src/components/dashboard/tickets/PrintedTicket.vue')['default']
     ProfileView: typeof import('./src/components/ProfileView.vue')['default']
     ProposalEditDialog: typeof import('./src/components/ProposalEditDialog.vue')['default']
     QRCodeExpandDialog: typeof import('./src/components/QRCodeExpandDialog.vue')['default']

--- a/dashboard/src/components/dashboard/tickets/PrintedTicket.vue
+++ b/dashboard/src/components/dashboard/tickets/PrintedTicket.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import QRCodeExpandDialog from "@/components/QRCodeExpandDialog.vue";
+import type { TicketWithEvent } from "@/types";
+import { barcodePattern } from "@/utils/ticketBarcode";
+import { dayjs } from "frappe-ui";
+import { computed, ref } from "vue";
+
+const props = defineProps<{ ticket: TicketWithEvent }>();
+
+const showQR = ref(false);
+
+const barcode = computed(() => ({ backgroundImage: barcodePattern(props.ticket.name) }));
+// Plain dayjs: start_date is date-only, and a timezone shift moves it a day back.
+const day = computed(() => dayjs(props.ticket.start_date).format("DD.MM"));
+const year = computed(() => dayjs(props.ticket.start_date).format("YYYY"));
+
+// Times arrive as a serialized timedelta ("9:00:00"), so the hour needs padding.
+const doors = computed(() => {
+	if (!props.ticket.start_time) return "To be announced";
+	const [hour, minute] = props.ticket.start_time.split(":");
+	return `${hour.padStart(2, "0")}:${minute}`;
+});
+</script>
+
+<template>
+	<article class="flex items-stretch gap-3 text-ink-gray-9">
+		<section
+			class="flex-1 min-w-0 flex flex-col justify-between gap-6 rounded-2xl bg-surface-gray-4 p-6 min-h-[12rem]"
+		>
+			<div
+				class="flex flex-col gap-1 md:flex-row md:items-start md:justify-between md:gap-6"
+			>
+				<h3
+					class="font-black uppercase text-[1.375rem] md:text-[1.75rem] leading-[0.92] tracking-tight line-clamp-2"
+				>
+					{{ ticket.event_title }}
+				</h3>
+				<p
+					class="font-black text-[1.375rem] md:text-[1.75rem] leading-[0.92] tracking-tight tabular-nums md:shrink-0 md:text-right"
+				>
+					<span>{{ day }}</span>
+					<span class="ml-2 md:ml-0 md:block">{{ year }}</span>
+				</p>
+			</div>
+
+			<div
+				class="flex flex-col gap-4 md:flex-row md:gap-10 text-[10px] uppercase leading-[1.5]"
+			>
+				<dl class="shrink-0 space-y-3">
+					<div>
+						<dt class="tracking-[0.12em] text-ink-gray-8">Doors</dt>
+						<dd class="tracking-wide tabular-nums">{{ doors }}</dd>
+					</div>
+					<div>
+						<dt class="tracking-[0.12em] text-ink-gray-8">Ticket</dt>
+						<dd class="tracking-wide">{{ ticket.ticket_type }}</dd>
+					</div>
+				</dl>
+
+				<dl class="min-w-0">
+					<dt class="tracking-[0.12em] text-ink-gray-8">Venue</dt>
+					<dd class="tracking-wide line-clamp-2">
+						{{ ticket.venue || "To be announced" }}
+					</dd>
+				</dl>
+			</div>
+		</section>
+
+		<!-- Spans only: a button may not contain flow content. -->
+		<button
+			type="button"
+			:disabled="!ticket.qr_code"
+			:aria-label="
+				ticket.qr_code
+					? `Show QR code for ${ticket.attendee_name}, ticket #${ticket.name}`
+					: undefined
+			"
+			class="ticket-stub w-[27%] min-w-[10.5rem] shrink-0 flex flex-col justify-between gap-4 rounded-2xl bg-surface-gray-2 p-4 text-left enabled:active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-gray-9"
+			@click="showQR = true"
+		>
+			<span class="block truncate text-[9px] font-semibold uppercase tracking-[0.2em]">
+				{{ ticket.event_title }}
+			</span>
+
+			<span class="flex justify-between gap-2 text-[10px] uppercase tracking-[0.12em]">
+				<span class="shrink-0 text-ink-gray-8">Admits</span>
+				<span class="truncate">{{ ticket.attendee_name }}</span>
+			</span>
+
+			<span class="block space-y-2">
+				<span class="block h-6 w-full" :style="barcode" aria-hidden="true" />
+				<span class="flex justify-between gap-2 text-[10px] uppercase tracking-[0.12em]">
+					<span class="shrink-0 whitespace-nowrap text-ink-gray-8">Ticket</span>
+					<span class="truncate font-mono tracking-normal">#{{ ticket.name }}</span>
+				</span>
+			</span>
+		</button>
+
+		<!-- Portalled, so it renders at the body and nothing here shifts. -->
+		<QRCodeExpandDialog
+			v-if="ticket.qr_code"
+			v-model="showQR"
+			:qr-code-src="ticket.qr_code"
+			:alt-text="`QR code for ticket ${ticket.name}`"
+		/>
+	</article>
+</template>
+
+<style scoped>
+/* Tear notches. The mask clips anything outside the border box, so focus rings must be inset. */
+.ticket-stub {
+	--notch: transparent 5px, black 6px;
+	-webkit-mask-image: radial-gradient(circle 6px at 0 32%, var(--notch)),
+		radial-gradient(circle 6px at 0 68%, var(--notch)),
+		radial-gradient(circle 6px at 100% 32%, var(--notch)),
+		radial-gradient(circle 6px at 100% 68%, var(--notch));
+	mask-image: radial-gradient(circle 6px at 0 32%, var(--notch)),
+		radial-gradient(circle 6px at 0 68%, var(--notch)),
+		radial-gradient(circle 6px at 100% 32%, var(--notch)),
+		radial-gradient(circle 6px at 100% 68%, var(--notch));
+	-webkit-mask-composite: source-in;
+	mask-composite: intersect;
+	transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1), background-color 160ms ease;
+}
+
+/* A touch tap fires hover and leaves it stuck. */
+@media (hover: hover) and (pointer: fine) {
+	.ticket-stub:not(:disabled):hover {
+		background-color: var(--surface-gray-3);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.ticket-stub:not(:disabled):active {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/data/tickets.ts
+++ b/dashboard/src/data/tickets.ts
@@ -1,0 +1,31 @@
+import { session } from "@/data/session"
+import { userResource } from "@/data/user"
+import type { TicketStub } from "@/types"
+import { useList } from "frappe-ui"
+
+// Everything the printed ticket shows lives on the ticket or one link hop away,
+// so the standard list call covers it without a whitelisted endpoint.
+export function useMyTickets() {
+	return useList<TicketStub>({
+		doctype: "Event Ticket",
+		fields: [
+			"name",
+			"attendee_name",
+			"qr_code",
+			"ticket_type.title as ticket_type",
+			"event.title as event_title",
+			"event.start_date",
+			"event.end_date",
+			"event.start_time",
+			"event.venue",
+		],
+		// Tickets are held by email address, which is the session id for everyone
+		// except Administrator — hence the account email first.
+		filters: () => ({
+			attendee_email: userResource.data?.email || session.user,
+			docstatus: 1,
+		}),
+		// No cacheKey: it persists to IndexedDB and would outlive this user's session.
+		orderBy: "creation desc",
+	})
+}

--- a/dashboard/src/pages/manage/MyEvents.vue
+++ b/dashboard/src/pages/manage/MyEvents.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import EventCard from "@/components/dashboard/events/EventCard.vue";
 import type { MyEvents } from "@/types";
+import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
 import { groupEventsByMonth } from "@/utils/eventGroups";
-import { ErrorMessage, LoadingText, TabButtons, dayjsLocal, useCall } from "frappe-ui";
+import { ErrorMessage, LoadingText, TabButtons, useCall } from "frappe-ui";
 import { computed, ref } from "vue";
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
@@ -18,22 +19,6 @@ const tabOptions = [
 ];
 
 const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || []));
-
-function monthLabel(month: string): string {
-	return dayjsLocal(`${month}-01`).format("MMMM YYYY");
-}
-
-// dayjs ships isToday here, but not the calendar plugin, so tomorrow is compared by hand.
-function dayLabel(date: string): string {
-	const day = dayjsLocal(date);
-	if (day.isToday()) return "Today";
-	if (day.isSame(dayjsLocal().add(1, "day"), "day")) return "Tomorrow";
-	return day.format("D MMM");
-}
-
-function weekday(date: string): string {
-	return dayjsLocal(date).format("dddd");
-}
 </script>
 
 <template>

--- a/dashboard/src/pages/manage/MyTickets.vue
+++ b/dashboard/src/pages/manage/MyTickets.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import PrintedTicket from "@/components/dashboard/tickets/PrintedTicket.vue";
+import { useMyTickets } from "@/data/tickets";
+import type { TicketWithEvent } from "@/types";
+import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
+import { groupEventsByMonth } from "@/utils/eventGroups";
+import { ErrorMessage, LoadingText, TabButtons, dayjs } from "frappe-ui";
+import { computed, ref } from "vue";
+
+const tab = ref<"upcoming" | "past">("upcoming");
+const tabOptions = [
+	{ label: "Upcoming", value: "upcoming" },
+	{ label: "Past", value: "past" },
+];
+
+const tickets = useMyTickets();
+
+// A ticket whose event was deleted has no date to file it under, so it drops out.
+const dated = computed(() =>
+	(tickets.data || []).filter((ticket): ticket is TicketWithEvent =>
+		Boolean(ticket.start_date && ticket.event_title)
+	)
+);
+
+const months = computed(() => {
+	const today = dayjs().format("YYYY-MM-DD");
+	const upcoming = tab.value === "upcoming";
+	// Same rule as the events feed: an event running through today is not over yet.
+	const isOver = (ticket: TicketWithEvent) => (ticket.end_date || ticket.start_date) < today;
+	const shown = dated.value
+		.filter((ticket) => isOver(ticket) !== upcoming)
+		.sort((a, b) =>
+			upcoming
+				? a.start_date.localeCompare(b.start_date)
+				: b.start_date.localeCompare(a.start_date)
+		);
+	return groupEventsByMonth(shown);
+});
+</script>
+
+<template>
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
+		<header class="flex items-center justify-between">
+			<h1 class="font-semibold text-4xl">Tickets</h1>
+			<TabButtons v-model="tab" :options="tabOptions" size="md" />
+		</header>
+
+		<ErrorMessage v-if="tickets.error" :message="tickets.error.message" />
+
+		<LoadingText v-else-if="tickets.loading" text="Loading tickets..." />
+
+		<div v-else class="relative space-y-6">
+			<section v-for="month in months" :key="month.month" class="space-y-4">
+				<h2
+					class="relative bg-surface-elevation-1 py-1 text-xl font-semibold text-ink-gray-8"
+				>
+					{{ monthLabel(month.month) }}
+				</h2>
+
+				<div
+					v-for="day in month.days"
+					:key="day.date"
+					class="grid grid-cols-[6rem_1fr] gap-4"
+				>
+					<div class="pt-1">
+						<p class="font-semibold text-ink-gray-8">{{ dayLabel(day.date) }}</p>
+						<p class="text-base text-ink-gray-5">{{ weekday(day.date) }}</p>
+					</div>
+
+					<div class="relative space-y-1 pl-6 pb-7">
+						<div class="absolute -left-4 flex flex-col items-center h-full">
+							<span
+								class="size-2 rounded-full bg-surface-gray-4"
+								aria-hidden="true"
+							/>
+							<div
+								class="w-px h-full bg-gradient-to-b from-outline-gray-2 from-75% to-transparent"
+							></div>
+						</div>
+
+						<div class="space-y-6">
+							<PrintedTicket
+								v-for="ticket in day.events"
+								:key="ticket.name"
+								:ticket="ticket"
+							/>
+						</div>
+					</div>
+				</div>
+			</section>
+		</div>
+
+		<p
+			v-if="!months.length && !tickets.loading && !tickets.error"
+			class="text-base text-ink-gray-5"
+		>
+			No {{ tab }} tickets.
+		</p>
+	</div>
+</template>

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -27,12 +27,17 @@ const routes: RouteRecordRaw[] = [
 				name: "events",
 				component: () => import("@/pages/manage/MyEvents.vue"),
 			},
+			{
+				path: "tickets",
+				name: "tickets",
+				component: () => import("@/pages/manage/MyTickets.vue"),
+			},
 			// Sidebar destinations that have no page yet. Unnamed on purpose: SidebarItem
 			// falls back to matching on path, so each one lights up on its own. Enumerated
 			// so a mistyped path reaches the 404 below — keep in step with the sidebar
 			// items in ManagerLayout.vue.
 			{
-				path: ":section(tickets|proposals|sponsorship|overview|registrations|sponsors|more)",
+				path: ":section(proposals|sponsorship|overview|registrations|sponsors|more)",
 				component: () => import("@/pages/manage/WorkInProgress.vue"),
 			},
 			// Claims the rest of /manage before the two-segment custom form route can:

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -85,6 +85,7 @@ export interface TicketStub {
 	// Event columns come over a link hop, so a deleted event leaves them null.
 	event_title: string | null
 	start_date: string | null
+	end_date: string | null
 	start_time: string | null
 	venue: string | null
 }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -76,6 +76,22 @@ export interface MyEvents {
 	past: MyEvent[]
 }
 
+// A ticket the user holds, flattened with the context its event carries.
+export interface TicketStub {
+	name: string
+	attendee_name: string
+	ticket_type: string
+	qr_code: string | null
+	// Event columns come over a link hop, so a deleted event leaves them null.
+	event_title: string | null
+	start_date: string | null
+	start_time: string | null
+	venue: string | null
+}
+
+// A ticket whose event row still resolves — the only kind the ticket UI can draw.
+export type TicketWithEvent = TicketStub & { event_title: string; start_date: string }
+
 // Languages served by the translation API (not a Buzz DocType).
 export interface Language {
 	name: string

--- a/dashboard/src/utils/dateLabels.ts
+++ b/dashboard/src/utils/dateLabels.ts
@@ -1,0 +1,19 @@
+// Plain dayjs, not dayjsLocal: these are date-only values, and shifting them
+// between timezones lands them on the day before.
+import { dayjs } from "frappe-ui"
+
+export function monthLabel(month: string): string {
+	return dayjs(`${month}-01`).format("MMMM YYYY")
+}
+
+// frappe-ui's dayjs ships isToday but not the calendar plugin, so tomorrow is compared by hand.
+export function dayLabel(date: string): string {
+	const day = dayjs(date)
+	if (day.isToday()) return "Today"
+	if (day.isSame(dayjs().add(1, "day"), "day")) return "Tomorrow"
+	return day.format("D MMM")
+}
+
+export function weekday(date: string): string {
+	return dayjs(date).format("dddd")
+}

--- a/dashboard/src/utils/ticketBarcode.test.ts
+++ b/dashboard/src/utils/ticketBarcode.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { barcodePattern } from "./ticketBarcode.ts"
+
+const IDS = ["a1b2c3d4e5", "0f9e8d7c6b", "1042", "a"]
+
+test("a ticket always draws the same strip", () => {
+	assert.equal(barcodePattern("a1b2c3d4e5"), barcodePattern("a1b2c3d4e5"))
+})
+
+test("different tickets draw different strips", () => {
+	const strips = new Set(IDS.map((id) => barcodePattern(id)))
+	assert.equal(strips.size, IDS.length)
+})
+
+test("bars and gaps stay between 1 and 3px", () => {
+	for (const id of IDS) {
+		for (const [, from, to] of barcodePattern(id).matchAll(/(\d+)px (\d+)px/g)) {
+			const width = Number(to) - Number(from)
+			assert.ok(width >= 1 && width <= 3, `${id} drew a ${width}px segment`)
+		}
+	}
+})
+
+test("a missing id draws nothing", () => {
+	assert.equal(barcodePattern(""), "none")
+})

--- a/dashboard/src/utils/ticketBarcode.ts
+++ b/dashboard/src/utils/ticketBarcode.ts
@@ -1,0 +1,21 @@
+// Decorative barcode: bar and gap widths come from the ticket id's characters, so a
+// ticket always draws the same strip. Not scannable — the QR code carries the data.
+
+const BAR = "var(--ink-gray-8)"
+
+export function barcodePattern(ticketId: string): string {
+	if (!ticketId) return "none"
+	const stops: string[] = []
+	let edge = 0
+	for (const character of ticketId) {
+		const code = character.charCodeAt(0)
+		const width = 1 + (code % 3)
+		const gap = 1 + ((code >> 2) % 3)
+		stops.push(
+			`${BAR} ${edge}px ${edge + width}px`,
+			`transparent ${edge + width}px ${edge + width + gap}px`,
+		)
+		edge += width + gap
+	}
+	return `linear-gradient(90deg, ${stops.join(", ")})`
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/e006cac3-2f7b-4694-9dbd-d4ffc80f6a8c



Fills in the My Tickets sidebar item, which until now landed on the
work-in-progress stub. Tickets render as physical tickets: an event panel
and a tear-off stub, grouped by month and day under upcoming/past tabs,
matching the events timeline minus the vertical rail.

## No new endpoint

Everything a ticket shows sits on the ticket or one link hop away, so the
standard `useList` call covers it the same way `TicketsList` already does.
`buzz/api/tickets/` is untouched. The joins were checked against the site
before wiring: `ticket_type.title`, `event.title`, `event.start_date`,
`event.start_time`, `event.venue` all resolve.

## Things worth knowing

- Filtering is by account email, not `session.user`. Administrator's session
  id is not an email and matches no ticket.
- Some tickets point at deleted events; those come back with null event
  columns and are dropped, since there is no date to group them under.
  `TicketWithEvent` narrows the type at that boundary.
- The notch mask clips anything painted outside the border box, so focus
  uses an inset ring. An outline is computed but never drawn.
- Date labels moved out of `MyEvents` into a shared util and switched from
  `dayjsLocal` to plain `dayjs`. These are date-only values and the timezone
  hop lands them a day early. Dormant while `window.timezone` is unset,
  armed on any site whose boot populates it.

## Not done here

`-webkit-mask-composite` is verified in Chrome only; the notches want a
Safari look before this ships. The barcode is decorative, the QR image the
server already attaches is the scannable one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)