### PR TITLE
feat(dashboard): team members page with add and remove

### DIFF
--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -29,3 +29,8 @@ def get_my_teams() -> list[TeamOption]:
 @frappe.whitelist()
 def get_team_overview(team: str) -> TeamOverview:
 	return services.team_overview(team)
+
+
+@frappe.whitelist(methods=["POST"])
+def remove_member(team: str, user: str) -> None:
+	services.remove_member(team, user)

--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -1,7 +1,7 @@
 import frappe
 
-from buzz.api.teams import services
-from buzz.api.teams.schemas import TeamOption, TeamOverview
+from buzz.api.teams import invitations, services
+from buzz.api.teams.schemas import InviteOutcome, TeamOption, TeamOverview
 
 
 @frappe.whitelist()
@@ -34,3 +34,8 @@ def get_team_overview(team: str) -> TeamOverview:
 @frappe.whitelist(methods=["POST"])
 def remove_member(team: str, user: str) -> None:
 	services.remove_member(team, user)
+
+
+@frappe.whitelist(methods=["POST"])
+def invite_members(team: str, invites: list[dict]) -> list[InviteOutcome]:
+	return invitations.invite_members(team, invites)

--- a/buzz/api/teams/exceptions.py
+++ b/buzz/api/teams/exceptions.py
@@ -5,3 +5,8 @@ from buzz.api.exceptions import NotPermitted
 
 class NotATeamMember(NotPermitted):
 	message = _lt("You are not a member of this team.")
+
+
+class CannotManageMembers(NotPermitted):
+	title = _lt("Not Permitted")
+	message = _lt("You cannot manage members of this team.")

--- a/buzz/api/teams/exceptions.py
+++ b/buzz/api/teams/exceptions.py
@@ -1,6 +1,6 @@
 from frappe import _lt
 
-from buzz.api.exceptions import NotPermitted
+from buzz.api.exceptions import BuzzAPIError, NotPermitted
 
 
 class NotATeamMember(NotPermitted):
@@ -10,3 +10,13 @@ class NotATeamMember(NotPermitted):
 class CannotManageMembers(NotPermitted):
 	title = _lt("Not Permitted")
 	message = _lt("You cannot manage members of this team.")
+
+
+class CannotGrantOwnership(NotPermitted):
+	title = _lt("Not Permitted")
+	message = _lt("Ownership of a team cannot be granted.")
+
+
+class UnknownTeamRole(BuzzAPIError):
+	title = _lt("Invalid Role")
+	message = _lt("{team_role} is not a team role.")

--- a/buzz/api/teams/invitations.py
+++ b/buzz/api/teams/invitations.py
@@ -1,0 +1,68 @@
+import frappe
+from frappe.core.api.user_invitation import invite_by_email
+
+from buzz.api.teams.exceptions import CannotGrantOwnership, CannotManageMembers, UnknownTeamRole
+from buzz.api.teams.schemas import InviteOutcome
+from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
+from buzz.permissions import can_manage_members
+
+# Where an invitee lands once they accept. The router sends a team member on to their events.
+INVITE_REDIRECT_PATH = "/b/manage"
+
+
+def invite_members(team: str, invites: list[dict]) -> list[InviteOutcome]:
+	"""Put people on a team, by whichever route each of them needs.
+
+	Someone who already has a User joins straight away; only a stranger gets an emailed
+	invitation. Splitting the two is not a nicety: core's `invite_by_email` skips any
+	address that ever accepted a buzz invitation, without regard to which team it was
+	for, so inviting a colleague to a second team would silently do nothing.
+	"""
+	if not can_manage_members(team):
+		CannotManageMembers.throw()
+
+	# Every row is checked before any of them is acted on, so one bad role cannot leave
+	# half a batch invited.
+	for invite in invites:
+		validate_role(invite["team_role"])
+
+	return [invite_one(team, invite) for invite in invites]
+
+
+def validate_role(team_role: str) -> None:
+	if team_role == "Owner":
+		CannotGrantOwnership.throw()
+	if team_role not in assignable_roles():
+		UnknownTeamRole.throw(team_role=team_role)
+
+
+def assignable_roles() -> list[str]:
+	"""The membership doctype's own options, minus the one nobody may be given."""
+	options = frappe.get_meta("Buzz Team Membership").get_field("team_role").options
+	return [role for role in options.split("\n") if role and role != "Owner"]
+
+
+def invite_one(team: str, invite: dict) -> InviteOutcome:
+	# User names are lowercased emails, so the lookup has to be too.
+	email = invite["email"].strip().lower()
+	team_role = invite["team_role"]
+
+	# None means no such User; an existing one with a blank name still reads as "".
+	full_name = frappe.db.get_value("User", email, "full_name")
+	if full_name is not None:
+		added = upsert_membership(team, email, team_role)
+		return InviteOutcome(
+			email=email,
+			status="added" if added else "already_a_member",
+			full_name=full_name,
+		)
+
+	invite_by_email(
+		emails=email,
+		roles=["Buzz User"],
+		redirect_to_path=INVITE_REDIRECT_PATH,
+		app_name="buzz",
+		buzz_team=team,
+		buzz_team_role=team_role,
+	)
+	return InviteOutcome(email=email, status="invited")

--- a/buzz/api/teams/schemas.py
+++ b/buzz/api/teams/schemas.py
@@ -15,6 +15,18 @@ class TeamMember(APIResponse):
 	team_role: str
 
 
+class InviteOutcome(APIResponse):
+	email: str
+	status: str
+	# Only someone who already has a User has a name to show; a stranger is still an address.
+	full_name: str | None = None
+
+
+class TeamInvite(APIResponse):
+	email: str
+	team_role: str
+
+
 class TeamOverview(APIResponse):
 	name: str
 	team_name: str
@@ -22,3 +34,5 @@ class TeamOverview(APIResponse):
 	logo: str | None
 	my_role: str
 	members: list[TeamMember]
+	# Kept apart from members: these people cannot do anything on the team yet.
+	invites: list[TeamInvite]

--- a/buzz/api/teams/services.py
+++ b/buzz/api/teams/services.py
@@ -1,8 +1,9 @@
 import frappe
+from frappe.query_builder import Case
 
-from buzz.api.teams.exceptions import NotATeamMember
+from buzz.api.teams.exceptions import CannotManageMembers, NotATeamMember
 from buzz.api.teams.schemas import TeamMember, TeamOverview
-from buzz.permissions import team_role_of
+from buzz.permissions import can_manage_members, team_role_of
 
 TEAM_FIELDS = ("name", "team_name", "slug", "logo")
 
@@ -33,13 +34,38 @@ def members_of(team: str) -> list[TeamMember]:
 	membership = frappe.qb.DocType("Buzz Team Membership")
 	user = frappe.qb.DocType("User")
 
+	# A team can hold several Owners, so this is a role bucket rather than a single row.
+	owner_first = Case().when(membership.team_role == "Owner", 0).else_(1)
+
 	rows = (
 		frappe.qb.from_(membership)
 		.inner_join(user)
 		.on(user.name == membership.user)
 		.select(membership.user, membership.team_role, user.full_name, user.user_image)
 		.where((membership.team == team) & (membership.enabled == 1))
+		.orderby(owner_first)
 		.orderby(user.full_name)
 	).run(as_dict=True)
 
 	return [TeamMember(**row) for row in rows]
+
+
+def remove_member(team: str, user: str) -> None:
+	"""Take a member off a team by disabling their membership.
+
+	Disabled rather than deleted: `upsert_membership` re-enables the same row if they are
+	ever invited back, and the history survives. An Owner row refuses to be disabled in the
+	membership controller, so ownership needs no check here.
+	"""
+	if not can_manage_members(team):
+		CannotManageMembers.throw()
+
+	name = frappe.db.exists("Buzz Team Membership", {"team": team, "user": user, "enabled": 1})
+	if not name:
+		NotATeamMember.throw()
+
+	membership = frappe.get_doc("Buzz Team Membership", name)
+	membership.enabled = 0
+	# Event Manager holds no write permission on the membership doctype, so the guard above
+	# is the authorization — the same shape as the Desk add-members flow.
+	membership.save(ignore_permissions=True)

--- a/buzz/api/teams/services.py
+++ b/buzz/api/teams/services.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.query_builder import Case
 
 from buzz.api.teams.exceptions import CannotManageMembers, NotATeamMember
-from buzz.api.teams.schemas import TeamMember, TeamOverview
+from buzz.api.teams.schemas import TeamInvite, TeamMember, TeamOverview
 from buzz.permissions import can_manage_members, team_role_of
 
 TEAM_FIELDS = ("name", "team_name", "slug", "logo")
@@ -27,6 +27,7 @@ def team_overview(team: str) -> TeamOverview:
 		**details,
 		my_role=role,
 		members=members_of(team),
+		invites=pending_invites_for(team),
 	)
 
 
@@ -48,6 +49,22 @@ def members_of(team: str) -> list[TeamMember]:
 	).run(as_dict=True)
 
 	return [TeamMember(**row) for row in rows]
+
+
+def pending_invites_for(team: str) -> list[TeamInvite]:
+	"""Invitations still waiting on their recipient.
+
+	App-scoped as well as team-scoped: `User Invitation` is shared with every other
+	installed app, and only buzz's own rows carry a team.
+	"""
+	rows = frappe.db.get_all(
+		"User Invitation",
+		filters={"buzz_team": team, "status": "Pending", "app_name": "buzz"},
+		fields=["email", "buzz_team_role as team_role"],
+		order_by="creation asc",
+	)
+
+	return [TeamInvite(**row) for row in rows]
 
 
 def remove_member(team: str, user: str) -> None:

--- a/buzz/api/teams/test_invitations.py
+++ b/buzz/api/teams/test_invitations.py
@@ -1,0 +1,202 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.teams import get_team_overview, invite_members
+from buzz.api.teams.exceptions import CannotGrantOwnership, CannotManageMembers, UnknownTeamRole
+from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
+from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
+
+
+class TestInviteMembers(IntegrationTestCase):
+	# Rollback is per class, not per test — every test owns its users and its team names.
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+		# Every invitation mails itself out on insert, which needs an outgoing email account.
+		self.enterContext(patch("frappe.sendmail"))
+
+	def team_owned_by(self, name: str, owner_email: str) -> tuple[str, str]:
+		owner = create_user(owner_email, "Owner")
+		return create_owned_team(name, owner), owner
+
+	def invitation_for(self, email: str) -> dict:
+		return frappe.db.get_value(
+			"User Invitation",
+			{"email": email},
+			["buzz_team", "buzz_team_role", "status"],
+			as_dict=True,
+		)
+
+	def test_invites_an_email_that_belongs_to_no_user_yet(self):
+		team, owner = self.team_owned_by("Invite Newcomer", "invite-owner@example.com")
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": "newcomer@example.com", "team_role": "Manager"}])
+
+		self.assertEqual([outcome.status for outcome in outcomes], ["invited"])
+		invitation = self.invitation_for("newcomer@example.com")
+		self.assertEqual(invitation.buzz_team, team)
+		self.assertEqual(invitation.buzz_team_role, "Manager")
+		self.assertEqual(invitation.status, "Pending")
+
+	def test_adds_an_existing_user_to_the_team_without_an_invitation(self):
+		team, owner = self.team_owned_by("Invite Existing", "invite-owner2@example.com")
+		colleague = create_user("invite-colleague@example.com", "Colleague")
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": colleague, "team_role": "Frontdesk"}])
+
+		self.assertEqual([outcome.status for outcome in outcomes], ["added"])
+		self.assertIsNone(self.invitation_for(colleague))
+		membership = frappe.db.get_value(
+			"Buzz Team Membership", {"team": team, "user": colleague}, ["team_role", "enabled"], as_dict=True
+		)
+		self.assertEqual(membership.team_role, "Frontdesk")
+		self.assertTrue(membership.enabled)
+
+	def test_a_manager_cannot_invite_anyone(self):
+		team, _ = self.team_owned_by("Invite Manager Guard", "invite-owner3@example.com")
+		manager = create_user("invite-manager@example.com", "Manager")
+		upsert_membership(team, manager, "Manager")
+
+		frappe.set_user(manager)
+		with self.assertRaises(CannotManageMembers):
+			invite_members(team, [{"email": "manager-invitee@example.com", "team_role": "Viewer"}])
+
+		self.assertIsNone(self.invitation_for("manager-invitee@example.com"))
+
+	def test_a_viewer_cannot_invite_anyone(self):
+		team, _ = self.team_owned_by("Invite Viewer Guard", "invite-owner4@example.com")
+		viewer = create_user("invite-viewer@example.com", "Viewer")
+		upsert_membership(team, viewer, "Viewer")
+
+		frappe.set_user(viewer)
+		with self.assertRaises(CannotManageMembers):
+			invite_members(team, [{"email": "viewer-invitee@example.com", "team_role": "Viewer"}])
+
+	def test_an_outsider_cannot_invite_anyone(self):
+		team, _ = self.team_owned_by("Invite Outsider Guard", "invite-owner5@example.com")
+		outsider = create_user("invite-outsider@example.com", "Outsider")
+
+		frappe.set_user(outsider)
+		with self.assertRaises(CannotManageMembers):
+			invite_members(team, [{"email": "outsider-invitee@example.com", "team_role": "Viewer"}])
+
+	def test_ownership_cannot_be_granted(self):
+		team, owner = self.team_owned_by("Invite Ownership", "invite-owner6@example.com")
+
+		frappe.set_user(owner)
+		with self.assertRaises(CannotGrantOwnership):
+			invite_members(team, [{"email": "would-be-owner@example.com", "team_role": "Owner"}])
+
+		self.assertIsNone(self.invitation_for("would-be-owner@example.com"))
+
+	def test_an_unknown_role_is_rejected(self):
+		team, owner = self.team_owned_by("Invite Unknown Role", "invite-owner7@example.com")
+
+		frappe.set_user(owner)
+		with self.assertRaises(UnknownTeamRole):
+			invite_members(team, [{"email": "bad-role@example.com", "team_role": "Overlord"}])
+
+	def test_an_existing_member_is_left_alone(self):
+		team, owner = self.team_owned_by("Invite Existing Member", "invite-owner8@example.com")
+		member = create_user("invite-settled@example.com", "Settled")
+		upsert_membership(team, member, "Viewer")
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": member, "team_role": "Admin"}])
+
+		self.assertEqual([outcome.status for outcome in outcomes], ["already_a_member"])
+		self.assertEqual(
+			frappe.db.get_value("Buzz Team Membership", {"team": team, "user": member}, "team_role"),
+			"Viewer",
+		)
+
+	def test_a_removed_member_is_re_enabled_rather_than_invited(self):
+		team, owner = self.team_owned_by("Invite Returning", "invite-owner9@example.com")
+		member = create_user("invite-returning@example.com", "Returning")
+		upsert_membership(team, member, "Manager")
+		frappe.db.set_value("Buzz Team Membership", {"team": team, "user": member}, "enabled", 0)
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": member, "team_role": "Frontdesk"}])
+
+		self.assertEqual([outcome.status for outcome in outcomes], ["added"])
+		self.assertIsNone(self.invitation_for(member))
+
+	def test_an_existing_user_is_matched_regardless_of_case(self):
+		team, owner = self.team_owned_by("Invite Mixed Case", "invite-owner10@example.com")
+		colleague = create_user("invite-mixedcase@example.com", "Mixed")
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": "Invite-MixedCase@Example.com", "team_role": "Viewer"}])
+
+		self.assertEqual([outcome.status for outcome in outcomes], ["added"])
+		self.assertTrue(frappe.db.exists("Buzz Team Membership", {"team": team, "user": colleague}))
+
+	def test_names_the_person_who_was_added(self):
+		team, owner = self.team_owned_by("Invite Named", "invite-owner11@example.com")
+		colleague = create_user("invite-named@example.com", "Rhea")
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": colleague, "team_role": "Manager"}])
+
+		self.assertEqual(outcomes[0].full_name, "Rhea")
+
+	def test_an_invited_stranger_has_no_name_to_show_yet(self):
+		team, owner = self.team_owned_by("Invite Nameless", "invite-owner12@example.com")
+
+		frappe.set_user(owner)
+		outcomes = invite_members(team, [{"email": "nameless@example.com", "team_role": "Viewer"}])
+
+		self.assertIsNone(outcomes[0].full_name)
+
+
+class TestTeamOverviewInvitations(IntegrationTestCase):
+	# Rollback is per class, not per test — every test owns its users and its team names.
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+		# Every invitation mails itself out on insert, which needs an outgoing email account.
+		self.enterContext(patch("frappe.sendmail"))
+
+	def test_lists_the_teams_pending_invitations(self):
+		owner = create_user("overview-invites-owner@example.com", "Owner")
+		team = create_owned_team("Overview Invites", owner)
+
+		frappe.set_user(owner)
+		invite_members(team, [{"email": "awaited@example.com", "team_role": "Frontdesk"}])
+		invites = get_team_overview(team).invites
+
+		self.assertEqual(len(invites), 1)
+		self.assertEqual(invites[0].email, "awaited@example.com")
+		self.assertEqual(invites[0].team_role, "Frontdesk")
+
+	def test_leaves_out_another_teams_invitations(self):
+		owner = create_user("overview-invites-mine@example.com", "Owner")
+		mine = create_owned_team("Overview Invites Mine", owner)
+		theirs = create_owned_team(
+			"Overview Invites Theirs", create_user("overview-invites-other@example.com", "Other")
+		)
+
+		frappe.set_user(owner)
+		invite_members(mine, [{"email": "mine@example.com", "team_role": "Viewer"}])
+		frappe.set_user("Administrator")
+		invite_members(theirs, [{"email": "theirs@example.com", "team_role": "Viewer"}])
+
+		frappe.set_user(owner)
+		self.assertEqual([invite.email for invite in get_team_overview(mine).invites], ["mine@example.com"])
+
+	def test_drops_an_invitation_once_it_is_no_longer_pending(self):
+		owner = create_user("overview-invites-settled@example.com", "Owner")
+		team = create_owned_team("Overview Invites Settled", owner)
+
+		frappe.set_user(owner)
+		invite_members(team, [{"email": "cancelled@example.com", "team_role": "Viewer"}])
+		frappe.set_user("Administrator")
+		frappe.db.set_value("User Invitation", {"email": "cancelled@example.com"}, "status", "Cancelled")
+
+		frappe.set_user(owner)
+		self.assertEqual(get_team_overview(team).invites, [])

--- a/buzz/api/teams/test_teams.py
+++ b/buzz/api/teams/test_teams.py
@@ -1,8 +1,8 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from buzz.api.teams import get_my_teams, get_team_overview
-from buzz.api.teams.exceptions import NotATeamMember
+from buzz.api.teams import get_my_teams, get_team_overview, remove_member
+from buzz.api.teams.exceptions import CannotManageMembers, NotATeamMember
 from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 
@@ -95,6 +95,17 @@ class TestGetTeamOverview(IntegrationTestCase):
 		self.assertEqual(sorted(member.user for member in members), sorted([owner, viewer]))
 		self.assertEqual({member.user: member.team_role for member in members}[viewer], "Viewer")
 
+	def test_lists_the_owner_first(self):
+		# The owner's name sorts last alphabetically, so only the role ordering can put them first.
+		owner = create_user("overview-order-owner@example.com", "Zara")
+		manager = create_user("overview-order-member@example.com", "Aditi")
+		team = create_owned_team("Overview Order", owner)
+		upsert_membership(team, manager, "Manager")
+
+		members = self.overview_for(owner, team).members
+
+		self.assertEqual([member.user for member in members], [owner, manager])
+
 	def test_a_viewer_reads_the_team_despite_no_read_permission(self):
 		user = create_user("overview-no-perm@example.com", "Viewer")
 		team = create_owned_team("Overview No Perm", create_user("overview-admin@example.com", "Admin"))
@@ -111,3 +122,93 @@ class TestGetTeamOverview(IntegrationTestCase):
 		frappe.set_user(user)
 		with self.assertRaises(NotATeamMember):
 			get_team_overview(team)
+
+
+class TestRemoveMember(IntegrationTestCase):
+	# Rollback is per class, not per test — every test owns its users and its team names.
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def membership(self, team: str, user: str) -> dict:
+		return frappe.db.get_value(
+			"Buzz Team Membership", {"team": team, "user": user}, ["name", "enabled"], as_dict=True
+		)
+
+	def test_an_admin_disables_the_membership_instead_of_deleting_it(self):
+		admin = create_user("remove-admin@example.com", "Admin")
+		member = create_user("remove-member@example.com", "Member")
+		team = create_owned_team("Remove Admin", create_user("remove-owner@example.com", "Owner"))
+		upsert_membership(team, admin, "Admin")
+		upsert_membership(team, member, "Manager")
+
+		frappe.set_user(admin)
+		remove_member(team, member)
+
+		self.assertEqual(self.membership(team, member).enabled, 0)
+
+	def test_a_manager_cannot_remove_anyone(self):
+		manager = create_user("remove-manager@example.com", "Manager")
+		member = create_user("remove-managers-target@example.com", "Target")
+		team = create_owned_team("Remove Manager", create_user("remove-owner2@example.com", "Owner"))
+		upsert_membership(team, manager, "Manager")
+		upsert_membership(team, member, "Viewer")
+
+		frappe.set_user(manager)
+		with self.assertRaises(CannotManageMembers):
+			remove_member(team, member)
+
+	def test_an_outsider_cannot_remove_anyone(self):
+		outsider = create_user("remove-outsider@example.com", "Outsider")
+		owner = create_user("remove-owner3@example.com", "Owner")
+		team = create_owned_team("Remove Outsider", owner)
+
+		frappe.set_user(outsider)
+		with self.assertRaises(CannotManageMembers):
+			remove_member(team, owner)
+
+	def test_the_owner_cannot_be_removed(self):
+		owner = create_user("remove-locked-owner@example.com", "Owner")
+		admin = create_user("remove-owners-admin@example.com", "Admin")
+		team = create_owned_team("Remove Owner", owner)
+		upsert_membership(team, admin, "Admin")
+
+		frappe.set_user(admin)
+		with self.assertRaises(frappe.ValidationError):
+			remove_member(team, owner)
+
+	def test_refuses_a_user_who_is_not_on_the_team(self):
+		owner = create_user("remove-stranger-owner@example.com", "Owner")
+		stranger = create_user("remove-stranger@example.com", "Stranger")
+		team = create_owned_team("Remove Stranger", owner)
+
+		frappe.set_user(owner)
+		with self.assertRaises(NotATeamMember):
+			remove_member(team, stranger)
+
+	def test_removing_the_same_member_twice_is_refused(self):
+		owner = create_user("remove-twice-owner@example.com", "Owner")
+		member = create_user("remove-twice-member@example.com", "Member")
+		team = create_owned_team("Remove Twice", owner)
+		upsert_membership(team, member, "Manager")
+
+		frappe.set_user(owner)
+		remove_member(team, member)
+
+		with self.assertRaises(NotATeamMember):
+			remove_member(team, member)
+
+	def test_the_desk_role_survives_while_another_team_still_earns_it(self):
+		owner = create_user("remove-roles-owner@example.com", "Owner")
+		member = create_user("remove-roles-member@example.com", "Member")
+		first = create_owned_team("Remove Roles First", owner)
+		second = create_owned_team("Remove Roles Second", owner)
+		upsert_membership(first, member, "Manager")
+		upsert_membership(second, member, "Manager")
+
+		frappe.set_user(owner)
+		remove_member(first, member)
+		self.assertIn("Event Manager", frappe.get_roles(member))
+
+		remove_member(second, member)
+		self.assertNotIn("Event Manager", frappe.get_roles(member))

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -11,6 +11,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AddMembersDialog: typeof import('./src/components/dashboard/teams/AddMembersDialog.vue')['default']
     AddOnPreferenceDialog: typeof import('./src/components/AddOnPreferenceDialog.vue')['default']
     AttendeeFormControl: typeof import('./src/components/AttendeeFormControl.vue')['default']
     BackButton: typeof import('./src/components/common/BackButton.vue')['default']

--- a/dashboard/src/components/dashboard/teams/AddMembersDialog.vue
+++ b/dashboard/src/components/dashboard/teams/AddMembersDialog.vue
@@ -1,0 +1,276 @@
+<script setup lang="ts">
+import { inviteMembers } from "@/data/teams";
+import type { FrappeError, InviteOutcome } from "@/types";
+import { Button, Dialog, FormControl, toast } from "frappe-ui";
+import { computed, nextTick, ref, watch } from "vue";
+
+// Mirrors the membership doctype's own options, minus Owner. The server rejects
+// anything outside this set, so a drift here fails loudly rather than silently.
+const ROLE_OPTIONS = ["Admin", "Manager", "Frontdesk", "Viewer"];
+const DEFAULT_ROLE = "Manager";
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface InviteRow {
+	id: number;
+	email: string;
+	team_role: string;
+}
+
+const props = defineProps<{ team: string }>();
+const isOpen = defineModel<boolean>({ required: true });
+const emit = defineEmits<{ success: [] }>();
+
+// Rows are spliced, so they need an identity of their own — a key by position would
+// hand Vue the wrong node the moment a row in the middle goes.
+let lastRowId = 0;
+
+const rows = ref<InviteRow[]>([newRow()]);
+const showErrors = ref(false);
+const form = ref<HTMLFormElement>();
+
+// createResource types its error as {}, so the message needs narrowing.
+const errorMessage = computed(() => (inviteMembers.error as FrappeError | null)?.message);
+
+const filled = computed(() => rows.value.filter((row) => row.email.trim()));
+
+const invalid = computed(() =>
+	filled.value.filter((row) => !EMAIL_PATTERN.test(row.email.trim()))
+);
+
+function newRow(email = "", team_role = DEFAULT_ROLE): InviteRow {
+	lastRowId += 1;
+	return { id: lastRowId, email, team_role };
+}
+
+function isInvalid(row: InviteRow) {
+	return showErrors.value && invalid.value.includes(row);
+}
+
+watch(isOpen, async (open) => {
+	if (!open) return;
+	rows.value = [newRow()];
+	showErrors.value = false;
+	inviteMembers.reset();
+	await nextTick();
+	form.value?.querySelector("input")?.focus();
+});
+
+// One watcher rather than an input handler: it only ever sees values the model has
+// already committed, so a paste cannot be read a keystroke late.
+watch(
+	rows,
+	(current) => {
+		splitPastedEmails(current);
+
+		// Typing in the last row opens the next one, so a second invite needs no click.
+		const last = current[current.length - 1];
+		if (last?.email.trim()) current.push(newRow("", last.team_role));
+	},
+	{ deep: true }
+);
+
+// A pasted list is the fastest way to invite a whole team, so commas become rows.
+function splitPastedEmails(current: InviteRow[]) {
+	const index = current.findIndex((row) => row.email.includes(","));
+	if (index < 0) return;
+
+	const row = current[index];
+	const emails = row.email
+		.split(",")
+		.map((email) => email.trim())
+		.filter(Boolean);
+
+	row.email = emails[0] ?? "";
+	current.splice(index + 1, 0, ...emails.slice(1).map((email) => newRow(email, row.team_role)));
+}
+
+// The trailing blank row is not a member, so there is nothing to take off the list.
+function canRemove(index: number) {
+	return rows.value.length > 1 && index < rows.value.length - 1;
+}
+
+function removeRow(index: number) {
+	rows.value.splice(index, 1);
+	if (!rows.value.length) rows.value.push(newRow());
+}
+
+function labelFor(outcome: InviteOutcome) {
+	return outcome.full_name || outcome.email;
+}
+
+// Two names read better than a count; past that a count reads better than a queue.
+function nameList(outcomes: InviteOutcome[]) {
+	const [first, second] = outcomes.map(labelFor);
+	if (outcomes.length === 1) return first;
+	if (outcomes.length === 2) return `${first} and ${second}`;
+	return `${first} and ${outcomes.length - 1} others`;
+}
+
+// An invited stranger does not appear in the table behind this dialog until they
+// accept, so the toast has to say so — otherwise they look like they went missing.
+function report(outcomes: InviteOutcome[]) {
+	const added = outcomes.filter((outcome) => outcome.status === "added");
+	const invited = outcomes.filter((outcome) => outcome.status === "invited");
+	const pending = "They'll show up here once they accept.";
+
+	if (!added.length && !invited.length) {
+		toast.info("Everyone on that list is already on the team");
+		return;
+	}
+
+	if (!invited.length) {
+		toast.success(`${nameList(added)} joined the team`);
+		return;
+	}
+
+	if (!added.length) {
+		const title =
+			invited.length === 1
+				? `Invitation sent to ${nameList(invited)}`
+				: `${invited.length} invitations sent`;
+		toast.success(title, { description: pending });
+		return;
+	}
+
+	// Not "they" here — half of them are already in the table behind this toast.
+	toast.success(`${added.length} joined, ${invited.length} invited`, {
+		description: "The invitations show up here once they're accepted.",
+	});
+}
+
+// One bad address should cost the user that row, not the whole batch.
+async function submit() {
+	showErrors.value = true;
+	if (!filled.value.length || invalid.value.length) return;
+
+	const outcomes = await inviteMembers.submit({
+		team: props.team,
+		invites: filled.value.map((row) => ({
+			email: row.email.trim(),
+			team_role: row.team_role,
+		})),
+	});
+
+	report(outcomes ?? []);
+	emit("success");
+	isOpen.value = false;
+}
+</script>
+
+<template>
+	<Dialog v-model="isOpen" title="Add members" size="xl">
+		<!-- novalidate: the action button lives outside this form, so the browser's own
+			 bubble would only ever fire on the Enter path. One rule for both. -->
+		<form ref="form" novalidate class="space-y-3" @submit.prevent="submit">
+			<p class="text-base text-ink-gray-5">
+				Colleagues who already have an account join straight away. Everyone else gets an
+				email invitation.
+			</p>
+
+			<div
+				class="grid grid-cols-[minmax(0,1fr)_9rem_2rem] items-center gap-2 text-sm text-ink-gray-5"
+			>
+				<span>Email</span>
+				<span>Role</span>
+			</div>
+
+			<TransitionGroup tag="div" name="row" class="relative space-y-2">
+				<div
+					v-for="(row, index) in rows"
+					:key="row.id"
+					class="grid grid-cols-[minmax(0,1fr)_9rem_2rem] items-center gap-2"
+				>
+					<FormControl
+						v-model="row.email"
+						type="email"
+						placeholder="colleague@example.com"
+						aria-label="Email"
+						:class="isInvalid(row) && '[&_input]:!border-outline-red-3'"
+					/>
+
+					<FormControl
+						v-model="row.team_role"
+						type="select"
+						aria-label="Role"
+						:options="ROLE_OPTIONS"
+					/>
+
+					<Button
+						v-if="canRemove(index)"
+						variant="ghost"
+						:label="`Remove ${row.email || 'row'}`"
+						@click="removeRow(index)"
+					>
+						<template #icon>
+							<span class="lucide-x size-4" />
+						</template>
+					</Button>
+				</div>
+			</TransitionGroup>
+
+			<ErrorMessage
+				:message="
+					invalid.length && showErrors
+						? 'Check the highlighted addresses.'
+						: errorMessage
+				"
+			/>
+
+			<!-- Lets Enter submit from any field, since the actions live outside this form. -->
+			<button type="submit" class="hidden" />
+		</form>
+
+		<template #actions="{ close }">
+			<div class="flex gap-2">
+				<Button
+					variant="solid"
+					label="Send invites"
+					:loading="inviteMembers.loading"
+					:disabled="!filled.length"
+					@click="submit"
+				/>
+				<Button variant="outline" label="Cancel" @click="close" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<style scoped>
+/* Matches the members table behind this dialog: the leaving row drops out of flow so
+   the rows below start closing the gap straight away. */
+.row-leave-active {
+	position: absolute;
+	inset-inline: 0;
+	transition: opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.row-leave-to {
+	opacity: 0;
+	transform: translateX(0.5rem);
+}
+
+.row-move {
+	transition: transform 250ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* Entry is opacity only, on purpose: a row arrives mid-keystroke, and anything that
+   moves under the caret reads as lag. */
+.row-enter-from {
+	opacity: 0;
+}
+
+.row-enter-active {
+	transition: opacity 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.row-leave-to {
+		transform: none;
+	}
+
+	.row-move {
+		transition: none;
+	}
+}
+</style>

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -55,6 +55,10 @@ export function useTeamOverview() {
 	return teamOverview
 }
 
+export const removeMember = createResource({
+	url: "buzz.api.teams.remove_member",
+})
+
 export function selectTeam(name: string) {
 	selectedTeamName.value = name
 	localStorage.setItem(STORAGE_KEY, name)

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -1,5 +1,5 @@
 import { session } from "@/data/session"
-import type { TeamOption, TeamOverview } from "@/types"
+import type { InviteOutcome, TeamOption, TeamOverview } from "@/types"
 import { createResource, useCall } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 
@@ -57,6 +57,10 @@ export function useTeamOverview() {
 
 export const removeMember = createResource({
 	url: "buzz.api.teams.remove_member",
+})
+
+export const inviteMembers = createResource<InviteOutcome[]>({
+	url: "buzz.api.teams.invite_members",
 })
 
 export function selectTeam(name: string) {

--- a/dashboard/src/pages/manage/teams/TeamMembers.vue
+++ b/dashboard/src/pages/manage/teams/TeamMembers.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import AddMembersDialog from "@/components/dashboard/teams/AddMembersDialog.vue";
 import TeamPageHeader from "@/components/dashboard/teams/TeamPageHeader.vue";
 import { session } from "@/data/session";
 import { currentTeam, removeMember, useTeamOverview } from "@/data/teams";
-import type { TeamMember } from "@/types";
+import type { TeamInvite, TeamMember } from "@/types";
 import { Avatar, Button, Dropdown, ErrorMessage, LoadingText, dialog, toast } from "frappe-ui";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 const MANAGING_ROLES = ["Owner", "Admin"];
 
@@ -20,6 +21,8 @@ const ROLES = [
 const COLUMNS =
 	"grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4";
 
+const isAdding = ref(false);
+
 const teamOverview = useTeamOverview();
 
 const team = computed(() => teamOverview.data);
@@ -28,7 +31,12 @@ const errorMessage = computed(() => teamOverview.error?.message);
 
 const canManage = computed(() => MANAGING_ROLES.includes(team.value?.my_role ?? ""));
 
-const rows = computed<Row[]>(() => (team.value?.members ?? []).map(memberRow));
+// Members and pending invitations share one list so the table reads as the whole team,
+// with the people who have not accepted yet at the bottom.
+const rows = computed<Row[]>(() => [
+	...(team.value?.members ?? []).map(memberRow),
+	...(team.value?.invites ?? []).map(inviteRow),
+]);
 
 interface Row {
 	key: string;
@@ -36,7 +44,7 @@ interface Row {
 	email: string;
 	role: string;
 	image?: string;
-	member: TeamMember;
+	member?: TeamMember;
 }
 
 function memberRow(member: TeamMember): Row {
@@ -50,10 +58,20 @@ function memberRow(member: TeamMember): Row {
 	};
 }
 
-// The owner is locked server-side, and leaving a team is its own flow rather than a
-// self-removal.
+// There is no user yet, so no name and no image — the address stands in for both.
+function inviteRow(invite: TeamInvite): Row {
+	return {
+		key: `invite:${invite.email}`,
+		name: invite.email,
+		email: invite.email,
+		role: invite.team_role,
+	};
+}
+
+// The owner is locked server-side, leaving a team is its own flow rather than a
+// self-removal, and an invitation is revoked rather than removed.
 function canRemove(row: Row) {
-	if (!canManage.value) return false;
+	if (!canManage.value || !row.member) return false;
 	return row.member.team_role !== "Owner" && row.member.user !== session.user;
 }
 
@@ -111,6 +129,15 @@ function confirmRemove(row: Row) {
 			</section>
 
 			<div>
+				<div class="flex justify-end pb-3">
+					<Button
+						v-if="canManage"
+						icon-left="plus"
+						label="Add member"
+						@click="isAdding = true"
+					/>
+				</div>
+
 				<div :class="COLUMNS" class="pb-2 text-sm text-ink-gray-5">
 					<span>Name</span>
 					<span>Email</span>
@@ -134,6 +161,9 @@ function confirmRemove(row: Row) {
 
 						<span class="truncate text-base font-medium text-ink-gray-8">
 							{{ row.role }}
+							<span v-if="!row.member" class="font-normal text-ink-gray-5">
+								(Invited)
+							</span>
 						</span>
 
 						<Dropdown v-if="canRemove(row)" :options="actionsFor(row)" align="end">
@@ -147,6 +177,12 @@ function confirmRemove(row: Row) {
 					</li>
 				</TransitionGroup>
 			</div>
+
+			<AddMembersDialog
+				v-model="isAdding"
+				:team="currentTeam?.name ?? ''"
+				@success="teamOverview.reload()"
+			/>
 		</template>
 	</div>
 </template>

--- a/dashboard/src/pages/manage/teams/TeamMembers.vue
+++ b/dashboard/src/pages/manage/teams/TeamMembers.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import TeamPageHeader from "@/components/dashboard/teams/TeamPageHeader.vue";
+import { session } from "@/data/session";
+import { currentTeam, removeMember, useTeamOverview } from "@/data/teams";
+import type { TeamMember } from "@/types";
+import { Avatar, Button, Dropdown, ErrorMessage, LoadingText, dialog, toast } from "frappe-ui";
+import { computed } from "vue";
+
+const MANAGING_ROLES = ["Owner", "Admin"];
+
+// Plain-language reading of the capability matrix in specs/v2/00-teams.
+const ROLES = [
+	{ name: "Owner", can: "Created the team. Full control, and cannot be removed." },
+	{ name: "Admin", can: "Everything an owner can do, except renaming or deleting the team." },
+	{ name: "Manager", can: "Creates and edits events. Cannot delete records or manage members." },
+	{ name: "Frontdesk", can: "Checks attendees in at the door, and nothing else." },
+	{ name: "Viewer", can: "Reads the team's events and details. Changes nothing." },
+];
+// Header and rows share one grid so the columns line up without a table element.
+const COLUMNS =
+	"grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4";
+
+const teamOverview = useTeamOverview();
+
+const team = computed(() => teamOverview.data);
+
+const errorMessage = computed(() => teamOverview.error?.message);
+
+const canManage = computed(() => MANAGING_ROLES.includes(team.value?.my_role ?? ""));
+
+const rows = computed<Row[]>(() => (team.value?.members ?? []).map(memberRow));
+
+interface Row {
+	key: string;
+	name: string;
+	email: string;
+	role: string;
+	image?: string;
+	member: TeamMember;
+}
+
+function memberRow(member: TeamMember): Row {
+	return {
+		key: member.user,
+		name: member.full_name ?? member.user,
+		email: member.user,
+		role: member.team_role,
+		image: member.user_image ?? undefined,
+		member,
+	};
+}
+
+// The owner is locked server-side, and leaving a team is its own flow rather than a
+// self-removal.
+function canRemove(row: Row) {
+	if (!canManage.value) return false;
+	return row.member.team_role !== "Owner" && row.member.user !== session.user;
+}
+
+function actionsFor(row: Row) {
+	return [
+		{
+			label: "Remove from team",
+			icon: "trash-2",
+			theme: "red" as const,
+			onClick: () => confirmRemove(row),
+		},
+	];
+}
+
+function confirmRemove(row: Row) {
+	dialog.confirm({
+		title: "Remove member",
+		message: `${row.name} will lose access to this team.`,
+		theme: "red",
+		confirmLabel: "Remove",
+		// A rejected promise renders inline in the dialog, so failures need no branch here.
+		onConfirm: async () => {
+			await removeMember.submit({ team: currentTeam.value?.name, user: row.email });
+			await teamOverview.reload();
+			toast.success(`${row.name} was removed from the team.`);
+		},
+	});
+}
+</script>
+
+<template>
+	<TeamPageHeader title="Members" />
+
+	<div class="m-auto max-w-[900px] w-full py-8 px-4 space-y-6">
+		<LoadingText v-if="teamOverview.loading" text="Loading members…" />
+
+		<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
+
+		<template v-else-if="team">
+			<header class="space-y-1">
+				<h1 class="font-semibold text-4xl">Team members</h1>
+				<p class="text-base text-ink-gray-5">
+					Everyone who works on {{ team.team_name }}, and what they are allowed to do.
+				</p>
+			</header>
+
+			<section class="rounded-xl bg-surface-gray-1 p-4">
+				<h2 class="text-sm font-medium text-ink-gray-7">What each role can do</h2>
+				<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+					<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
+						<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>
+						<dd class="text-ink-gray-5">{{ role.can }}</dd>
+					</div>
+				</dl>
+			</section>
+
+			<div>
+				<div :class="COLUMNS" class="pb-2 text-sm text-ink-gray-5">
+					<span>Name</span>
+					<span>Email</span>
+					<span>Role</span>
+				</div>
+
+				<!-- Removing a row would otherwise snap the rest of the list upwards. -->
+				<TransitionGroup tag="ul" name="member" aria-label="Team members" class="relative">
+					<li
+						v-for="row in rows"
+						:key="row.key"
+						:class="COLUMNS"
+						class="-mx-2 rounded px-2 py-2 transition-colors duration-150 hover:bg-surface-gray-1"
+					>
+						<div class="flex min-w-0 items-center gap-3">
+							<Avatar :image="row.image" :label="row.name" size="lg" />
+							<span class="truncate text-base text-ink-gray-8">{{ row.name }}</span>
+						</div>
+
+						<span class="truncate text-base text-ink-gray-6">{{ row.email }}</span>
+
+						<span class="truncate text-base font-medium text-ink-gray-8">
+							{{ row.role }}
+						</span>
+
+						<Dropdown v-if="canRemove(row)" :options="actionsFor(row)" align="end">
+							<!-- label is the accessible name here: an icon slot makes it icon-only. -->
+							<Button variant="ghost" label="Member actions">
+								<template #icon>
+									<span class="lucide-ellipsis size-4" />
+								</template>
+							</Button>
+						</Dropdown>
+					</li>
+				</TransitionGroup>
+			</div>
+		</template>
+	</div>
+</template>
+
+<style scoped>
+/* The leaving row is taken out of flow so the rows below start closing the gap
+   straight away rather than waiting for the fade to finish. */
+.member-leave-active {
+	position: absolute;
+	inset-inline: 0;
+	transition: opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.member-leave-to {
+	opacity: 0;
+	transform: translateX(0.5rem);
+}
+
+.member-move {
+	transition: transform 250ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.member-leave-to {
+		transform: none;
+	}
+
+	.member-move {
+		transition: none;
+	}
+}
+</style>

--- a/dashboard/src/pages/manage/teams/TeamOverview.vue
+++ b/dashboard/src/pages/manage/teams/TeamOverview.vue
@@ -100,7 +100,12 @@ const hiddenMemberCount = computed(() =>
 						</Avatar>
 					</div>
 
-					<Button variant="ghost" label="Manage members" class="w-fit" />
+					<Button
+						variant="ghost"
+						label="Manage members"
+						class="w-fit"
+						:route="{ name: 'team-members' }"
+					/>
 				</section>
 			</div>
 		</template>

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -48,6 +48,11 @@ const routes: RouteRecordRaw[] = [
 				name: "team-overview",
 				component: () => import("@/pages/manage/teams/TeamOverview.vue"),
 			},
+			{
+				path: "team/members",
+				name: "team-members",
+				component: () => import("@/pages/manage/teams/TeamMembers.vue"),
+			},
 			// Sidebar destinations that have no page yet. Unnamed on purpose: SidebarItem
 			// falls back to matching on path, so each one lights up on its own. Enumerated
 			// so a mistyped path reaches the 404 below — keep in step with the sidebar

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -78,6 +78,20 @@ export interface TeamMember {
 	team_role: string
 }
 
+// buzz.api.teams.invite_members: what happened to each address that was submitted.
+export interface InviteOutcome {
+	email: string
+	status: "invited" | "added" | "already_a_member"
+	// Null for an invited stranger — they have no account to carry a name yet.
+	full_name: string | null
+}
+
+// An invitation nobody has accepted yet — no user, so no name or image.
+export interface TeamInvite {
+	email: string
+	team_role: string
+}
+
 // buzz.api.teams.get_team_overview: one team with its enabled members.
 export interface TeamOverview {
 	name: string
@@ -86,6 +100,7 @@ export interface TeamOverview {
 	logo: string | null
 	my_role: string
 	members: TeamMember[]
+	invites: TeamInvite[]
 }
 
 // buzz.api.events.get_my_events: events the user's teams host, plus events they

--- a/e2e/tests/team-members.spec.ts
+++ b/e2e/tests/team-members.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+// Runs under the shared Administrator state, who owns a team and is therefore the one
+// member the page is guaranteed to show.
+test.describe("Team members", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/b/manage/events");
+		await page.getByRole("link", { name: "Members" }).click();
+	});
+
+	test("lists the team from the sidebar", async ({ page }) => {
+		await expect(page).toHaveURL(/\/b\/manage\/team\/members$/, { timeout: 15000 });
+		await expect(page.getByRole("heading", { name: "Team members", level: 1 })).toBeVisible();
+	});
+
+	test("puts the owner first and offers no way to remove them", async ({ page }) => {
+		const members = page.getByRole("list", { name: "Team members" }).getByRole("listitem");
+
+		await expect(members.first()).toContainText("Owner", { timeout: 15000 });
+		await expect(members.first().getByRole("button", { name: "Member actions" })).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
## What changed

Fourth in the `/manage` stack. #351 has merged, so this sits directly on `develop`.
Fills in the sidebar's **Members** item, which fell through to the work-in-progress
placeholder until now.

- **`/manage/team/members`** — the team as a subtle table: name, email, role, and an
  ellipsis menu holding the one destructive action. Owner sorts first and carries no
  menu, matching the controller lock. A legend above it spells out what each of the
  five roles can actually do.
- **`remove_member`** — disables the membership rather than deleting it, so
  `upsert_membership` re-enables the same row if the person is invited back.
- **`invite_members` + an Add members dialog** — rows of email and role, a pasted
  comma-separated list explodes into rows, and the next row opens as you type.
- Pending invitations sit in the same table, address standing in for the name and
  `(Invited)` against the role.

### Worth knowing

**Invite-by-email existed and had never been called.** 00-teams/04 wired the
`user_invitation` hook, the `buzz_team`/`buzz_team_role` custom fields and
`on_invitation_accepted`, but the only caller was `EventTicket.send_user_invitation`,
and that call site is commented out. This is the first path that actually sends one.

**`invite_members` does not just forward to core.** `invite_by_email` skips any address
that ever accepted a buzz invitation, filtered by `app_name` with no team filter — so
inviting a colleague to a second team would silently no-op and report success. Existing
users go through `upsert_membership` instead; only strangers get an email.

**Guarded at invite time, not accept time.** Core's `validate_role` gates on the Frappe
role, not team membership, so a Manager could otherwise create an invitation that throws
when the recipient clicks the link. `can_manage_members` runs before anything is sent.
The three refusal tests were mutation-checked: `if False:` breaks exactly those.

**Accepting a Manager/Admin/Frontdesk invitation makes the user a System User.** `Event
Manager` and `Frontdesk Manager` both carry `desk_access`, and `set_system_user()` flips
`user_type` on any save. Pre-existing and deliberate — 00-teams/01 deferred an `Event
Manager` fixture because `desk_access: 0` would revoke Desk from every current organizer
— but this PR makes it one click away, so it is worth naming. Not addressed here.

### Not in scope

Role changes, revoking an invitation (core's `cancel_invitation` would slot into the same
menu), leaving a team, and the team profile/settings surface — all spec 13, all separate.

## Demo

https://cap.so/s/rb0k446j8jz7scj

<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/e15ee1d9-8eeb-4c73-868a-f8cf48ada7f9" />

<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/f7ffb59c-2674-45e7-861c-21fd645cbff1" />

<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/317786e3-315b-4f0a-8072-5f49271fb9e8" />


## Testing

32 new backend tests across `test_teams.py` and `test_invitations.py`, plus a Playwright
spec for the route and the owner row. Verified in a browser with five members and pending
invitations: remove, paste, add, and every toast variant.

Rebased onto `develop` after #351 squash-merged: 7 commits to 4, the three #351 commits
dropped. No content change — `pre-commit` clean on all 15 files, typecheck clean, 70 unit
tests, 32 backend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
