### PR TITLE
feat(dashboard): a team's events at /manage/team/events

### DIFF
--- a/dashboard/src/components/dashboard/events/EventCard.vue
+++ b/dashboard/src/components/dashboard/events/EventCard.vue
@@ -2,12 +2,18 @@
 import type { MyEvent } from "@/types";
 import { dayLabel } from "@/utils/dateLabels";
 import { bannerPattern } from "@/utils/eventBanner";
-import { Avatar } from "frappe-ui";
+import { Avatar, Button } from "frappe-ui";
 import { computed } from "vue";
 
 // The Events page files cards under a date heading; a standalone list has to
 // carry the date on the card itself.
-const props = defineProps<{ event: MyEvent; showDate?: boolean }>();
+const props = withDefaults(
+	defineProps<{ event: MyEvent; showDate?: boolean; showManage?: boolean }>(),
+	{ showManage: true }
+);
+
+// Two gates: the caller has to want the button, and only a host has anything to manage.
+const canManage = computed(() => props.showManage && props.event.is_host);
 
 // Times arrive as a serialized timedelta ("9:00:00"), so the hour needs padding.
 const startTime = computed((): string => {
@@ -69,14 +75,18 @@ const venue = computed(() => {
 				</p>
 			</div>
 
-			<p class="mt-2 flex items-center gap-2 text-base text-ink-gray-5">
-				<span
-					class="size-4 shrink-0"
-					:class="[venue.icon, venue.tone]"
-					aria-hidden="true"
-				/>
-				{{ venue.label }}
-			</p>
+			<div class="flex justify-between">
+				<p class="mt-2 flex items-center gap-2 text-base text-ink-gray-5">
+					<span
+						class="size-4 shrink-0"
+						:class="[venue.icon, venue.tone]"
+						aria-hidden="true"
+					/>
+					{{ venue.label }}
+				</p>
+				<!-- TODO: wire this button up with the manage event page -->
+				<Button v-if="canManage" label="Manage" icon-right="arrow-right" size="sm" />
+			</div>
 		</div>
 	</article>
 </template>

--- a/dashboard/src/components/dashboard/teams/TeamPageHeader.vue
+++ b/dashboard/src/components/dashboard/teams/TeamPageHeader.vue
@@ -13,7 +13,7 @@ const items = computed(() => {
 </script>
 
 <template>
-	<PageHeader class="border-none pt-2">
+	<PageHeader class="border-none pt-2 bg-surface-elevation-1">
 		<Breadcrumbs :items="items" />
 		<Button variant="solid" icon-left="plus" label="Create Event" />
 	</PageHeader>

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -20,7 +20,7 @@ const route = useRoute();
 const isActive = (to: string) => route.path === to;
 
 const personalItems = [
-	{ label: "Events", icon: "lucide-calendar-days", to: "/manage/events" },
+	{ label: "My Events", icon: "lucide-calendar-days", to: "/manage/events" },
 	{ label: "My Tickets", icon: "lucide-ticket", to: "/manage/tickets" },
 	{ label: "Talk Proposals", icon: "lucide-file-text", to: "/manage/proposals" },
 	{ label: "Sponsorship", icon: "lucide-handshake", to: "/manage/sponsorship" },
@@ -30,10 +30,8 @@ const personalItems = [
 // so they are fixed and need no team loaded to render.
 const teamItems = [
 	{ label: "Overview", icon: "lucide-layout-dashboard", to: "/manage/team/overview" },
+	{ label: "Events", icon: "lucide-calendar-days", to: "/manage/team/events" },
 	{ label: "Members", icon: "lucide-users-round", to: "/manage/team/members" },
-	{ label: "Registrations", icon: "lucide-users", to: "/manage/registrations" },
-	{ label: "Sponsors", icon: "lucide-badge-dollar-sign", to: "/manage/sponsors" },
-	{ label: "More", icon: "lucide-ellipsis", to: "/manage/more" },
 ];
 </script>
 

--- a/dashboard/src/pages/manage/teams/TeamEvents.vue
+++ b/dashboard/src/pages/manage/teams/TeamEvents.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import TimelineList from "@/components/dashboard/TimelineList.vue";
 import EventCard from "@/components/dashboard/events/EventCard.vue";
+import TeamPageHeader from "@/components/dashboard/teams/TeamPageHeader.vue";
 import { useMyEvents } from "@/data/events";
+import { currentTeam } from "@/data/teams";
 import { groupEventsByMonth } from "@/utils/eventGroups";
 import type { TimelineTab } from "@/utils/timelineTabs";
 import { computed, ref } from "vue";
@@ -10,21 +12,31 @@ const myEvents = useMyEvents();
 
 const tab = ref<TimelineTab>("upcoming");
 
-// The feed arrives already split, so the tab only picks a side.
-const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || []));
+// Reuses the feed the Events page already loads: a member sees every event their own
+// team hosts, so filtering that feed by team is the team's whole calendar.
+const months = computed(() =>
+	groupEventsByMonth(
+		(myEvents.data?.[tab.value] || []).filter(
+			(event) => event.team === currentTeam.value?.name
+		)
+	)
+);
 </script>
 
 <template>
+	<TeamPageHeader title="Events" />
+
 	<TimelineList
 		v-model:tab="tab"
-		heading="My Events"
+		heading="Events"
 		noun="events"
 		:months="months"
 		:loading="myEvents.loading"
 		:error="myEvents.error"
 	>
+		<!-- Every event here belongs to the team, so a per-card Manage button says nothing. -->
 		<template #default="{ item }">
-			<EventCard :event="item" />
+			<EventCard :event="item" :show-manage="false" />
 		</template>
 	</TimelineList>
 </template>

--- a/dashboard/src/pages/manage/teams/TeamOverview.vue
+++ b/dashboard/src/pages/manage/teams/TeamOverview.vue
@@ -72,7 +72,7 @@ const hiddenMemberCount = computed(() =>
 						variant="ghost"
 						label="See all events"
 						class="w-fit"
-						:route="{ name: 'events' }"
+						:route="{ name: 'team-events' }"
 					/>
 				</section>
 

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -49,6 +49,11 @@ const routes: RouteRecordRaw[] = [
 				component: () => import("@/pages/manage/teams/TeamOverview.vue"),
 			},
 			{
+				path: "team/events",
+				name: "team-events",
+				component: () => import("@/pages/manage/teams/TeamEvents.vue"),
+			},
+			{
 				path: "team/members",
 				name: "team-members",
 				component: () => import("@/pages/manage/teams/TeamMembers.vue"),

--- a/e2e/tests/manage-access.spec.ts
+++ b/e2e/tests/manage-access.spec.ts
@@ -13,9 +13,9 @@ test.describe("Manage access", () => {
 
 	test("routes a sidebar item with no page yet to the placeholder", async ({ page }) => {
 		await page.goto("/b/manage/events");
-		await page.getByRole("link", { name: "Registrations" }).click();
+		await page.getByRole("link", { name: "Sponsorship" }).click();
 
-		await expect(page).toHaveURL(/\/b\/manage\/registrations$/);
+		await expect(page).toHaveURL(/\/b\/manage\/sponsorship$/);
 		await expect(page.getByText("Work in progress")).toBeVisible();
 	});
 


### PR DESCRIPTION
## What changed

Fifth in the `/manage` stack. #352 has merged, so this sits directly on `develop`.
The team dashboard could show its members but not its events. This fills in a new
**Team > Events** sidebar item at `/manage/team/events`.

- **`/manage/team/events`** — `TeamPageHeader` over the same `TimelineList` and
  Upcoming/Past toggle the personal Events page already uses.
- **No new endpoint.** `get_my_events` already returns every event the user's teams
  host, each row carrying its `team`. Filtering that feed by `currentTeam` is the
  team's whole calendar.
- **A Manage button on `EventCard`.** Two gates: the caller has to want it
  (`showManage`, default `true`) and the event has to be one the user hosts
  (`is_host`). The team page passes `false` — every row there belongs to the team,
  so a per-card button says nothing.
- **Sidebar trimmed.** Team's Registrations, Sponsors and More were placeholders for
  pages that are not planned. The personal item becomes "My Events" to tell it apart
  from the team's, and Overview's "See all events" now lands on the team page.

### Worth knowing

**The Manage button goes nowhere yet.** It renders and does nothing — #354/#355 land
the event workspace behind it. Marked with a TODO rather than held back, so the card
layout lands once.

**Team scope stays ambient.** The route is the fixed `/manage/team/events`, not
`/manage/<team>/events`; the page reads `currentTeam` like every other team page in
this stack.

**`manage-access.spec.ts` clicks Sponsorship now.** It used Registrations to reach
the work-in-progress placeholder, and that sidebar item is gone.

### Not in scope

No e2e spec for the new route — asserting the team filter needs a second seeded team
and `auth.setup.ts` seeds one. `MyTickets.vue` and `MyProposals.vue` still declare
their own tab options.

## Demo

<img width="5088" height="3354" alt="image" src="https://github.com/user-attachments/assets/3026dc22-b635-4584-aa70-793e4f910cfa" />

## Testing

`pre-commit` clean on all 8 files, `yarn typecheck` clean, 70 unit tests, `yarn build`
clean. Playwright was green on the pre-rebase head.

Rebased onto `develop` after #352 squash-merged: the four #352 commits dropped, one
commit left. The only content change is a prettier reflow of the filter callback in
`TeamEvents.vue`, folded in — it was the Frappe Linter red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
