### PR TITLE
feat(dashboard): my talk proposals timeline at /manage/proposals

### DIFF
--- a/buzz/api/proposals/__init__.py
+++ b/buzz/api/proposals/__init__.py
@@ -1,6 +1,6 @@
 import frappe
 
-from buzz.api.proposals.schemas import ProposalListItem
+from buzz.api.proposals.schemas import ProposalListItem, ProposalSpeakerItem
 
 
 @frappe.whitelist()
@@ -24,8 +24,38 @@ def get_my_proposals() -> list[ProposalListItem]:
 			"submitted_by": user,
 			"name": ["in", speaker_proposal_names],
 		},
-		fields=["name", "title", "event", "event.title as event_title", "status", "creation"],
+		fields=[
+			"name",
+			"title",
+			"event",
+			"event.title as event_title",
+			"event.start_date",
+			"event.banner_image",
+			"status",
+			"creation",
+			"modified",
+		],
 		order_by="creation desc",
 	)
 
-	return [ProposalListItem(**row) for row in rows]
+	speakers = speakers_by_proposal([row.name for row in rows])
+
+	return [ProposalListItem(**row, speakers=speakers.get(row.name, [])) for row in rows]
+
+
+def speakers_by_proposal(proposal_names: list[str]) -> dict[str, list[ProposalSpeakerItem]]:
+	"""Speaker rows for many proposals in one query, keyed by proposal."""
+	if not proposal_names:
+		return {}
+
+	rows = frappe.get_all(
+		"Proposal Speaker",
+		filters={"parenttype": "Talk Proposal", "parent": ["in", proposal_names]},
+		fields=["parent", "first_name", "last_name", "email"],
+		order_by="parent asc, idx asc",
+	)
+
+	grouped: dict[str, list[ProposalSpeakerItem]] = {}
+	for row in rows:
+		grouped.setdefault(row.pop("parent"), []).append(ProposalSpeakerItem(**row))
+	return grouped

--- a/buzz/api/proposals/__init__.py
+++ b/buzz/api/proposals/__init__.py
@@ -1,61 +1,10 @@
 import frappe
 
-from buzz.api.proposals.schemas import ProposalListItem, ProposalSpeakerItem
+from buzz.api.proposals import services
+from buzz.api.proposals.schemas import ProposalListItem
 
 
 @frappe.whitelist()
 def get_my_proposals() -> list[ProposalListItem]:
-	"""Proposals where the session user is the submitter or a listed speaker.
-
-	Speaker matching runs on the speakers child table because guest form
-	submissions leave submitted_by as "Guest".
-	"""
-	user = frappe.session.user
-
-	speaker_proposal_names = frappe.get_all(
-		"Proposal Speaker",
-		filters={"parenttype": "Talk Proposal", "email": user},
-		pluck="parent",
-	)
-
-	rows = frappe.get_all(
-		"Talk Proposal",
-		or_filters={
-			"submitted_by": user,
-			"name": ["in", speaker_proposal_names],
-		},
-		fields=[
-			"name",
-			"title",
-			"event",
-			"event.title as event_title",
-			"event.start_date",
-			"event.banner_image",
-			"status",
-			"creation",
-			"modified",
-		],
-		order_by="creation desc",
-	)
-
-	speakers = speakers_by_proposal([row.name for row in rows])
-
-	return [ProposalListItem(**row, speakers=speakers.get(row.name, [])) for row in rows]
-
-
-def speakers_by_proposal(proposal_names: list[str]) -> dict[str, list[ProposalSpeakerItem]]:
-	"""Speaker rows for many proposals in one query, keyed by proposal."""
-	if not proposal_names:
-		return {}
-
-	rows = frappe.get_all(
-		"Proposal Speaker",
-		filters={"parenttype": "Talk Proposal", "parent": ["in", proposal_names]},
-		fields=["parent", "first_name", "last_name", "email"],
-		order_by="parent asc, idx asc",
-	)
-
-	grouped: dict[str, list[ProposalSpeakerItem]] = {}
-	for row in rows:
-		grouped.setdefault(row.pop("parent"), []).append(ProposalSpeakerItem(**row))
-	return grouped
+	"""Proposals where the session user is the submitter or a listed speaker."""
+	return services.my_proposals()

--- a/buzz/api/proposals/schemas.py
+++ b/buzz/api/proposals/schemas.py
@@ -13,9 +13,10 @@ class ProposalListItem(APIResponse):
 	name: str
 	title: str
 	event: str
-	# Joined over the event link, so a deleted event leaves both empty.
+	# Joined over the event link, so a deleted event leaves them empty.
 	event_title: str | None = None
 	start_date: date | None = None
+	end_date: date | None = None
 	banner_image: str | None = None
 	status: str
 	creation: datetime

--- a/buzz/api/proposals/schemas.py
+++ b/buzz/api/proposals/schemas.py
@@ -1,12 +1,23 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from buzz.api.schemas import APIResponse
+
+
+class ProposalSpeakerItem(APIResponse):
+	first_name: str
+	last_name: str | None = None
+	email: str
 
 
 class ProposalListItem(APIResponse):
 	name: str
 	title: str
 	event: str
+	# Joined over the event link, so a deleted event leaves both empty.
 	event_title: str | None = None
+	start_date: date | None = None
+	banner_image: str | None = None
 	status: str
 	creation: datetime
+	modified: datetime
+	speakers: list[ProposalSpeakerItem]

--- a/buzz/api/proposals/services.py
+++ b/buzz/api/proposals/services.py
@@ -1,0 +1,61 @@
+import frappe
+
+from buzz.api.proposals.schemas import ProposalListItem, ProposalSpeakerItem
+
+
+def my_proposals() -> list[ProposalListItem]:
+	"""Proposals where the session user is the submitter or a listed speaker.
+
+	Speaker matching runs on the speakers child table because guest form
+	submissions leave submitted_by as "Guest".
+	"""
+	user = frappe.session.user
+
+	speaker_proposal_names = frappe.get_all(
+		"Proposal Speaker",
+		filters={"parenttype": "Talk Proposal", "email": user},
+		pluck="parent",
+	)
+
+	rows = frappe.get_all(
+		"Talk Proposal",
+		or_filters={
+			"submitted_by": user,
+			"name": ["in", speaker_proposal_names],
+		},
+		fields=[
+			"name",
+			"title",
+			"event",
+			"event.title as event_title",
+			"event.start_date",
+			"event.end_date",
+			"event.banner_image",
+			"status",
+			"creation",
+			"modified",
+		],
+		order_by="creation desc",
+	)
+
+	speakers = speakers_by_proposal([row.name for row in rows])
+
+	return [ProposalListItem(**row, speakers=speakers.get(row.name, [])) for row in rows]
+
+
+def speakers_by_proposal(proposal_names: list[str]) -> dict[str, list[ProposalSpeakerItem]]:
+	"""Speaker rows for many proposals in one query, keyed by proposal."""
+	if not proposal_names:
+		return {}
+
+	rows = frappe.get_all(
+		"Proposal Speaker",
+		filters={"parenttype": "Talk Proposal", "parent": ["in", proposal_names]},
+		fields=["parent", "first_name", "last_name", "email"],
+		order_by="parent asc, idx asc",
+	)
+
+	grouped: dict[str, list[ProposalSpeakerItem]] = {}
+	for row in rows:
+		grouped.setdefault(row.pop("parent"), []).append(ProposalSpeakerItem(**row))
+	return grouped

--- a/buzz/api/proposals/test_proposals.py
+++ b/buzz/api/proposals/test_proposals.py
@@ -60,7 +60,70 @@ class TestGetMyProposals(IntegrationTestCase):
 		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
 		self.assertEqual(row["event"], cstr(self.event))
 		self.assertEqual(row["status"], "Review Pending")
-		self.assertEqual(set(row), {"name", "title", "event", "event_title", "status", "creation"})
+		self.assertEqual(
+			set(row),
+			{
+				"name",
+				"title",
+				"event",
+				"event_title",
+				"start_date",
+				"banner_image",
+				"status",
+				"creation",
+				"modified",
+				"speakers",
+			},
+		)
+
+	def test_rows_carry_their_speakers(self):
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
+		self.assertEqual(
+			row["speakers"],
+			[{"first_name": "Speaker", "last_name": None, "email": self.speaker_user}],
+		)
+
+	def test_speakers_keep_their_row_order(self):
+		proposal = frappe.get_doc(
+			{
+				"doctype": "Talk Proposal",
+				"title": f"Duo Talk {frappe.generate_hash(length=6)}",
+				"event": self.event,
+				"submitted_by": self.speaker_user,
+				"speakers": [
+					{"first_name": "First", "email": "first-speaker@example.com"},
+					{"first_name": "Second", "email": "second-speaker@example.com"},
+				],
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in serialized_proposals() if r["name"] == proposal.name)
+		self.assertEqual([speaker["first_name"] for speaker in row["speakers"]], ["First", "Second"])
+
+	def test_rows_carry_the_event_start_date(self):
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
+		self.assertEqual(cstr(row["start_date"]), "2030-01-01")
+
+	def test_rows_carry_the_event_banner(self):
+		frappe.db.set_value("Buzz Event", self.event, "banner_image", "/files/banner-probe.png")
+		self.addCleanup(frappe.clear_document_cache, "Buzz Event", self.event)
+
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
+		self.assertEqual(row["banner_image"], "/files/banner-probe.png")
+
+	def test_modified_tracks_the_latest_edit(self):
+		proposal = frappe.get_doc("Talk Proposal", self.guest_proposal)
+		proposal.title = f"Edited {frappe.generate_hash(length=6)}"
+		proposal.save(ignore_permissions=True)
+		self.addCleanup(frappe.clear_document_cache, "Talk Proposal", self.guest_proposal)
+
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
+		self.assertGreater(row["modified"], row["creation"])
 
 	def test_creation_serializes_in_frappe_datetime_format(self):
 		frappe.set_user(self.speaker_user)

--- a/buzz/api/proposals/test_proposals.py
+++ b/buzz/api/proposals/test_proposals.py
@@ -68,6 +68,7 @@ class TestGetMyProposals(IntegrationTestCase):
 				"event",
 				"event_title",
 				"start_date",
+				"end_date",
 				"banner_image",
 				"status",
 				"creation",
@@ -102,17 +103,13 @@ class TestGetMyProposals(IntegrationTestCase):
 		row = next(r for r in serialized_proposals() if r["name"] == proposal.name)
 		self.assertEqual([speaker["first_name"] for speaker in row["speakers"]], ["First", "Second"])
 
-	def test_rows_carry_the_event_start_date(self):
-		frappe.set_user(self.speaker_user)
-		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
-		self.assertEqual(cstr(row["start_date"]), "2030-01-01")
-
-	def test_rows_carry_the_event_banner(self):
+	def test_rows_carry_the_joined_event_columns(self):
 		frappe.db.set_value("Buzz Event", self.event, "banner_image", "/files/banner-probe.png")
 		self.addCleanup(frappe.clear_document_cache, "Buzz Event", self.event)
 
 		frappe.set_user(self.speaker_user)
 		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
+		self.assertEqual(cstr(row["start_date"]), "2030-01-01")
 		self.assertEqual(row["banner_image"], "/files/banner-probe.png")
 
 	def test_modified_tracks_the_latest_edit(self):

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder import Criterion
@@ -78,6 +79,13 @@ class TalkProposal(Document):
 
 	@frappe.whitelist()
 	def create_talk(self):
+		# A listed speaker holds write on their own proposal, so has_permission("write")
+		# would wave them through their own acceptance. Accepting belongs to the event's
+		# team, which is what the derived rule asks on its own. That rule waves through a
+		# team-less document, which cannot happen here: Buzz Event.team is mandatory.
+		if not derived_has_permission(self, ptype="write"):
+			frappe.throw(_("Only the event's team can accept a proposal."), frappe.PermissionError)
+
 		talk = get_mapped_doc("Talk Proposal", self.name, {"Talk Proposal": {"doctype": "Event Talk"}})
 
 		for speaker in self.speakers:

--- a/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
@@ -160,6 +160,37 @@ class TestCreateTalk(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value("User", email, "user_type"), "Website User")
 
+	def test_a_member_of_the_events_team_can_accept_a_proposal(self):
+		manager = make_test_user("create-talk-manager@example.com", roles=["Event Manager"])
+		team = create_owned_team("Create Talk Team", manager)
+		event = make_test_event(self.category, self.host, team=team)
+		proposal = frappe.get_doc("Talk Proposal", make_guest_proposal(event, self.speaker_user))
+
+		frappe.set_user(manager)
+		self.addCleanup(frappe.set_user, "Administrator")
+		talk = proposal.run_method("create_talk")
+
+		self.assertEqual(talk.proposal, proposal.name)
+		self.assertEqual(frappe.db.get_value("Talk Proposal", proposal.name, "status"), "Accepted")
+
+	def test_a_listed_speaker_cannot_accept_their_own_proposal(self):
+		# A speaker who already has a profile reaches the end of create_talk: nothing it
+		# touches needs a permission the speaker lacks.
+		if not frappe.db.exists("Speaker Profile", {"user": self.speaker_user}):
+			frappe.get_doc({"doctype": "Speaker Profile", "user": self.speaker_user}).insert()
+		proposal = frappe.get_doc("Talk Proposal", make_guest_proposal(self.event, self.speaker_user))
+
+		frappe.set_user(self.speaker_user)
+		self.addCleanup(frappe.set_user, "Administrator")
+		# run_doc_method loads the document with a read check and nothing more.
+		doc = frappe.get_doc("Talk Proposal", proposal.name, check_permission=True)
+
+		with self.assertRaises(frappe.PermissionError):
+			doc.run_method("create_talk")
+
+		self.assertEqual(frappe.db.get_value("Talk Proposal", proposal.name, "status"), "Review Pending")
+		self.assertEqual(frappe.db.count("Event Talk", {"proposal": proposal.name}), 0)
+
 	def test_second_create_talk_leaves_no_partial_state(self):
 		proposal = frappe.get_doc("Talk Proposal", make_guest_proposal(self.event, self.speaker_user))
 		proposal.create_talk()

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -53,6 +53,7 @@ declare module 'vue' {
     TicketDetailsModal: typeof import('./src/components/TicketDetailsModal.vue')['default']
     TicketsSection: typeof import('./src/components/TicketsSection.vue')['default']
     TicketTransferDialog: typeof import('./src/components/TicketTransferDialog.vue')['default']
+    TimelineList: typeof import('./src/components/dashboard/TimelineList.vue')['default']
     TransferTicketDialog: typeof import('./src/components/TransferTicketDialog.vue')['default']
     UserMenu: typeof import('./src/components/UserMenu.vue')['default']
   }

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -39,6 +39,7 @@ declare module 'vue' {
     PhoneInput: typeof import('./src/components/PhoneInput.vue')['default']
     PrintedTicket: typeof import('./src/components/dashboard/tickets/PrintedTicket.vue')['default']
     ProfileView: typeof import('./src/components/ProfileView.vue')['default']
+    ProposalCard: typeof import('./src/components/dashboard/proposals/ProposalCard.vue')['default']
     ProposalEditDialog: typeof import('./src/components/ProposalEditDialog.vue')['default']
     QRCodeExpandDialog: typeof import('./src/components/QRCodeExpandDialog.vue')['default']
     QRScanner: typeof import('./src/components/QRScanner.vue')['default']

--- a/dashboard/src/components/dashboard/TimelineList.vue
+++ b/dashboard/src/components/dashboard/TimelineList.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts" generic="T extends { name: string }">
+import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
+import type { MonthGroup } from "@/utils/eventGroups";
+import type { TimelineTab } from "@/utils/timelineTabs";
+import { ErrorMessage, LoadingText, TabButtons } from "frappe-ui";
+
+defineProps<{
+	heading: string;
+	// Names the rows in "Loading tickets..." and "No upcoming tickets.".
+	noun: string;
+	months: MonthGroup<T>[];
+	loading?: boolean;
+	error?: { message: string } | null;
+}>();
+
+const tab = defineModel<TimelineTab>("tab", { required: true });
+
+const tabOptions = [
+	{ label: "Upcoming", value: "upcoming" },
+	{ label: "Past", value: "past" },
+];
+</script>
+
+<template>
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
+		<header class="flex items-center justify-between">
+			<h1 class="font-semibold text-4xl">{{ heading }}</h1>
+			<TabButtons v-model="tab" :options="tabOptions" size="md" />
+		</header>
+
+		<ErrorMessage v-if="error" :message="error.message" />
+
+		<LoadingText v-else-if="loading" :text="`Loading ${noun}...`" />
+
+		<div v-else class="relative space-y-6">
+			<section v-for="month in months" :key="month.month" class="space-y-4">
+				<h2
+					class="relative bg-surface-elevation-1 py-1 text-xl font-semibold text-ink-gray-8"
+				>
+					{{ monthLabel(month.month) }}
+				</h2>
+
+				<div
+					v-for="day in month.days"
+					:key="day.date"
+					class="grid grid-cols-[6rem_1fr] gap-4"
+				>
+					<div class="pt-1">
+						<p class="font-semibold text-ink-gray-8">{{ dayLabel(day.date) }}</p>
+						<p class="text-base text-ink-gray-5">{{ weekday(day.date) }}</p>
+					</div>
+
+					<div class="relative space-y-1 pl-6 pb-7">
+						<div class="absolute -left-4 flex flex-col items-center h-full">
+							<span
+								class="size-2 rounded-full bg-surface-gray-4"
+								aria-hidden="true"
+							/>
+							<div
+								class="w-px h-full bg-gradient-to-b from-outline-gray-2 from-75% to-transparent"
+							></div>
+						</div>
+
+						<div class="space-y-6">
+							<template v-for="item in day.events" :key="item.name">
+								<slot :item="item" />
+							</template>
+						</div>
+					</div>
+				</div>
+			</section>
+		</div>
+
+		<p v-if="!months.length && !loading && !error" class="text-base text-ink-gray-5">
+			No {{ tab }} {{ noun }}.
+		</p>
+	</div>
+</template>

--- a/dashboard/src/components/dashboard/proposals/ProposalCard.vue
+++ b/dashboard/src/components/dashboard/proposals/ProposalCard.vue
@@ -42,21 +42,23 @@ const lastUpdated = computed(() =>
 				<h3 class="font-semibold text-xl text-ink-gray-8">{{ proposal.title }}</h3>
 				<p v-if="byline" class="text-base text-ink-gray-7">
 					By {{ byline.lead
-					}}<template v-if="byline.partner"> &amp; {{ byline.partner }}</template>
-					<template v-else-if="byline.others.length">
+					}}<template v-if="byline.rest.length === 1">
+						&amp; {{ byline.rest[0] }}</template
+					>
+					<template v-else-if="byline.rest.length">
 						and
 						<HoverCard :hover-delay="0.15" align="start">
 							<template #trigger>
 								<span
 									class="underline decoration-dotted underline-offset-2 transition-colors hover:text-ink-gray-9"
 								>
-									{{ byline.others.length }} others
+									{{ byline.rest.length }} others
 								</span>
 							</template>
 							<div class="p-2">
 								<ul class="space-y-2">
 									<li
-										v-for="(name, index) in byline.others"
+										v-for="(name, index) in byline.rest"
 										:key="index"
 										class="flex items-center gap-2 text-sm text-ink-gray-8"
 									>
@@ -67,7 +69,7 @@ const lastUpdated = computed(() =>
 							</div>
 						</HoverCard>
 						<!-- The card is hover-only, so the names need a spoken path too. -->
-						<span class="sr-only">: {{ byline.others.join(", ") }}</span>
+						<span class="sr-only">: {{ byline.rest.join(", ") }}</span>
 					</template>
 				</p>
 			</div>

--- a/dashboard/src/components/dashboard/proposals/ProposalCard.vue
+++ b/dashboard/src/components/dashboard/proposals/ProposalCard.vue
@@ -5,26 +5,28 @@ import { userResource } from "@/data/user";
 import type { ProposalWithEvent } from "@/types";
 import { bannerPattern } from "@/utils/eventBanner";
 import { speakerByline } from "@/utils/speakerByline";
-import { Avatar, Badge, HoverCard, dayjs, dayjsLocal } from "frappe-ui";
+import { Avatar, Badge, HoverCard, Tooltip, dayjs, dayjsLocal } from "frappe-ui";
 import { computed } from "vue";
 
 const props = defineProps<{ proposal: ProposalWithEvent }>();
 
-const { getStatusTheme } = useProposalStatuses();
+const { getStatusTheme, getStatusIcon } = useProposalStatuses();
 
 const byline = computed(() =>
 	speakerByline(props.proposal.speakers, userResource.data?.email || session.user)
 );
 
-const banner = computed(() => ({ backgroundImage: bannerPattern(props.proposal.event) }));
+const banner = computed(() => ({
+	backgroundImage: bannerPattern(props.proposal.event),
+}));
 
 // Plain dayjs: start_date is date-only, and a timezone shift moves it a day back.
 const eventDate = computed(() => dayjs(props.proposal.start_date).format("D MMM YYYY"));
 
 // modified is a full timestamp in the site's timezone, so this one does convert.
-const lastUpdated = computed(() =>
-	dayjsLocal(props.proposal.modified).format("D MMM YYYY, h:mm A")
-);
+const modified = computed(() => dayjsLocal(props.proposal.modified));
+const lastUpdated = computed(() => modified.value.fromNow());
+const lastUpdatedExact = computed(() => modified.value.format("D MMM YYYY, h:mm A"));
 </script>
 
 <template>
@@ -34,11 +36,6 @@ const lastUpdated = computed(() =>
 	>
 		<article class="flex flex-col space-y-6 p-4">
 			<div class="space-y-2">
-				<Badge
-					class="w-fit mb-1"
-					:label="proposal.status"
-					:theme="getStatusTheme(proposal.status)"
-				/>
 				<h3 class="font-semibold text-xl text-ink-gray-8">{{ proposal.title }}</h3>
 				<p v-if="byline" class="text-base text-ink-gray-7">
 					By {{ byline.lead
@@ -75,32 +72,47 @@ const lastUpdated = computed(() =>
 			</div>
 
 			<div class="flex gap-4 justify-between">
-				<p class="text-base text-ink-gray-7">
-					For
-					<HoverCard :hover-delay="0.15" align="start">
-						<template #trigger>
-							<span
-								class="font-medium text-ink-gray-8 transition-colors hover:text-ink-gray-9"
-								>{{ proposal.event_title }}</span
-							>
+				<div class="flex items-center gap-2">
+					<Badge class="w-fit" :theme="getStatusTheme(proposal.status)">
+						<template #prefix>
+							<span :class="getStatusIcon(proposal.status)" class="size-3.5" />
 						</template>
-						<div class="w-56 space-y-2 p-2">
-							<!-- The pattern also backs the image, so the slot is never blank while it loads. -->
-							<img
-								v-if="proposal.banner_image"
-								class="h-24 w-full rounded object-cover object-top"
-								:src="proposal.banner_image"
-								:style="banner"
-								alt=""
-							/>
-							<div v-else class="h-24 w-full rounded" :style="banner" />
+						<span class="ml-0.5">{{ proposal.status }}</span>
+					</Badge>
+					<p class="text-base text-ink-gray-7">
+						For
+						<HoverCard :hover-delay="0.15" align="start">
+							<template #trigger>
+								<span
+									class="font-medium text-ink-gray-8 transition-colors hover:text-ink-gray-9"
+									>{{ proposal.event_title }}</span
+								>
+							</template>
+							<div class="w-56 space-y-2 p-2">
+								<!-- The pattern also backs the image, so the slot is never blank while it loads. -->
+								<img
+									v-if="proposal.banner_image"
+									class="h-24 w-full rounded object-cover object-top"
+									:src="proposal.banner_image"
+									:style="banner"
+									alt=""
+								/>
+								<div v-else class="h-24 w-full rounded" :style="banner" />
 
-							<p class="font-medium text-ink-gray-8">{{ proposal.event_title }}</p>
-							<p class="text-sm text-ink-gray-5">{{ eventDate }}</p>
-						</div>
-					</HoverCard>
-				</p>
-				<p class="shrink-0 text-sm text-ink-gray-6">Last updated {{ lastUpdated }}</p>
+								<p class="font-medium text-ink-gray-8">
+									{{ proposal.event_title }}
+								</p>
+								<p class="text-sm text-ink-gray-5">{{ eventDate }}</p>
+							</div>
+						</HoverCard>
+					</p>
+				</div>
+				<Tooltip :text="`Last updated on ${lastUpdatedExact}`">
+					<span class="flex items-center gap-1 text-ink-gray-5">
+						<span class="lucide-clock-fading size-3.5"></span>
+						<p class="shrink-0 text-sm">{{ lastUpdated }}</p>
+					</span>
+				</Tooltip>
 			</div>
 		</article>
 	</RouterLink>

--- a/dashboard/src/components/dashboard/proposals/ProposalCard.vue
+++ b/dashboard/src/components/dashboard/proposals/ProposalCard.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { useProposalStatuses } from "@/composables/useProposalStatuses";
+import { session } from "@/data/session";
+import { userResource } from "@/data/user";
+import type { ProposalWithEvent } from "@/types";
+import { bannerPattern } from "@/utils/eventBanner";
+import { speakerByline } from "@/utils/speakerByline";
+import { Avatar, Badge, HoverCard, dayjs, dayjsLocal } from "frappe-ui";
+import { computed } from "vue";
+
+const props = defineProps<{ proposal: ProposalWithEvent }>();
+
+const { getStatusTheme } = useProposalStatuses();
+
+const byline = computed(() =>
+	speakerByline(props.proposal.speakers, userResource.data?.email || session.user)
+);
+
+const banner = computed(() => ({ backgroundImage: bannerPattern(props.proposal.event) }));
+
+// Plain dayjs: start_date is date-only, and a timezone shift moves it a day back.
+const eventDate = computed(() => dayjs(props.proposal.start_date).format("D MMM YYYY"));
+
+// modified is a full timestamp in the site's timezone, so this one does convert.
+const lastUpdated = computed(() =>
+	dayjsLocal(props.proposal.modified).format("D MMM YYYY, h:mm A")
+);
+</script>
+
+<template>
+	<RouterLink
+		:to="{ name: 'proposal-details', params: { proposalId: proposal.name } }"
+		class="proposal-card block rounded-2xl border border-outline-gray-2"
+	>
+		<article class="flex flex-col space-y-6 p-4">
+			<div class="space-y-2">
+				<Badge
+					class="w-fit mb-1"
+					:label="proposal.status"
+					:theme="getStatusTheme(proposal.status)"
+				/>
+				<h3 class="font-semibold text-xl text-ink-gray-8">{{ proposal.title }}</h3>
+				<p v-if="byline" class="text-base text-ink-gray-7">
+					By {{ byline.lead
+					}}<template v-if="byline.partner"> &amp; {{ byline.partner }}</template>
+					<template v-else-if="byline.others.length">
+						and
+						<HoverCard :hover-delay="0.15" align="start">
+							<template #trigger>
+								<span
+									class="underline decoration-dotted underline-offset-2 transition-colors hover:text-ink-gray-9"
+								>
+									{{ byline.others.length }} others
+								</span>
+							</template>
+							<div class="p-2">
+								<ul class="space-y-2">
+									<li
+										v-for="(name, index) in byline.others"
+										:key="index"
+										class="flex items-center gap-2 text-sm text-ink-gray-8"
+									>
+										<Avatar size="sm" :label="name" />
+										<span class="min-w-0 truncate">{{ name }}</span>
+									</li>
+								</ul>
+							</div>
+						</HoverCard>
+						<!-- The card is hover-only, so the names need a spoken path too. -->
+						<span class="sr-only">: {{ byline.others.join(", ") }}</span>
+					</template>
+				</p>
+			</div>
+
+			<div class="flex gap-4 justify-between">
+				<p class="text-base text-ink-gray-7">
+					For
+					<HoverCard :hover-delay="0.15" align="start">
+						<template #trigger>
+							<span
+								class="font-medium text-ink-gray-8 transition-colors hover:text-ink-gray-9"
+								>{{ proposal.event_title }}</span
+							>
+						</template>
+						<div class="w-56 space-y-2 p-2">
+							<!-- The pattern also backs the image, so the slot is never blank while it loads. -->
+							<img
+								v-if="proposal.banner_image"
+								class="h-24 w-full rounded object-cover object-top"
+								:src="proposal.banner_image"
+								:style="banner"
+								alt=""
+							/>
+							<div v-else class="h-24 w-full rounded" :style="banner" />
+
+							<p class="font-medium text-ink-gray-8">{{ proposal.event_title }}</p>
+							<p class="text-sm text-ink-gray-5">{{ eventDate }}</p>
+						</div>
+					</HoverCard>
+				</p>
+				<p class="shrink-0 text-sm text-ink-gray-6">Last updated {{ lastUpdated }}</p>
+			</div>
+		</article>
+	</RouterLink>
+</template>
+
+<style scoped>
+.proposal-card {
+	transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms ease;
+}
+
+.proposal-card:active {
+	transform: scale(0.98);
+}
+
+/* A touch tap fires hover and leaves it stuck. */
+@media (hover: hover) and (pointer: fine) {
+	.proposal-card:hover {
+		border-color: var(--outline-gray-3);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.proposal-card:active {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/composables/useProposalStatuses.ts
+++ b/dashboard/src/composables/useProposalStatuses.ts
@@ -24,6 +24,18 @@ const FALLBACK_THEME: Record<string, BadgeTheme> = {
 	Duplicate: "gray",
 };
 
+// Tailwind emits only the icon classes it can see, so no interpolated names.
+const STATUS_ICONS: Record<string, string> = {
+	"Review Pending": "lucide-clock",
+	Shortlisted: "lucide-bookmark",
+	Accepted: "lucide-circle-check",
+	Rejected: "lucide-circle-x",
+	Replied: "lucide-reply",
+	Duplicate: "lucide-layers-2",
+};
+
+const FALLBACK_ICON = "lucide-squircle-dashed";
+
 // Module-level so every caller shares one fetch of the status list.
 const statuses = createListResource({
 	doctype: "Talk Proposal Status",
@@ -43,5 +55,7 @@ export function useProposalStatuses() {
 		return FALLBACK_THEME[status] ?? "gray";
 	};
 
-	return { statuses, getStatusTheme };
+	const getStatusIcon = (status: string): string => STATUS_ICONS[status] ?? FALLBACK_ICON;
+
+	return { statuses, getStatusTheme, getStatusIcon };
 }

--- a/dashboard/src/data/proposals.ts
+++ b/dashboard/src/data/proposals.ts
@@ -1,8 +1,10 @@
 import type { ProposalListItem } from "@/types"
-import { createResource } from "frappe-ui"
+import { useCall } from "frappe-ui"
 
-export const myProposals = createResource<ProposalListItem[]>({
-	url: "buzz.api.proposals.get_my_proposals",
-	cache: "My Proposals",
-	auto: true,
-})
+// v2 path: useCall reads the payload from `data`, which /api/method names `message`.
+// Uncached: cacheKey would persist this user's proposals to IndexedDB past a logout.
+export function useMyProposals() {
+	return useCall<ProposalListItem[]>({
+		url: "/api/v2/method/buzz.api.proposals.get_my_proposals",
+	})
+}

--- a/dashboard/src/data/proposals.ts
+++ b/dashboard/src/data/proposals.ts
@@ -1,0 +1,8 @@
+import type { ProposalListItem } from "@/types"
+import { createResource } from "frappe-ui"
+
+export const myProposals = createResource<ProposalListItem[]>({
+	url: "buzz.api.proposals.get_my_proposals",
+	cache: "My Proposals",
+	auto: true,
+})

--- a/dashboard/src/pages/ProposalDetails.vue
+++ b/dashboard/src/pages/ProposalDetails.vue
@@ -122,6 +122,12 @@
 							variant="subtle"
 							size="md"
 						>
+							<template #prefix>
+								<span
+									:class="getStatusIcon(proposal.doc.status)"
+									class="size-3.5"
+								/>
+							</template>
 							{{ proposal.doc.status }}
 						</Badge>
 					</div>
@@ -300,7 +306,7 @@ const isEditingEventTalk = computed(() => {
 	);
 });
 
-const { getStatusTheme } = useProposalStatuses();
+const { getStatusTheme, getStatusIcon } = useProposalStatuses();
 
 const formatDate = (dateString: string) => {
 	return dayjsLocal(dateString).format("MMM DD, YYYY");

--- a/dashboard/src/pages/ProposalsList.vue
+++ b/dashboard/src/pages/ProposalsList.vue
@@ -24,6 +24,9 @@
 					variant="subtle"
 					size="sm"
 				>
+					<template #prefix>
+						<span :class="getStatusIcon(row.status)" class="size-3" />
+					</template>
 					{{ item }}
 				</Badge>
 				<ListRowItem v-else :column="column" :row="row" :item="item" :align="align" />
@@ -49,12 +52,12 @@
 </template>
 
 <script setup lang="ts">
-import { session } from "@/data/session";
 import { useProposalStatuses } from "@/composables/useProposalStatuses";
+import { session } from "@/data/session";
 import type { ProposalListItem } from "@/types";
 import { Badge, ListRowItem, ListView, Spinner, createResource, dayjsLocal } from "frappe-ui";
 
-const { getStatusTheme } = useProposalStatuses();
+const { getStatusTheme, getStatusIcon } = useProposalStatuses();
 
 const columns = [
 	{ label: __("Title"), key: "title", width: "240px" },

--- a/dashboard/src/pages/manage/MyEvents.vue
+++ b/dashboard/src/pages/manage/MyEvents.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import TimelineList from "@/components/dashboard/TimelineList.vue";
 import EventCard from "@/components/dashboard/events/EventCard.vue";
 import type { MyEvents } from "@/types";
-import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
 import { groupEventsByMonth } from "@/utils/eventGroups";
-import { ErrorMessage, LoadingText, TabButtons, useCall } from "frappe-ui";
+import type { TimelineTab } from "@/utils/timelineTabs";
+import { useCall } from "frappe-ui";
 import { computed, ref } from "vue";
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
@@ -12,72 +13,23 @@ const myEvents = useCall<MyEvents>({
 	url: "/api/v2/method/buzz.api.events.get_my_events",
 });
 
-const tab = ref<"upcoming" | "past">("upcoming");
-const tabOptions = [
-	{ label: "Upcoming", value: "upcoming" },
-	{ label: "Past", value: "past" },
-];
+const tab = ref<TimelineTab>("upcoming");
 
+// The feed arrives already split, so the tab only picks a side.
 const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || []));
 </script>
 
 <template>
-	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
-		<header class="flex items-center justify-between">
-			<h1 class="font-semibold text-4xl">Events</h1>
-			<TabButtons v-model="tab" :options="tabOptions" size="md" />
-		</header>
-
-		<ErrorMessage v-if="myEvents.error" :message="myEvents.error.message" />
-
-		<LoadingText v-else-if="myEvents.loading" text="Loading events..." />
-
-		<div v-else class="relative space-y-6">
-			<section v-for="month in months" :key="month.month" class="space-y-4">
-				<h2
-					class="relative bg-surface-elevation-1 py-1 text-xl font-semibold text-ink-gray-8"
-				>
-					{{ monthLabel(month.month) }}
-				</h2>
-
-				<div
-					v-for="day in month.days"
-					:key="day.date"
-					class="grid grid-cols-[6rem_1fr] gap-4"
-				>
-					<div class="pt-1">
-						<p class="font-semibold text-ink-gray-8">{{ dayLabel(day.date) }}</p>
-						<p class="text-base text-ink-gray-5">{{ weekday(day.date) }}</p>
-					</div>
-
-					<div class="relative space-y-1 pl-6 pb-7">
-						<div class="absolute -left-4 flex flex-col items-center h-full">
-							<span
-								class="size-2 rounded-full bg-surface-gray-4"
-								aria-hidden="true"
-							/>
-							<div
-								class="w-px h-full bg-gradient-to-b from-outline-gray-2 from-75% to-transparent"
-							></div>
-						</div>
-
-						<div class="space-y-6">
-							<EventCard
-								v-for="event in day.events"
-								:key="event.name"
-								:event="event"
-							/>
-						</div>
-					</div>
-				</div>
-			</section>
-		</div>
-
-		<p
-			v-if="!months.length && !myEvents.loading && !myEvents.error"
-			class="text-base text-ink-gray-5"
-		>
-			No {{ tab }} events.
-		</p>
-	</div>
+	<TimelineList
+		v-model:tab="tab"
+		heading="Events"
+		noun="events"
+		:months="months"
+		:loading="myEvents.loading"
+		:error="myEvents.error"
+	>
+		<template #default="{ item }">
+			<EventCard :event="item" />
+		</template>
+	</TimelineList>
 </template>

--- a/dashboard/src/pages/manage/MyProposals.vue
+++ b/dashboard/src/pages/manage/MyProposals.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import ProposalCard from "@/components/dashboard/proposals/ProposalCard.vue";
+import { myProposals } from "@/data/proposals";
+import type { FrappeError, ProposalWithEvent } from "@/types";
+import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
+import { groupEventsByMonth } from "@/utils/eventGroups";
+import { type TimelineTab, inTab } from "@/utils/timelineTabs";
+import { LoadingText, TabButtons, dayjsLocal } from "frappe-ui";
+import { computed, ref } from "vue";
+
+const tab = ref<TimelineTab>("upcoming");
+const tabOptions = [
+	{
+		label: "Upcoming",
+		value: "upcoming",
+	},
+	{
+		label: "Past",
+		value: "past",
+	},
+];
+
+// createResource types its error as {}, so the message needs narrowing.
+const errorMessage = computed(() => (myProposals.error as FrappeError | null)?.message);
+
+// A proposal whose event was deleted has no date to file it under, so it drops out.
+const dated = computed(() =>
+	(myProposals.data || []).filter((proposal): proposal is ProposalWithEvent =>
+		Boolean(proposal.start_date && proposal.event_title)
+	)
+);
+
+const months = computed(() =>
+	groupEventsByMonth(inTab(dated.value, tab.value, dayjsLocal().format("YYYY-MM-DD")))
+);
+</script>
+
+<template>
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
+		<header class="flex items-center justify-between">
+			<h1 class="font-semibold text-4xl">Talk Proposals</h1>
+			<TabButtons v-model="tab" :options="tabOptions" size="md" />
+		</header>
+
+		<LoadingText v-if="myProposals.loading" text="Loading proposals…" />
+
+		<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
+
+		<div v-else class="space-y-6">
+			<section v-for="month in months" :key="month.month" class="space-y-4">
+				<h2 class="bg-surface-elevation-1 py-1 text-xl font-semibold text-ink-gray-8">
+					{{ monthLabel(month.month) }}
+				</h2>
+
+				<div
+					v-for="day in month.days"
+					:key="day.date"
+					class="grid grid-cols-[6rem_1fr] gap-4 pb-4"
+				>
+					<div class="pt-1">
+						<p class="font-semibold text-ink-gray-8">{{ dayLabel(day.date) }}</p>
+						<p class="text-base text-ink-gray-5">{{ weekday(day.date) }}</p>
+					</div>
+
+					<div class="min-w-0 space-y-4">
+						<ProposalCard
+							v-for="proposal in day.events"
+							:key="proposal.name"
+							:proposal="proposal"
+						/>
+					</div>
+				</div>
+			</section>
+
+			<p v-if="!months.length" class="text-base text-ink-gray-5">No {{ tab }} proposals.</p>
+		</div>
+	</div>
+</template>

--- a/dashboard/src/pages/manage/MyProposals.vue
+++ b/dashboard/src/pages/manage/MyProposals.vue
@@ -1,27 +1,16 @@
 <script setup lang="ts">
+import TimelineList from "@/components/dashboard/TimelineList.vue";
 import ProposalCard from "@/components/dashboard/proposals/ProposalCard.vue";
-import { myProposals } from "@/data/proposals";
-import type { FrappeError, ProposalWithEvent } from "@/types";
-import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
+import { useMyProposals } from "@/data/proposals";
+import type { ProposalWithEvent } from "@/types";
 import { groupEventsByMonth } from "@/utils/eventGroups";
 import { type TimelineTab, inTab } from "@/utils/timelineTabs";
-import { LoadingText, TabButtons, dayjsLocal } from "frappe-ui";
+import { dayjs } from "frappe-ui";
 import { computed, ref } from "vue";
 
 const tab = ref<TimelineTab>("upcoming");
-const tabOptions = [
-	{
-		label: "Upcoming",
-		value: "upcoming",
-	},
-	{
-		label: "Past",
-		value: "past",
-	},
-];
 
-// createResource types its error as {}, so the message needs narrowing.
-const errorMessage = computed(() => (myProposals.error as FrappeError | null)?.message);
+const myProposals = useMyProposals();
 
 // A proposal whose event was deleted has no date to file it under, so it drops out.
 const dated = computed(() =>
@@ -30,49 +19,23 @@ const dated = computed(() =>
 	)
 );
 
+// Plain dayjs: these are date-only values, and dayjsLocal shifts them a day back.
 const months = computed(() =>
-	groupEventsByMonth(inTab(dated.value, tab.value, dayjsLocal().format("YYYY-MM-DD")))
+	groupEventsByMonth(inTab(dated.value, tab.value, dayjs().format("YYYY-MM-DD")))
 );
 </script>
 
 <template>
-	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
-		<header class="flex items-center justify-between">
-			<h1 class="font-semibold text-4xl">Talk Proposals</h1>
-			<TabButtons v-model="tab" :options="tabOptions" size="md" />
-		</header>
-
-		<LoadingText v-if="myProposals.loading" text="Loading proposals…" />
-
-		<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
-
-		<div v-else class="space-y-6">
-			<section v-for="month in months" :key="month.month" class="space-y-4">
-				<h2 class="bg-surface-elevation-1 py-1 text-xl font-semibold text-ink-gray-8">
-					{{ monthLabel(month.month) }}
-				</h2>
-
-				<div
-					v-for="day in month.days"
-					:key="day.date"
-					class="grid grid-cols-[6rem_1fr] gap-4 pb-4"
-				>
-					<div class="pt-1">
-						<p class="font-semibold text-ink-gray-8">{{ dayLabel(day.date) }}</p>
-						<p class="text-base text-ink-gray-5">{{ weekday(day.date) }}</p>
-					</div>
-
-					<div class="min-w-0 space-y-4">
-						<ProposalCard
-							v-for="proposal in day.events"
-							:key="proposal.name"
-							:proposal="proposal"
-						/>
-					</div>
-				</div>
-			</section>
-
-			<p v-if="!months.length" class="text-base text-ink-gray-5">No {{ tab }} proposals.</p>
-		</div>
-	</div>
+	<TimelineList
+		v-model:tab="tab"
+		heading="Talk Proposals"
+		noun="proposals"
+		:months="months"
+		:loading="myProposals.loading"
+		:error="myProposals.error"
+	>
+		<template #default="{ item }">
+			<ProposalCard :proposal="item" />
+		</template>
+	</TimelineList>
 </template>

--- a/dashboard/src/pages/manage/MyTickets.vue
+++ b/dashboard/src/pages/manage/MyTickets.vue
@@ -1,18 +1,14 @@
 <script setup lang="ts">
+import TimelineList from "@/components/dashboard/TimelineList.vue";
 import PrintedTicket from "@/components/dashboard/tickets/PrintedTicket.vue";
 import { useMyTickets } from "@/data/tickets";
 import type { TicketWithEvent } from "@/types";
-import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
 import { groupEventsByMonth } from "@/utils/eventGroups";
 import { type TimelineTab, inTab } from "@/utils/timelineTabs";
-import { ErrorMessage, LoadingText, TabButtons, dayjs } from "frappe-ui";
+import { dayjs } from "frappe-ui";
 import { computed, ref } from "vue";
 
 const tab = ref<TimelineTab>("upcoming");
-const tabOptions = [
-	{ label: "Upcoming", value: "upcoming" },
-	{ label: "Past", value: "past" },
-];
 
 const tickets = useMyTickets();
 
@@ -23,68 +19,23 @@ const dated = computed(() =>
 	)
 );
 
+// Plain dayjs: these are date-only values, and dayjsLocal shifts them a day back.
 const months = computed(() =>
 	groupEventsByMonth(inTab(dated.value, tab.value, dayjs().format("YYYY-MM-DD")))
 );
 </script>
 
 <template>
-	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
-		<header class="flex items-center justify-between">
-			<h1 class="font-semibold text-4xl">Tickets</h1>
-			<TabButtons v-model="tab" :options="tabOptions" size="md" />
-		</header>
-
-		<ErrorMessage v-if="tickets.error" :message="tickets.error.message" />
-
-		<LoadingText v-else-if="tickets.loading" text="Loading tickets..." />
-
-		<div v-else class="relative space-y-6">
-			<section v-for="month in months" :key="month.month" class="space-y-4">
-				<h2
-					class="relative bg-surface-elevation-1 py-1 text-xl font-semibold text-ink-gray-8"
-				>
-					{{ monthLabel(month.month) }}
-				</h2>
-
-				<div
-					v-for="day in month.days"
-					:key="day.date"
-					class="grid grid-cols-[6rem_1fr] gap-4"
-				>
-					<div class="pt-1">
-						<p class="font-semibold text-ink-gray-8">{{ dayLabel(day.date) }}</p>
-						<p class="text-base text-ink-gray-5">{{ weekday(day.date) }}</p>
-					</div>
-
-					<div class="relative space-y-1 pl-6 pb-7">
-						<div class="absolute -left-4 flex flex-col items-center h-full">
-							<span
-								class="size-2 rounded-full bg-surface-gray-4"
-								aria-hidden="true"
-							/>
-							<div
-								class="w-px h-full bg-gradient-to-b from-outline-gray-2 from-75% to-transparent"
-							></div>
-						</div>
-
-						<div class="space-y-6">
-							<PrintedTicket
-								v-for="ticket in day.events"
-								:key="ticket.name"
-								:ticket="ticket"
-							/>
-						</div>
-					</div>
-				</div>
-			</section>
-		</div>
-
-		<p
-			v-if="!months.length && !tickets.loading && !tickets.error"
-			class="text-base text-ink-gray-5"
-		>
-			No {{ tab }} tickets.
-		</p>
-	</div>
+	<TimelineList
+		v-model:tab="tab"
+		heading="Tickets"
+		noun="tickets"
+		:months="months"
+		:loading="tickets.loading"
+		:error="tickets.error"
+	>
+		<template #default="{ item }">
+			<PrintedTicket :ticket="item" />
+		</template>
+	</TimelineList>
 </template>

--- a/dashboard/src/pages/manage/MyTickets.vue
+++ b/dashboard/src/pages/manage/MyTickets.vue
@@ -4,10 +4,11 @@ import { useMyTickets } from "@/data/tickets";
 import type { TicketWithEvent } from "@/types";
 import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels";
 import { groupEventsByMonth } from "@/utils/eventGroups";
+import { type TimelineTab, inTab } from "@/utils/timelineTabs";
 import { ErrorMessage, LoadingText, TabButtons, dayjs } from "frappe-ui";
 import { computed, ref } from "vue";
 
-const tab = ref<"upcoming" | "past">("upcoming");
+const tab = ref<TimelineTab>("upcoming");
 const tabOptions = [
 	{ label: "Upcoming", value: "upcoming" },
 	{ label: "Past", value: "past" },
@@ -22,20 +23,9 @@ const dated = computed(() =>
 	)
 );
 
-const months = computed(() => {
-	const today = dayjs().format("YYYY-MM-DD");
-	const upcoming = tab.value === "upcoming";
-	// Same rule as the events feed: an event running through today is not over yet.
-	const isOver = (ticket: TicketWithEvent) => (ticket.end_date || ticket.start_date) < today;
-	const shown = dated.value
-		.filter((ticket) => isOver(ticket) !== upcoming)
-		.sort((a, b) =>
-			upcoming
-				? a.start_date.localeCompare(b.start_date)
-				: b.start_date.localeCompare(a.start_date)
-		);
-	return groupEventsByMonth(shown);
-});
+const months = computed(() =>
+	groupEventsByMonth(inTab(dated.value, tab.value, dayjs().format("YYYY-MM-DD")))
+);
 </script>
 
 <template>

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -42,7 +42,7 @@ const routes: RouteRecordRaw[] = [
 			// so a mistyped path reaches the 404 below — keep in step with the sidebar
 			// items in ManagerLayout.vue.
 			{
-				path: ":section(proposals|sponsorship|overview|registrations|sponsors|more)",
+				path: ":section(sponsorship|overview|registrations|sponsors|more)",
 				component: () => import("@/pages/manage/WorkInProgress.vue"),
 			},
 			// Claims the rest of /manage before the two-segment custom form route can:

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -32,6 +32,11 @@ const routes: RouteRecordRaw[] = [
 				name: "tickets",
 				component: () => import("@/pages/manage/MyTickets.vue"),
 			},
+			{
+				path: "proposals",
+				name: "proposals",
+				component: () => import("@/pages/manage/MyProposals.vue"),
+			},
 			// Sidebar destinations that have no page yet. Unnamed on purpose: SidebarItem
 			// falls back to matching on path, so each one lights up on its own. Enumerated
 			// so a mistyped path reaches the 404 below — keep in step with the sidebar

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -12,16 +12,32 @@ import type { FrappeField } from "@/composables/useCustomFields"
 import type { EventTicket } from "@/types/Ticketing/EventTicket"
 import type { TicketAddOnValue } from "@/types/Ticketing/TicketAddOnValue"
 
+// A speaker listed on a proposal. Proposal Speaker holds contact details only —
+// no photo, bio or Speaker Profile link until a proposal is accepted.
+export interface ProposalSpeaker {
+	first_name: string
+	last_name: string | null
+	email: string
+}
+
 // Rows from buzz.api.proposals.get_my_proposals: proposals where the session
-// user is the submitter or a listed speaker, with the event title joined on.
+// user is the submitter or a listed speaker, with the event columns joined on.
 export interface ProposalListItem {
 	name: string
 	title: string
 	event: string
+	// Event columns come over a link hop, so a deleted event leaves them null.
 	event_title: string | null
+	start_date: string | null
+	banner_image: string | null
 	status: string
 	creation: string
+	modified: string
+	speakers: ProposalSpeaker[]
 }
+
+// A proposal whose event row still resolves — the only kind the timeline can place.
+export type ProposalWithEvent = ProposalListItem & { event_title: string; start_date: string }
 
 // Errors rejected by frappe-ui resources carry server messages beyond Error.
 export interface FrappeError extends Error {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -29,6 +29,7 @@ export interface ProposalListItem {
 	// Event columns come over a link hop, so a deleted event leaves them null.
 	event_title: string | null
 	start_date: string | null
+	end_date: string | null
 	banner_image: string | null
 	status: string
 	creation: string

--- a/dashboard/src/utils/eventGroups.ts
+++ b/dashboard/src/utils/eventGroups.ts
@@ -3,7 +3,7 @@ interface DayGroup<T> {
 	events: T[]
 }
 
-interface MonthGroup<T> {
+export interface MonthGroup<T> {
 	month: string
 	days: DayGroup<T>[]
 }

--- a/dashboard/src/utils/speakerByline.test.ts
+++ b/dashboard/src/utils/speakerByline.test.ts
@@ -17,16 +17,14 @@ test("no speakers have no byline", () => {
 test("a lone speaker who is the reader is You", () => {
 	assert.deepEqual(speakerByline([speaker("Me", ME)], ME), {
 		lead: "You",
-		partner: null,
-		others: [],
+		rest: [],
 	})
 })
 
 test("a lone speaker who is someone else gets their full name", () => {
 	assert.deepEqual(speakerByline([speaker("Jane", "jane@example.com", "Doe")], ME), {
 		lead: "Jane Doe",
-		partner: null,
-		others: [],
+		rest: [],
 	})
 })
 
@@ -35,8 +33,7 @@ test("a pair reads as you and the other speaker, whatever the row order", () => 
 
 	assert.deepEqual(speakerByline(speakers, ME), {
 		lead: "You",
-		partner: "Jane Doe",
-		others: [],
+		rest: ["Jane Doe"],
 	})
 })
 
@@ -45,8 +42,7 @@ test("a pair without the reader keeps its row order", () => {
 
 	assert.deepEqual(speakerByline(speakers, ME), {
 		lead: "Jane",
-		partner: "Ravi",
-		others: [],
+		rest: ["Ravi"],
 	})
 })
 
@@ -60,8 +56,7 @@ test("a crowd names the reader and hides the rest", () => {
 
 	assert.deepEqual(speakerByline(speakers, ME), {
 		lead: "You",
-		partner: null,
-		others: ["Jane", "Ravi", "Sam"],
+		rest: ["Jane", "Ravi", "Sam"],
 	})
 })
 
@@ -74,23 +69,20 @@ test("a crowd without the reader leads with the first speaker", () => {
 
 	assert.deepEqual(speakerByline(speakers, ME), {
 		lead: "Jane",
-		partner: null,
-		others: ["Ravi", "Sam"],
+		rest: ["Ravi", "Sam"],
 	})
 })
 
 test("a speaker email cased differently is still the reader", () => {
 	assert.deepEqual(speakerByline([speaker("Me", "Me@Example.COM")], ME), {
 		lead: "You",
-		partner: null,
-		others: [],
+		rest: [],
 	})
 })
 
 test("a speaker with no name falls back to their email", () => {
 	assert.deepEqual(speakerByline([speaker("", "jane@example.com")], ME), {
 		lead: "jane@example.com",
-		partner: null,
-		others: [],
+		rest: [],
 	})
 })

--- a/dashboard/src/utils/speakerByline.test.ts
+++ b/dashboard/src/utils/speakerByline.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { speakerByline } from "./speakerByline.ts"
+
+const ME = "me@example.com"
+
+const speaker = (first_name: string, email: string, last_name: string | null = null) => ({
+	first_name,
+	last_name,
+	email,
+})
+
+test("no speakers have no byline", () => {
+	assert.equal(speakerByline([], ME), null)
+})
+
+test("a lone speaker who is the reader is You", () => {
+	assert.deepEqual(speakerByline([speaker("Me", ME)], ME), {
+		lead: "You",
+		partner: null,
+		others: [],
+	})
+})
+
+test("a lone speaker who is someone else gets their full name", () => {
+	assert.deepEqual(speakerByline([speaker("Jane", "jane@example.com", "Doe")], ME), {
+		lead: "Jane Doe",
+		partner: null,
+		others: [],
+	})
+})
+
+test("a pair reads as you and the other speaker, whatever the row order", () => {
+	const speakers = [speaker("Jane", "jane@example.com", "Doe"), speaker("Me", ME)]
+
+	assert.deepEqual(speakerByline(speakers, ME), {
+		lead: "You",
+		partner: "Jane Doe",
+		others: [],
+	})
+})
+
+test("a pair without the reader keeps its row order", () => {
+	const speakers = [speaker("Jane", "jane@example.com"), speaker("Ravi", "ravi@example.com")]
+
+	assert.deepEqual(speakerByline(speakers, ME), {
+		lead: "Jane",
+		partner: "Ravi",
+		others: [],
+	})
+})
+
+test("a crowd names the reader and hides the rest", () => {
+	const speakers = [
+		speaker("Jane", "jane@example.com"),
+		speaker("Me", ME),
+		speaker("Ravi", "ravi@example.com"),
+		speaker("Sam", "sam@example.com"),
+	]
+
+	assert.deepEqual(speakerByline(speakers, ME), {
+		lead: "You",
+		partner: null,
+		others: ["Jane", "Ravi", "Sam"],
+	})
+})
+
+test("a crowd without the reader leads with the first speaker", () => {
+	const speakers = [
+		speaker("Jane", "jane@example.com"),
+		speaker("Ravi", "ravi@example.com"),
+		speaker("Sam", "sam@example.com"),
+	]
+
+	assert.deepEqual(speakerByline(speakers, ME), {
+		lead: "Jane",
+		partner: null,
+		others: ["Ravi", "Sam"],
+	})
+})
+
+test("a speaker email cased differently is still the reader", () => {
+	assert.deepEqual(speakerByline([speaker("Me", "Me@Example.COM")], ME), {
+		lead: "You",
+		partner: null,
+		others: [],
+	})
+})
+
+test("a speaker with no name falls back to their email", () => {
+	assert.deepEqual(speakerByline([speaker("", "jane@example.com")], ME), {
+		lead: "jane@example.com",
+		partner: null,
+		others: [],
+	})
+})

--- a/dashboard/src/utils/speakerByline.ts
+++ b/dashboard/src/utils/speakerByline.ts
@@ -1,0 +1,40 @@
+export interface BylineSpeaker {
+	first_name: string
+	last_name: string | null
+	email: string
+}
+
+export interface Byline {
+	/** The speaker the byline names first — "you" when that is the reader. */
+	lead: string
+	/** The other half of a pair. Null unless there are exactly two speakers. */
+	partner: string | null
+	/** Everyone the byline leaves for the hover card. Empty below three speakers. */
+	others: string[]
+}
+
+const displayName = (speaker: BylineSpeaker): string =>
+	[speaker.first_name, speaker.last_name].filter(Boolean).join(" ") || speaker.email
+
+const isReader = (speaker: BylineSpeaker, reader: string): boolean =>
+	// User emails are stored lowercase; guest-entered speaker emails keep their casing.
+	Boolean(reader) && speaker.email.toLowerCase() === reader.toLowerCase()
+
+/** Reorders so the reader speaks first, and names them "you". */
+function namesReaderFirst(speakers: BylineSpeaker[], reader: string): string[] {
+	const mine = speakers.filter((speaker) => isReader(speaker, reader))
+	const theirs = speakers.filter((speaker) => !isReader(speaker, reader))
+
+	return [...mine.map(() => "You"), ...theirs.map(displayName)]
+}
+
+export function speakerByline(speakers: BylineSpeaker[], reader: string): Byline | null {
+	const [lead, ...rest] = namesReaderFirst(speakers, reader)
+	if (!lead) return null
+
+	return {
+		lead,
+		partner: rest.length === 1 ? rest[0] : null,
+		others: rest.length > 1 ? rest : [],
+	}
+}

--- a/dashboard/src/utils/speakerByline.ts
+++ b/dashboard/src/utils/speakerByline.ts
@@ -1,40 +1,29 @@
-export interface BylineSpeaker {
-	first_name: string
-	last_name: string | null
-	email: string
-}
+import type { ProposalSpeaker } from "@/types"
 
 export interface Byline {
 	/** The speaker the byline names first — "you" when that is the reader. */
 	lead: string
-	/** The other half of a pair. Null unless there are exactly two speakers. */
-	partner: string | null
-	/** Everyone the byline leaves for the hover card. Empty below three speakers. */
-	others: string[]
+	/** Everyone else, in listed order. A single name reads inline, more go behind a hover card. */
+	rest: string[]
 }
 
-const displayName = (speaker: BylineSpeaker): string =>
+const displayName = (speaker: ProposalSpeaker): string =>
 	[speaker.first_name, speaker.last_name].filter(Boolean).join(" ") || speaker.email
 
-const isReader = (speaker: BylineSpeaker, reader: string): boolean =>
+const isReader = (speaker: ProposalSpeaker, reader: string): boolean =>
 	// User emails are stored lowercase; guest-entered speaker emails keep their casing.
 	Boolean(reader) && speaker.email.toLowerCase() === reader.toLowerCase()
 
 /** Reorders so the reader speaks first, and names them "you". */
-function namesReaderFirst(speakers: BylineSpeaker[], reader: string): string[] {
+function namesReaderFirst(speakers: ProposalSpeaker[], reader: string): string[] {
 	const mine = speakers.filter((speaker) => isReader(speaker, reader))
 	const theirs = speakers.filter((speaker) => !isReader(speaker, reader))
 
 	return [...mine.map(() => "You"), ...theirs.map(displayName)]
 }
 
-export function speakerByline(speakers: BylineSpeaker[], reader: string): Byline | null {
+export function speakerByline(speakers: ProposalSpeaker[], reader: string): Byline | null {
 	const [lead, ...rest] = namesReaderFirst(speakers, reader)
-	if (!lead) return null
 
-	return {
-		lead,
-		partner: rest.length === 1 ? rest[0] : null,
-		others: rest.length > 1 ? rest : [],
-	}
+	return lead ? { lead, rest } : null
 }

--- a/dashboard/src/utils/timelineTabs.test.ts
+++ b/dashboard/src/utils/timelineTabs.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { inTab } from "./timelineTabs.ts"
+
+const TODAY = "2026-08-13"
+
+const item = (start_date: string) => ({ start_date })
+
+test("today counts as upcoming", () => {
+	assert.deepEqual(inTab([item(TODAY)], "upcoming", TODAY), [item(TODAY)])
+	assert.deepEqual(inTab([item(TODAY)], "past", TODAY), [])
+})
+
+test("upcoming comes back soonest first", () => {
+	const items = [item("2026-09-01"), item("2026-08-14"), item("2026-08-20")]
+
+	assert.deepEqual(
+		inTab(items, "upcoming", TODAY).map((row) => row.start_date),
+		["2026-08-14", "2026-08-20", "2026-09-01"],
+	)
+})
+
+test("past comes back newest first", () => {
+	const items = [item("2026-07-01"), item("2026-08-12"), item("2026-06-15")]
+
+	assert.deepEqual(
+		inTab(items, "past", TODAY).map((row) => row.start_date),
+		["2026-08-12", "2026-07-01", "2026-06-15"],
+	)
+})
+
+test("no items produce no rows", () => {
+	assert.deepEqual(inTab([], "upcoming", TODAY), [])
+})
+
+test("a multi-day row running through today is still upcoming", () => {
+	const running = { start_date: "2026-08-10", end_date: "2026-08-13" }
+
+	assert.deepEqual(inTab([running], "upcoming", TODAY), [running])
+	assert.deepEqual(inTab([running], "past", TODAY), [])
+})
+
+test("a multi-day row that ended is past, sorted by its start", () => {
+	const ended = { start_date: "2026-08-10", end_date: "2026-08-12" }
+
+	assert.deepEqual(inTab([ended], "past", TODAY), [ended])
+	assert.deepEqual(inTab([ended], "upcoming", TODAY), [])
+})
+
+test("a null end_date falls back to start_date", () => {
+	const row = { start_date: "2026-08-12", end_date: null }
+
+	assert.deepEqual(inTab([row], "past", TODAY), [row])
+})

--- a/dashboard/src/utils/timelineTabs.ts
+++ b/dashboard/src/utils/timelineTabs.ts
@@ -1,0 +1,20 @@
+export type TimelineTab = "upcoming" | "past"
+
+interface Dated {
+	start_date: string
+	end_date?: string | null
+}
+
+/**
+ * Splits dated rows into the tab they belong to, sorted the way that tab reads:
+ * upcoming counts from today forwards, past counts backwards from yesterday.
+ * A row running through today is not over yet, so end_date decides where it falls.
+ */
+export function inTab<T extends Dated>(items: T[], tab: TimelineTab, today: string): T[] {
+	const upcoming = tab === "upcoming"
+	const isOver = (item: T) => (item.end_date || item.start_date) < today
+
+	return items
+		.filter((item) => isOver(item) !== upcoming)
+		.sort((a, b) => (upcoming ? 1 : -1) * a.start_date.localeCompare(b.start_date))
+}


### PR DESCRIPTION
## What changed

`/manage/proposals` was the last sidebar item falling through to the
work-in-progress placeholder. It now renders the proposals you submitted or are
a listed speaker on, in the same timeline as Events and Tickets.

Cards file under the **event's** date, not the submission date. The footer
carries the status badge, the event name, and a relative "last updated" —
absolute stamps answer a question nobody asks of a feed, so the exact time
moved into a tooltip. Status badges get a lucide glyph so the state doesn't
rest on badge tint alone. Two hover cards: the speakers behind "and N others",
and an event preview on the event name.

Backend: `get_my_proposals` gains `start_date`, `banner_image`, `modified` and
the `Proposal Speaker` rows, batched in one query rather than a lookup per row.

### The permission fix in here

`run_doc_method` loads a doc with a **read** check, then calls any whitelisted
method on it. `TalkProposal.create_talk` had no guard, so a speaker on a
proposal — who holds write via the speaker carve-out — could accept their own
proposal, provided they already had a Speaker Profile. `check_permission("write")`
is not the fix; the carve-out grants exactly that. The guard asks the team rule
directly. Two tests: a speaker can't self-accept, an event team member still can.

### Not in here

- `allow_editing_talks_after_acceptance` doesn't reach speakers — the accepted
  `Event Talk` is owned by whoever accepted it, and nothing consults
  `Talk Speaker`. Pre-existing, wants its own fix.
- No `/manage`-native proposal detail page; cards link to the existing one
  under `/account`.
- `PrintedTicket.vue` keeps the dead `focus-visible:ring-ink-gray-9` this PR
  removed from the proposal card (the preset registers `outline-*`, not
  `ringColor`, so `ring-2` falls back to Tailwind blue).

## Demo


https://github.com/user-attachments/assets/b2c6bd66-2414-47ae-aa04-dcada4cf2cc4



## Testing

Backend tests for the permission guard (self-accept denied, team member
allowed). `vue-tsc` clean; timeline, list, and detail views checked manually
against buzz.localhost.
