### PR TITLE
feat(dashboard): create an event from the dashboard

### DIFF
--- a/buzz/api/events/__init__.py
+++ b/buzz/api/events/__init__.py
@@ -1,10 +1,15 @@
 import frappe
 
 from buzz.api.events import services
-from buzz.api.events.schemas import MyEventsResponse
+from buzz.api.events.schemas import CreatedEvent, MyEventsResponse, NewEvent
 
 
 @frappe.whitelist()
 def get_my_events() -> MyEventsResponse:
 	"""Events hosted by the session user's teams, plus events they hold a ticket to."""
 	return services.my_events()
+
+
+@frappe.whitelist(methods=["POST"])
+def create_event(event: NewEvent) -> CreatedEvent:
+	return services.create_event(event)

--- a/buzz/api/events/exceptions.py
+++ b/buzz/api/events/exceptions.py
@@ -1,0 +1,13 @@
+from frappe import _lt
+
+from buzz.api.exceptions import BuzzAPIError, NotPermitted
+
+
+class CannotCreateEvents(NotPermitted):
+	title = _lt("Not Permitted")
+	message = _lt("You cannot create events for this team.")
+
+
+class ZoomNotAvailable(BuzzAPIError):
+	title = _lt("Zoom Not Available")
+	message = _lt("Zoom is not set up on this site, so a Zoom meeting cannot be created.")

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -1,6 +1,6 @@
 from datetime import date, timedelta
 
-from buzz.api.schemas import APIResponse
+from buzz.api.schemas import APIRequest, APIResponse
 
 
 class MyEvent(APIResponse):
@@ -21,3 +21,24 @@ class MyEvent(APIResponse):
 class MyEventsResponse(APIResponse):
 	upcoming: list[MyEvent]
 	past: list[MyEvent]
+
+
+class NewEvent(APIRequest):
+	team: str
+	title: str
+	start_date: date
+	start_time: timedelta
+	end_time: timedelta
+	end_date: date | None = None
+	about: str | None = None
+	banner_image: str | None = None
+	time_zone: str | None = None
+	venue: str | None = None
+	# Zoom cannot be booked before the event exists, so the dashboard asks for it here
+	# and the service books it once the event is saved.
+	zoom_meeting: bool = False
+
+
+class CreatedEvent(APIResponse):
+	name: str
+	title: str

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -1,9 +1,13 @@
 import frappe
+from frappe import _
+from frappe.model.naming import append_number_if_name_exists
 from frappe.query_builder import Case
 from frappe.utils import getdate
 
-from buzz.api.events.schemas import MyEvent, MyEventsResponse
-from buzz.permissions import my_teams
+from buzz.api.events.exceptions import CannotCreateEvents, ZoomNotAvailable
+from buzz.api.events.schemas import CreatedEvent, MyEvent, MyEventsResponse, NewEvent
+from buzz.permissions import has_team_access, my_teams
+from buzz.utils import is_app_installed
 
 
 def my_events() -> MyEventsResponse:
@@ -63,3 +67,84 @@ def split_by_date(events: list[MyEvent]) -> tuple[list[MyEvent], list[MyEvent]]:
 		is_over = (event.end_date or event.start_date) < getdate()
 		(past if is_over else upcoming).append(event)
 	return upcoming, list(reversed(past))
+
+
+# Buzz Event demands a category and a host, neither of which the create form asks for.
+# These are the defaults it fills in; the organiser changes them on the event afterwards.
+DEFAULT_CATEGORY = "Meetups"
+# Zoom-backed, so the meeting the organiser asked for is the one the event gets.
+ZOOM_CATEGORY = "Zoom Meeting"
+
+
+def create_event(new: NewEvent) -> CreatedEvent:
+	"""Create an event for a team from the dashboard's create form."""
+	if not has_team_access(new.team, "create", frappe.session.user):
+		CannotCreateEvents.throw()
+
+	# Checked before the insert: a half-made event the organiser has to clean up is worse
+	# than a refusal.
+	if new.zoom_meeting and not is_app_installed("zoom_integration"):
+		ZoomNotAvailable.throw()
+
+	event = frappe.get_doc(
+		{
+			"doctype": "Buzz Event",
+			"team": new.team,
+			"title": new.title,
+			"start_date": new.start_date,
+			"end_date": new.end_date,
+			"start_time": new.start_time,
+			"end_time": new.end_time,
+			"about": new.about,
+			"banner_image": new.banner_image,
+			"time_zone": new.time_zone,
+			"venue": new.venue,
+			"medium": "Online" if new.zoom_meeting else "In Person",
+			"category": ZOOM_CATEGORY if new.zoom_meeting else DEFAULT_CATEGORY,
+			"host": host_for(new.team),
+		}
+	).insert()
+
+	if new.zoom_meeting:
+		book_zoom_meeting(event)
+
+	return CreatedEvent(name=str(event.name), title=event.title)
+
+
+def book_zoom_meeting(event) -> None:
+	"""Book the Zoom meeting the organiser asked for, and keep the event either way.
+
+	`create_meeting_on_zoom` calls Zoom during the request and writes the meeting back
+	onto the event. Letting it raise would roll the insert back with it, so a Zoom outage
+	would cost the organiser the whole event rather than just the meeting; they can add
+	one from the event afterwards.
+	"""
+	try:
+		event.create_meeting_on_zoom()
+	except Exception:
+		frappe.log_error(title="Zoom meeting not created", reference_doctype="Buzz Event")
+		frappe.msgprint(
+			_("The event was created, but its Zoom meeting could not be. Add one from the event."),
+			title=_("Zoom Meeting Not Created"),
+			indicator="orange",
+		)
+
+
+def host_for(team: str) -> str:
+	"""The team's own Event Host, made on first use.
+
+	Event Host is required on every event but absent from the create form, and a new team
+	has none. Host names are docnames and therefore global, so an existing name is given a
+	suffix rather than joined.
+	"""
+	existing = frappe.db.get_value("Event Host", {"team": team}, "name")
+	if existing:
+		return existing
+
+	team_name = frappe.db.get_value("Buzz Team", team, "team_name") or team
+	host = frappe.get_doc({"doctype": "Event Host", "name": team_name, "team": team})
+	host.name = append_number_if_name_exists("Event Host", team_name)
+	# Event Host is readable by the team but writable by Event Manager only, and creating
+	# an event is what mints it — the team check above is the authorisation.
+	host.insert(ignore_permissions=True)
+	return host.name

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -2,9 +2,13 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, today
 
+from buzz.api.events import create_event as create_event_endpoint
 from buzz.api.events import get_my_events
+from buzz.api.events.exceptions import CannotCreateEvents, ZoomNotAvailable
+from buzz.api.events.schemas import NewEvent
 from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user, payload_for
 from buzz.test_permissions import add_member, create_ticket
+from buzz.utils import is_app_installed
 
 
 def create_event(title: str, team: str, **overrides) -> str:
@@ -174,3 +178,86 @@ class TestGetMyEvents(IntegrationTestCase):
 				"team_logo",
 			},
 		)
+
+
+class TestCreateEvent(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+		if not frappe.db.exists("Event Category", "Meetups"):
+			frappe.get_doc({"doctype": "Event Category", "name": "Meetups"}).insert(ignore_permissions=True)
+
+		cls.owner = create_user("create-event-owner@example.com", "Owner")
+		cls.viewer = create_user("create-event-viewer@example.com", "Viewer")
+		cls.team = create_owned_team("Create Event Team", cls.owner)
+		add_member(cls.team, cls.viewer, "Viewer")
+
+	def setUp(self):
+		frappe.set_user(self.owner)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def payload(self, **overrides) -> NewEvent:
+		return NewEvent(
+			**{
+				"team": self.team,
+				"title": "Frappeverse Mumbai",
+				"start_date": add_days(today(), 30),
+				"start_time": "09:00:00",
+				"end_time": "17:00:00",
+				**overrides,
+			}
+		)
+
+	def test_creates_an_event_the_team_owns(self):
+		created = create_event_endpoint(self.payload())
+
+		event = frappe.get_doc("Buzz Event", created.name)
+		self.assertEqual(created.title, "Frappeverse Mumbai")
+		self.assertEqual(event.team, self.team)
+		self.assertEqual(event.medium, "In Person")
+		self.assertEqual(event.category, "Meetups")
+
+	def test_mints_one_host_per_team_and_reuses_it(self):
+		first = frappe.get_doc("Buzz Event", create_event_endpoint(self.payload()).name)
+		second = frappe.get_doc("Buzz Event", create_event_endpoint(self.payload(title="Second")).name)
+
+		self.assertTrue(first.host)
+		self.assertEqual(first.host, second.host)
+		self.assertEqual(frappe.db.get_value("Event Host", first.host, "team"), self.team)
+
+	def test_carries_the_optional_fields_through(self):
+		created = create_event_endpoint(
+			self.payload(
+				end_date=add_days(today(), 31),
+				about="<p>Come along</p>",
+				time_zone="Asia/Kolkata",
+			)
+		)
+
+		event = frappe.get_doc("Buzz Event", created.name)
+		self.assertEqual(event.about, "<p>Come along</p>")
+		self.assertEqual(event.time_zone, "Asia/Kolkata")
+		# Derived on validate from the zone, so it proves the zone reached the document.
+		self.assertEqual(event.time_zone_label, "IST")
+
+	def test_a_viewer_cannot_create_events(self):
+		frappe.set_user(self.viewer)
+
+		with self.assertRaises(CannotCreateEvents):
+			create_event_endpoint(self.payload())
+
+	def test_a_non_member_cannot_create_events(self):
+		stranger = create_user("create-event-stranger@example.com", "Stranger")
+		frappe.set_user(stranger)
+
+		with self.assertRaises(CannotCreateEvents):
+			create_event_endpoint(self.payload())
+
+	def test_zoom_is_refused_when_the_app_is_missing(self):
+		if is_app_installed("zoom_integration"):
+			self.skipTest("zoom_integration is installed on this site")
+
+		with self.assertRaises(ZoomNotAvailable):
+			create_event_endpoint(self.payload(zoom_meeting=True))

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -255,6 +255,27 @@ class TestCreateEvent(IntegrationTestCase):
 		with self.assertRaises(CannotCreateEvents):
 			create_event_endpoint(self.payload())
 
+	def test_a_venue_from_another_team_is_refused(self):
+		"""The reported vector: a manager naming a venue that belongs to someone else.
+
+		Event Venue is autonamed by prompt, so another team's venue name is guessable,
+		and the booking confirmation reads the linked venue's address without a
+		permission check.
+		"""
+		stranger = create_user("create-event-venue-stranger@example.com", "Stranger")
+		their_team = create_owned_team("Create Event Other Team", stranger)
+		theirs = frappe.get_doc(
+			{
+				"doctype": "Event Venue",
+				"__newname": "Create Event Other Team Hall",
+				"address": "1 Test Street",
+				"team": their_team,
+			}
+		).insert(ignore_permissions=True)
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_event_endpoint(self.payload(venue=str(theirs.name)))
+
 	def test_zoom_is_refused_when_the_app_is_missing(self):
 		if is_app_installed("zoom_integration"):
 			self.skipTest("zoom_integration is installed on this site")

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -99,7 +99,23 @@ class BuzzEvent(Document):
 		self.validate_tax_settings()
 		self.validate_guest_verification_config()
 		self.validate_custom_forms()
+		self.validate_venue_team()
 		self.set_time_zone_label()
+
+	def validate_venue_team(self):
+		"""A venue may only be linked by the team that owns it.
+
+		Nothing downstream re-checks this: the booking confirmation and the calendar
+		invite both read the linked venue's address without a permission check, so a
+		cross-team link publishes the other team's address.
+		"""
+		if not self.venue:
+			return
+
+		venue_team = frappe.db.get_value("Event Venue", self.venue, "team")
+		# An unstamped venue predates the team backfill; role permissions still gate it.
+		if venue_team and venue_team != self.team:
+			frappe.throw(_("Venue {0} belongs to another team.").format(self.venue))
 
 	def set_time_zone_label(self):
 		# validate runs before the mandatory check, so dates may still be empty here

--- a/buzz/events/doctype/buzz_event/test_buzz_event.py
+++ b/buzz/events/doctype/buzz_event/test_buzz_event.py
@@ -9,6 +9,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from buzz.api.booking.services import are_registrations_closed
 from buzz.events.doctype.buzz_event.buzz_event import RESERVED_EVENT_ROUTES, create_from_template
+from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
 from buzz.events.doctype.buzz_team_settings.test_buzz_team_settings import (
 	create_webinar_template,
 	set_team_settings,
@@ -157,6 +158,73 @@ class TestBuzzEvent(FrappeTestCase):
 		event = self._make_event_with_route("my-conference-2026")
 		event.insert()
 		self.assertEqual(event.route, "my-conference-2026")
+
+	# ==================== Venue Team Tests ====================
+
+	def _make_team(self, team_name: str) -> str:
+		"""Per test, not per class: tearDown rolls back everything setUpClass inserts."""
+		owner = create_user("buzz-event-venue-owner@example.com", "Owner")
+		return create_owned_team(team_name, owner)
+
+	def _make_venue(self, name: str, team: str | None) -> str:
+		"""Event Venue is autonamed by prompt, so the docname is the venue's own name."""
+		venue = frappe.get_doc(
+			{
+				"doctype": "Event Venue",
+				"__newname": name,
+				"address": "1 Test Street",
+				"team": team,
+			}
+		).insert(ignore_permissions=True)
+		return str(venue.name)
+
+	def _make_event_with_venue(self, venue: str, team: str | None):
+		return frappe.get_doc(
+			{
+				"doctype": "Buzz Event",
+				"title": f"Venue Test Event {venue}",
+				"category": "Test Category",
+				"host": "Test Host",
+				"start_date": frappe.utils.today(),
+				"start_time": "09:00:00",
+				"end_time": "18:00:00",
+				"team": team,
+				"venue": venue,
+			}
+		)
+
+	def test_a_venue_from_another_team_is_rejected(self):
+		"""A venue carries its team's address, so linking one across teams leaks it.
+
+		Event Venue is autonamed by prompt, so the docname is the venue's own name and
+		therefore guessable; nothing else stops a manager naming another team's venue.
+		"""
+		team = self._make_team("Venue Test Team")
+		theirs = self._make_venue("Venue Test Other Team Hall", self._make_team("Venue Test Other Team"))
+		event = self._make_event_with_venue(theirs, team)
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			event.validate_venue_team()
+
+	def test_the_teams_own_venue_is_accepted(self):
+		team = self._make_team("Venue Test Team")
+		ours = self._make_venue("Venue Test Own Hall", team)
+		event = self._make_event_with_venue(ours, team)
+
+		event.validate_venue_team()
+
+	def test_a_venue_without_a_team_is_accepted(self):
+		"""An unstamped venue predates the team backfill; role permissions still gate it.
+
+		Same convention as `has_team_access`, which abstains on an unstamped row rather
+		than refusing one.
+		"""
+		team = self._make_team("Venue Test Team")
+		unstamped = self._make_venue("Venue Test Unstamped Hall", team)
+		frappe.db.set_value("Event Venue", unstamped, "team", None)
+		event = self._make_event_with_venue(unstamped, team)
+
+		event.validate_venue_team()
 
 	# ==================== Create from Template Tests ====================
 

--- a/buzz/install.py
+++ b/buzz/install.py
@@ -130,15 +130,15 @@ def setup_test_records():
 	create_talk_proposal_statuses()
 
 	# Administrator's only membership, so the team resolves for fixtures that omit one.
-	create_default_team_for("Administrator")
+	admin_team = create_default_team_for("Administrator").name
 
 	test_category = frappe.get_doc({"doctype": "Event Category", "name": "Test Category"}).insert(
 		ignore_if_duplicate=True
 	)
-	test_venue = frappe.get_doc({"doctype": "Event Venue", "name": "Test Venue", "address": "test"}).insert(
-		ignore_if_duplicate=True
-	)
-	test_host = frappe.get_doc({"doctype": "Event Host", "name": "Test Host"}).insert(
+	test_venue = frappe.get_doc(
+		{"doctype": "Event Venue", "name": "Test Venue", "address": "test", "team": admin_team}
+	).insert(ignore_if_duplicate=True)
+	test_host = frappe.get_doc({"doctype": "Event Host", "name": "Test Host", "team": admin_team}).insert(
 		ignore_if_duplicate=True
 	)
 
@@ -148,6 +148,7 @@ def setup_test_records():
 	frappe.get_doc(
 		{
 			"doctype": "Buzz Event",
+			"team": admin_team,
 			"category": test_category.name,
 			"venue": test_venue.name,
 			"host": test_host.name,

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     AddMembersDialog: typeof import('./src/components/dashboard/teams/AddMembersDialog.vue')['default']
     AddOnPreferenceDialog: typeof import('./src/components/AddOnPreferenceDialog.vue')['default']
+    AddVenueDialog: typeof import('./src/components/dashboard/events/AddVenueDialog.vue')['default']
     AttendeeFormControl: typeof import('./src/components/AttendeeFormControl.vue')['default']
     BackButton: typeof import('./src/components/common/BackButton.vue')['default']
     BaseCustomEventForm: typeof import('./src/components/BaseCustomEventForm.vue')['default']
@@ -29,6 +30,8 @@ declare module 'vue' {
     CustomFieldsSection: typeof import('./src/components/CustomFieldsSection.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
+    EventLocation: typeof import('./src/components/dashboard/events/EventLocation.vue')['default']
+    EventSchedule: typeof import('./src/components/dashboard/events/EventSchedule.vue')['default']
     EventSelector: typeof import('./src/components/EventSelector.vue')['default']
     FormFieldSections: typeof import('./src/components/FormFieldSections.vue')['default']
     LanguageSwitcher: typeof import('./src/components/LanguageSwitcher.vue')['default']

--- a/dashboard/src/components/dashboard/events/AddVenueDialog.vue
+++ b/dashboard/src/components/dashboard/events/AddVenueDialog.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { createVenue } from "@/data/venues";
+import type { FrappeError } from "@/types";
+import { Button, Dialog, FormControl, toast } from "frappe-ui";
+import { computed, ref, watch } from "vue";
+
+const props = defineProps<{ team: string }>();
+const isOpen = defineModel<boolean>({ required: true });
+// The name the picker was searching for when it gave up and offered to add one.
+const suggestedName = defineModel<string>("suggestedName", { default: "" });
+const emit = defineEmits<{ created: [venue: string] }>();
+
+const name = ref("");
+const address = ref("");
+const showErrors = ref(false);
+
+// createResource types its error as {}, so the message needs narrowing.
+const errorMessage = computed(() => (createVenue.error as FrappeError | null)?.message);
+
+watch(isOpen, (open) => {
+	if (!open) return;
+	name.value = suggestedName.value;
+	address.value = "";
+	showErrors.value = false;
+	createVenue.error = null;
+});
+
+const invalid = computed(() => !name.value.trim() || !address.value.trim());
+
+async function submit() {
+	showErrors.value = true;
+	if (invalid.value) return;
+
+	await createVenue.submit({
+		team: props.team,
+		name: name.value.trim(),
+		address: address.value.trim(),
+	});
+	if (createVenue.error) return;
+
+	toast.success(`${name.value.trim()} added`);
+	emit("created", name.value.trim());
+	isOpen.value = false;
+}
+</script>
+
+<template>
+	<Dialog v-model="isOpen" title="Add venue">
+		<form novalidate class="space-y-4" @submit.prevent="submit">
+			<FormControl
+				v-model="name"
+				label="Name"
+				placeholder="Nehru Centre Auditorium"
+				autocomplete="off"
+			/>
+
+			<FormControl
+				v-model="address"
+				type="textarea"
+				label="Address or map link"
+				placeholder="Paste a Google Maps link, or type the address"
+			/>
+
+			<p v-if="showErrors && invalid" class="text-sm text-ink-red-4">
+				A venue needs a name and an address.
+			</p>
+			<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
+
+			<!-- type=button: inside a form, a submit button would run `submit` twice —
+				 once on click, once on the form's own submit — and the second insert
+				 collides with the venue the first one just created. -->
+			<Button
+				type="button"
+				variant="solid"
+				label="Add venue"
+				class="w-full"
+				:loading="createVenue.loading"
+				@click="submit"
+			/>
+		</form>
+	</Dialog>
+</template>

--- a/dashboard/src/components/dashboard/events/EventLocation.vue
+++ b/dashboard/src/components/dashboard/events/EventLocation.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import AddVenueDialog from "@/components/dashboard/events/AddVenueDialog.vue";
+import { venues } from "@/data/venues";
+import { Combobox } from "frappe-ui";
+import { computed, ref, watch } from "vue";
+
+// A reserved value rather than a venue name. Event Venue is autonamed by prompt, so a
+// venue really could be called "Zoom" — the sentinel keeps the two apart.
+const ZOOM = "__zoom__";
+
+const props = defineProps<{ team: string }>();
+
+const venue = defineModel<string>("venue", { default: "" });
+// Zoom cannot be booked until the event exists, so this is the intent to act on at save.
+const zoomMeeting = defineModel<boolean>("zoomMeeting", { default: false });
+
+const isAdding = ref(false);
+const suggestedName = ref("");
+
+watch(
+	() => props.team,
+	(team) => team && venues.fetch({ team }),
+	{ immediate: true }
+);
+
+const selected = computed({
+	get: () => (zoomMeeting.value ? ZOOM : venue.value),
+	set: (value: string | null) => {
+		// The server derives `medium` from this, so it is not tracked here as well.
+		zoomMeeting.value = value === ZOOM;
+		venue.value = value === ZOOM ? "" : value ?? "";
+	},
+});
+
+const options = computed(() => [
+	{
+		group: "Venues",
+		options: (venues.data ?? []).map((row) => ({
+			label: row.name,
+			description: row.address,
+			value: row.name,
+		})),
+	},
+	{
+		group: "Virtual",
+		options: [
+			{ label: "Create Zoom meeting", value: ZOOM, icon: "lucide-video" },
+			{
+				type: "custom" as const,
+				key: "add-venue",
+				label: "Add venue",
+				icon: "lucide-plus",
+				// Only worth offering once they have typed a name nothing answers to.
+				condition: ({ query }: { query: string }) =>
+					Boolean(query.trim()) &&
+					!(venues.data ?? []).some(
+						(row) => row.name.toLowerCase() === query.trim().toLowerCase()
+					),
+				onClick: ({ query }: { query: string }) => {
+					suggestedName.value = query.trim();
+					isAdding.value = true;
+				},
+			},
+		],
+	},
+]);
+
+async function onVenueCreated(name: string) {
+	await venues.fetch({ team: props.team });
+	selected.value = name;
+}
+</script>
+
+<template>
+	<Combobox
+		v-model="selected"
+		:options="options"
+		placeholder="Search venues, or add one"
+		class="w-full mt-2"
+	/>
+
+	<AddVenueDialog
+		v-model="isAdding"
+		v-model:suggested-name="suggestedName"
+		:team="team"
+		@created="onVenueCreated"
+	/>
+</template>

--- a/dashboard/src/components/dashboard/events/EventLocation.vue
+++ b/dashboard/src/components/dashboard/events/EventLocation.vue
@@ -8,7 +8,7 @@ import { computed, ref, watch } from "vue";
 // venue really could be called "Zoom" — the sentinel keeps the two apart.
 const ZOOM = "__zoom__";
 
-const props = defineProps<{ team: string }>();
+const props = defineProps<{ team: string; disabled?: boolean }>();
 
 const venue = defineModel<string>("venue", { default: "" });
 // Zoom cannot be booked until the event exists, so this is the intent to act on at save.
@@ -77,6 +77,7 @@ async function onVenueCreated(name: string) {
 		:options="options"
 		placeholder="Search venues, or add one"
 		class="w-full mt-2"
+		:disabled="disabled"
 	/>
 
 	<AddVenueDialog

--- a/dashboard/src/components/dashboard/events/EventSchedule.vue
+++ b/dashboard/src/components/dashboard/events/EventSchedule.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { alignedEndDate } from "@/utils/eventDates";
+import {
+	allTimeZones,
+	zoneCity,
+	zoneCountry,
+	zoneOffsetLabel,
+	zoneSearchText,
+} from "@/utils/timeZones";
+import { Combobox, DatePicker, TimePicker, dayjsLocal } from "frappe-ui";
+import { computed, ref, watch } from "vue";
+
+const startDate = defineModel<string>("startDate", { default: "" });
+const startTime = defineModel<string>("startTime", { default: "" });
+const endDate = defineModel<string>("endDate", { default: "" });
+const endTime = defineModel<string>("endTime", { default: "" });
+const timeZone = defineModel<string>("timeZone", { default: "" });
+
+// An event cannot start in the past, and cannot end before it starts.
+const today = dayjsLocal().format("YYYY-MM-DD");
+const earliestEnd = computed(() => startDate.value || today);
+
+watch(startDate, (start) => {
+	endDate.value = alignedEndDate(start, endDate.value);
+});
+
+// The row slot is typed for custom rows too, which carry no value; ours never are.
+const zoneOf = (item: { type?: string; value?: string }) => item.value ?? "";
+
+// Built on first open, not on mount. `:options` is a prop, so an eager computed would
+// run the 676-code sweep behind `zoneCountry` plus 400-odd Intl formatters while the
+// create page is still rendering. The trigger reads `timeZone` directly, so an empty
+// list costs it nothing until then.
+const hasOpened = ref(false);
+
+const zoneOptions = computed(() =>
+	hasOpened.value
+		? allTimeZones().map((zone) => ({
+				label: zoneSearchText(zone),
+				value: zone,
+		  }))
+		: []
+);
+</script>
+
+<template>
+	<div class="space-y-4">
+		<div class="space-y-1">
+			<label class="text-base text-ink-gray-7">Start</label>
+			<div class="grid grid-cols-2 gap-2">
+				<DatePicker
+					v-model="startDate"
+					format="ddd D MMM"
+					placeholder="Date"
+					:min="today"
+				/>
+				<TimePicker v-model="startTime" placeholder="Time" />
+			</div>
+		</div>
+
+		<div class="space-y-1">
+			<label class="text-base text-ink-gray-7">End</label>
+			<div class="grid grid-cols-2 gap-2">
+				<DatePicker
+					v-model="endDate"
+					format="ddd D MMM"
+					placeholder="Date"
+					:min="earliestEnd"
+				/>
+				<TimePicker v-model="endTime" placeholder="Time" />
+			</div>
+		</div>
+
+		<div class="space-y-1">
+			<label class="text-base text-ink-gray-7">Timezone</label>
+
+			<Combobox
+				v-model="timeZone"
+				:options="zoneOptions"
+				placeholder="Search by city, country or zone"
+				@update:open="(open: boolean) => (hasOpened = hasOpened || open)"
+			>
+				<!-- Mounted inside the popover trigger, so the press opens it on its own. -->
+				<template #trigger>
+					<Button class="w-full mt-2">
+						<div class="flex gap-2">
+							<span
+								class="lucide-globe size-4 shrink-0 text-ink-gray-5"
+								aria-hidden="true"
+							/>
+							<span class="shrink-0 text-base text-ink-gray-8">
+								{{ timeZone ? zoneOffsetLabel(timeZone) : "Time zone" }}
+							</span>
+							<span v-if="timeZone" class="truncate text-base text-ink-gray-5">
+								{{ timeZone }}
+							</span>
+						</div>
+					</Button>
+				</template>
+
+				<!-- The option label is search text, so the row is drawn from the zone itself. -->
+				<template #item="{ item }">
+					<div class="flex w-full items-center gap-2 overflow-hidden p-2">
+						<span class="truncate text-ink-gray-8">{{ zoneCity(zoneOf(item)) }}</span>
+						<span class="truncate text-ink-gray-5">{{
+							zoneCountry(zoneOf(item))
+						}}</span>
+						<span class="ml-auto shrink-0 text-sm text-ink-gray-5">
+							{{ zoneOffsetLabel(zoneOf(item)) }}
+						</span>
+					</div>
+				</template>
+			</Combobox>
+		</div>
+	</div>
+</template>

--- a/dashboard/src/components/dashboard/events/EventSchedule.vue
+++ b/dashboard/src/components/dashboard/events/EventSchedule.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { alignedEndDate } from "@/utils/eventDates";
+import { alignedEndDate, isEndBeforeStart } from "@/utils/eventDates";
 import {
 	allTimeZones,
 	zoneCity,
@@ -7,7 +7,7 @@ import {
 	zoneOffsetLabel,
 	zoneSearchText,
 } from "@/utils/timeZones";
-import { Combobox, DatePicker, TimePicker, dayjsLocal } from "frappe-ui";
+import { Combobox, DatePicker, ErrorMessage, TimePicker, dayjsLocal } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
 defineProps<{ disabled?: boolean }>();
@@ -25,6 +25,20 @@ const earliestEnd = computed(() => startDate.value || today);
 watch(startDate, (start) => {
 	endDate.value = alignedEndDate(start, endDate.value);
 });
+
+// Only a single-day event is bounded: a span that runs into another day may well end
+// earlier in the day than it began. The picker rejects a typed value below `min` too,
+// not just the ones it lists.
+const earliestEndTime = computed(() =>
+	!endDate.value || endDate.value === startDate.value ? startTime.value : undefined
+);
+
+// `min` is inclusive, so it still lets the end land exactly on the start, which the
+// server refuses. It also cannot undo a time that was already valid as a multi-day
+// event before the end date was pulled back to the start.
+const endsBeforeItStarts = computed(() =>
+	isEndBeforeStart(startDate.value, endDate.value, startTime.value, endTime.value)
+);
 
 // The row slot is typed for custom rows too, which carry no value; ours never are.
 const zoneOf = (item: { type?: string; value?: string }) => item.value ?? "";
@@ -71,8 +85,15 @@ const zoneOptions = computed(() =>
 					:min="earliestEnd"
 					:disabled="disabled"
 				/>
-				<TimePicker v-model="endTime" placeholder="Time" :disabled="disabled" />
+				<TimePicker
+					v-model="endTime"
+					placeholder="Time"
+					:min="earliestEndTime"
+					:disabled="disabled"
+				/>
 			</div>
+
+			<ErrorMessage v-if="endsBeforeItStarts" message="End time must be after start time" />
 		</div>
 
 		<div class="space-y-1">

--- a/dashboard/src/components/dashboard/events/EventSchedule.vue
+++ b/dashboard/src/components/dashboard/events/EventSchedule.vue
@@ -10,6 +10,8 @@ import {
 import { Combobox, DatePicker, TimePicker, dayjsLocal } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
+defineProps<{ disabled?: boolean }>();
+
 const startDate = defineModel<string>("startDate", { default: "" });
 const startTime = defineModel<string>("startTime", { default: "" });
 const endDate = defineModel<string>("endDate", { default: "" });
@@ -53,8 +55,9 @@ const zoneOptions = computed(() =>
 					format="ddd D MMM"
 					placeholder="Date"
 					:min="today"
+					:disabled="disabled"
 				/>
-				<TimePicker v-model="startTime" placeholder="Time" />
+				<TimePicker v-model="startTime" placeholder="Time" :disabled="disabled" />
 			</div>
 		</div>
 
@@ -66,8 +69,9 @@ const zoneOptions = computed(() =>
 					format="ddd D MMM"
 					placeholder="Date"
 					:min="earliestEnd"
+					:disabled="disabled"
 				/>
-				<TimePicker v-model="endTime" placeholder="Time" />
+				<TimePicker v-model="endTime" placeholder="Time" :disabled="disabled" />
 			</div>
 		</div>
 
@@ -78,11 +82,12 @@ const zoneOptions = computed(() =>
 				v-model="timeZone"
 				:options="zoneOptions"
 				placeholder="Search by city, country or zone"
+				:disabled="disabled"
 				@update:open="(open: boolean) => (hasOpened = hasOpened || open)"
 			>
 				<!-- Mounted inside the popover trigger, so the press opens it on its own. -->
 				<template #trigger>
-					<Button class="w-full mt-2">
+					<Button class="w-full mt-2" :disabled="disabled">
 						<div class="flex gap-2">
 							<span
 								class="lucide-globe size-4 shrink-0 text-ink-gray-5"

--- a/dashboard/src/components/dashboard/teams/TeamPageHeader.vue
+++ b/dashboard/src/components/dashboard/teams/TeamPageHeader.vue
@@ -15,6 +15,12 @@ const items = computed(() => {
 <template>
 	<PageHeader class="border-none pt-2 bg-surface-elevation-1">
 		<Breadcrumbs :items="items" />
-		<Button variant="solid" icon-left="plus" label="Create Event" />
+		<Button
+			variant="solid"
+			icon-left="plus"
+			label="Create Event"
+			:disabled="!currentTeam"
+			:route="{ name: 'create-event' }"
+		/>
 	</PageHeader>
 </template>

--- a/dashboard/src/composables/useTeamAccess.ts
+++ b/dashboard/src/composables/useTeamAccess.ts
@@ -1,0 +1,21 @@
+import { isTeamMember } from "@/data/teams"
+import { type Ref, ref } from "vue"
+
+export type TeamAccess = "pending" | "granted" | "denied"
+
+/**
+ * Whether the session user belongs to any team.
+ *
+ * Tri-state so a caller can hold its 404 back until the answer is in, rather than
+ * flashing one while the teams load. Shared because pages outside the manager shell
+ * need the same guard the shell applies.
+ */
+export function useTeamAccess(): Ref<TeamAccess> {
+	const access = ref<TeamAccess>("pending")
+
+	isTeamMember().then((member) => {
+		access.value = member ? "granted" : "denied"
+	})
+
+	return access
+}

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -1,5 +1,5 @@
 import type { MyEvents } from "@/types"
-import { useCall } from "frappe-ui"
+import { createResource, useCall } from "frappe-ui"
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
 // Uncached: cacheKey would persist this user's feed to IndexedDB past a logout.
@@ -8,3 +8,7 @@ export function useMyEvents() {
 		url: "/api/v2/method/buzz.api.events.get_my_events",
 	})
 }
+
+export const createEvent = createResource<{ name: string; title: string }>({
+	url: "buzz.api.events.create_event",
+})

--- a/dashboard/src/data/venues.ts
+++ b/dashboard/src/data/venues.ts
@@ -1,0 +1,33 @@
+import { createResource } from "frappe-ui"
+
+export interface Venue {
+	name: string
+	address: string
+}
+
+// Plain doctype reads and writes, so they go through frappe.client rather than a buzz
+// endpoint. Event Venue carries the team query condition and permission hooks, so the
+// team filter below narrows what the picker asks for — it is not what enforces scope.
+export const venues = createResource<Venue[]>({
+	url: "frappe.client.get_list",
+	makeParams: (params: { team: string }) => ({
+		doctype: "Event Venue",
+		filters: { team: params.team },
+		fields: ["name", "address"],
+		order_by: "modified desc",
+		limit_page_length: 0,
+	}),
+})
+
+export const createVenue = createResource({
+	url: "frappe.client.insert",
+	makeParams: (params: { team: string; name: string; address: string }) => ({
+		doc: {
+			doctype: "Event Venue",
+			// Event Venue is autonamed by prompt, so the name is the venue's own.
+			__newname: params.name,
+			address: params.address,
+			team: params.team,
+		},
+	}),
+})

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -1,19 +1,16 @@
 <script setup lang="ts">
 import TeamSwitcher from "@/components/TeamSwitcher.vue";
 import UserMenu from "@/components/UserMenu.vue";
-import { isTeamMember } from "@/data/teams";
+import { useTeamAccess } from "@/composables/useTeamAccess";
 import NotFound from "@/pages/NotFound.vue";
 import { DesktopShell, PageHeaderTarget, Sidebar, SidebarItem, SidebarLabel } from "frappe-ui";
 import { ref } from "vue";
 import { useRoute } from "vue-router";
 
-const isMember = ref<boolean | null>(null);
-isTeamMember().then((member) => {
-	isMember.value = member;
-});
-
 const collapsed = ref(false);
 const route = useRoute();
+
+const access = useTeamAccess();
 
 // SidebarItem infers this from `to` on paper, but its `active` prop is declared
 // type Boolean, so Vue casts the absent prop to false and the inference never runs.
@@ -36,10 +33,10 @@ const teamItems = [
 </script>
 
 <template>
-	<NotFound v-if="isMember === false" />
+	<NotFound v-if="access === 'denied'" />
 
 	<!-- scroll=false: the rounded panel below owns its own scroll. -->
-	<DesktopShell v-else-if="isMember" :scroll="false">
+	<DesktopShell v-else-if="access === 'granted'" :scroll="false">
 		<template #sidebar>
 			<Sidebar v-model:collapsed="collapsed">
 				<div class="flex h-12 shrink-0 items-center px-1">

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -1,0 +1,271 @@
+<script setup lang="ts">
+import EventLocation from "@/components/dashboard/events/EventLocation.vue";
+import EventSchedule from "@/components/dashboard/events/EventSchedule.vue";
+import { useTeamAccess } from "@/composables/useTeamAccess";
+import { createEvent } from "@/data/events";
+import { currentTeam } from "@/data/teams";
+import NotFound from "@/pages/NotFound.vue";
+import { bannerPattern } from "@/utils/eventBanner";
+import { currentTimeZone } from "@/utils/timeZones";
+import { refDebounced } from "@vueuse/core";
+import type { FrappeError } from "@/types";
+import { Button, ErrorMessage, FileUploader, toast, useTheme } from "frappe-ui";
+import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor";
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+
+const access = useTeamAccess();
+
+// The picker is filtered to these, and the file that comes back is checked against the
+// same list: `accept` is a hint the OS may ignore, and a drag-drop never consults it.
+// Raster only — an SVG banner would be same-origin markup, which a banner has no need
+// to be. Neither check is enforcement; the upload endpoint takes what it is given.
+const BANNER_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+
+function validateBannerImage(file: File): string | void {
+	if (!BANNER_IMAGE_TYPES.includes(file.type)) {
+		return "Choose a PNG, JPEG, WebP or GIF image";
+	}
+}
+
+const { currentTheme, setTheme, getSystemTheme } = useTheme();
+// `system` resolves against the OS, so the icon shows what is on screen rather than
+// what was picked — and the toggle sets the opposite outright instead of stepping
+// through `system`, which would look like a no-op when the OS is already dark.
+const isDark = computed(
+	() => (currentTheme.value === "system" ? getSystemTheme() : currentTheme.value) === "dark"
+);
+
+const title = ref("");
+const about = ref("");
+const bannerImage = ref("");
+const startDate = ref("");
+const startTime = ref("");
+const endDate = ref("");
+const endTime = ref("");
+// The organiser's own zone is the safe opening guess; they change it if the event is
+// somewhere else.
+const timeZone = ref(currentTimeZone());
+
+const venue = ref("");
+// The Zoom meeting can only be booked once the event exists, so save has to act on this.
+const zoomMeeting = ref(false);
+
+// The pattern is seeded by the title, so the draft banner settles into the one the
+// event keeps. Seeded off a debounced copy: a gradient cannot be transitioned, so
+// re-seeding per keystroke would redraw the banner once per character while the
+// organiser types. An untitled draft seeds on "Untitled" rather than the empty string,
+// which would draw every new event the same.
+const settledTitle = refDebounced(title, 250);
+
+const banner = computed(() => ({
+	backgroundImage: bannerPattern(settledTitle.value.trim() || "Untitled"),
+}));
+
+// True from the first keystroke until the debounce fires — and the pattern swaps on the
+// same tick it turns false. So the blur is already up when the swap lands, and only
+// falls away afterwards, which is what hides the change.
+const isSettling = computed(() => title.value.trim() !== settledTitle.value.trim());
+
+// About is optional: an event needs a name, when it runs, and where.
+const canSave = computed(() =>
+	Boolean(
+		title.value.trim() &&
+			startDate.value &&
+			startTime.value &&
+			endTime.value &&
+			(venue.value || zoomMeeting.value)
+	)
+);
+
+// createResource types its error as {}, so the message needs narrowing.
+const errorMessage = computed(() => (createEvent.error as FrappeError | null)?.message);
+
+async function save() {
+	if (!canSave.value) return;
+
+	await createEvent.submit({
+		event: {
+			team: currentTeam.value?.name,
+			title: title.value.trim(),
+			start_date: startDate.value,
+			start_time: startTime.value,
+			end_date: endDate.value || null,
+			end_time: endTime.value,
+			about: about.value || null,
+			banner_image: bannerImage.value || null,
+			time_zone: timeZone.value || null,
+			venue: venue.value || null,
+			zoom_meeting: zoomMeeting.value,
+		},
+	});
+	if (createEvent.error) return;
+
+	toast.success(`${createEvent.data?.title} created`);
+	router.push({ name: "team-events" });
+}
+
+// Reset per image, so a second upload fades in rather than snapping.
+const bannerLoaded = ref(false);
+watch(bannerImage, () => {
+	bannerLoaded.value = false;
+});
+</script>
+
+<template>
+	<NotFound v-if="access === 'denied'" />
+
+	<!-- Nothing renders until the team resolves, so the page would otherwise pop in. -->
+	<Transition
+		v-else
+		enter-active-class="transition-opacity duration-150 ease-out motion-reduce:transition-none"
+		enter-from-class="opacity-0"
+	>
+		<div v-if="access === 'granted'" class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
+			<header class="space-y-4">
+				<div class="flex items-center justify-between">
+					<Button
+						variant="ghost"
+						icon-left="lucide-arrow-left"
+						label="Back"
+						class="-ml-2"
+						:route="{ name: 'team-events' }"
+					/>
+
+					<Button
+						variant="ghost"
+						:icon="isDark ? 'lucide-sun' : 'lucide-moon'"
+						:label="isDark ? 'Switch to light theme' : 'Switch to dark theme'"
+						@click="setTheme(isDark ? 'light' : 'dark')"
+					/>
+				</div>
+
+				<div class="flex items-center justify-between gap-4">
+					<h1 class="text-2xl font-semibold text-ink-gray-9">Create event</h1>
+					<Button
+						variant="solid"
+						label="Create event"
+						:disabled="!canSave"
+						:loading="createEvent.loading"
+						@click="save"
+					/>
+				</div>
+
+				<ErrorMessage v-if="errorMessage" :message="errorMessage" />
+			</header>
+
+			<FileUploader
+				:file-types="BANNER_IMAGE_TYPES"
+				:validate-file="validateBannerImage"
+				@success="(file: { file_url: string }) => (bannerImage = file.file_url)"
+			>
+				<template #default="{ openFileSelector, error: uploadError }">
+					<!-- The whole banner is the hit area; the button inside stays the -->
+					<!-- keyboard-reachable control, so its press must not fire twice. -->
+					<div
+						class="relative aspect-[3/1] cursor-pointer overflow-hidden rounded-xl border border-outline-gray-2"
+						@click="openFileSelector"
+					>
+						<!-- The pattern gets a layer of its own so the blur below never
+							 reaches the image or the button. Overscaled because blur samples
+							 past the edges, which would otherwise go milky against the border.
+							 A gradient cannot be interpolated, so blurring over the swap is
+							 what hides it. -->
+						<div
+							class="absolute inset-0 scale-105 transition-[filter] duration-200 ease-out"
+							:class="
+								isSettling && !bannerImage
+									? 'blur-[10px] motion-reduce:blur-none'
+									: 'blur-0'
+							"
+							:style="banner"
+							aria-hidden="true"
+						/>
+
+						<!-- Fades onto the pattern rather than replacing it outright. -->
+						<!-- Absolute, like the pattern behind it: a static sibling would paint
+							 under the positioned layer instead of over it. -->
+						<img
+							v-if="bannerImage"
+							class="absolute inset-0 h-full w-full object-cover object-center transition-opacity duration-200 ease-out"
+							:class="bannerLoaded ? 'opacity-100' : 'opacity-0'"
+							:src="bannerImage"
+							alt=""
+							@load="bannerLoaded = true"
+						/>
+
+						<div class="absolute inset-0 grid place-items-center">
+							<Button
+								variant="subtle"
+								icon-left="lucide-image-up"
+								:label="bannerImage ? 'Change banner' : 'Add a banner'"
+								@click.stop="openFileSelector"
+							/>
+						</div>
+					</div>
+
+					<!-- The slot types its error as {}, so the message needs narrowing. -->
+					<ErrorMessage v-if="uploadError" class="mt-2" :message="String(uploadError)" />
+				</template>
+			</FileUploader>
+
+			<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
+			<input
+				v-model="title"
+				aria-label="Event title"
+				placeholder="Name your event"
+				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none"
+			/>
+
+			<div class="grid gap-8 md:grid-cols-5">
+				<section class="space-y-3 md:col-span-3">
+					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
+						About
+					</h2>
+					<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
+					 itself: the height and scrolling land on the editable area rather than on a
+					 wrapper, and the whole box takes a click. -->
+					<div class="rounded-lg border border-outline-gray-2 p-3">
+						<Editor
+							v-model="about"
+							:extensions="[RichTextKit]"
+							placeholder="What is this event about?"
+						>
+							<EditorContent
+								class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
+							/>
+						</Editor>
+					</div>
+				</section>
+
+				<div class="space-y-8 md:col-span-2">
+					<section class="space-y-3">
+						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
+							When
+						</h2>
+						<EventSchedule
+							v-model:start-date="startDate"
+							v-model:start-time="startTime"
+							v-model:end-date="endDate"
+							v-model:end-time="endTime"
+							v-model:time-zone="timeZone"
+						/>
+					</section>
+
+					<section class="space-y-8">
+						<label class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
+							Where
+						</label>
+						<EventLocation
+							v-model:venue="venue"
+							v-model:zoom-meeting="zoomMeeting"
+							:team="currentTeam?.name ?? ''"
+						/>
+					</section>
+				</div>
+			</div>
+		</div>
+	</Transition>
+</template>

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -6,6 +6,7 @@ import { createEvent } from "@/data/events";
 import { currentTeam } from "@/data/teams";
 import NotFound from "@/pages/NotFound.vue";
 import { bannerPattern } from "@/utils/eventBanner";
+import { isEndBeforeStart } from "@/utils/eventDates";
 import { canCreateEvents } from "@/utils/teamRoles";
 import { currentTimeZone } from "@/utils/timeZones";
 import { refDebounced } from "@vueuse/core";
@@ -82,12 +83,15 @@ const canSave = computed(() =>
 			startDate.value &&
 			startTime.value &&
 			endTime.value &&
+			!isEndBeforeStart(startDate.value, endDate.value, startTime.value, endTime.value) &&
 			(venue.value || zoomMeeting.value)
 	)
 );
 
 // createResource types its error as {}, so the message needs narrowing.
-const errorMessage = computed(() => (createEvent.error as FrappeError | null)?.message);
+const errorMessage = computed(() =>
+	(createEvent.error as FrappeError | null)?.messages?.join("\n")
+);
 
 async function save() {
 	if (!canSave.value) return;

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -6,10 +6,11 @@ import { createEvent } from "@/data/events";
 import { currentTeam } from "@/data/teams";
 import NotFound from "@/pages/NotFound.vue";
 import { bannerPattern } from "@/utils/eventBanner";
+import { canCreateEvents } from "@/utils/teamRoles";
 import { currentTimeZone } from "@/utils/timeZones";
 import { refDebounced } from "@vueuse/core";
 import type { FrappeError } from "@/types";
-import { Button, ErrorMessage, FileUploader, toast, useTheme } from "frappe-ui";
+import { Alert, Button, ErrorMessage, FileUploader, toast, useTheme } from "frappe-ui";
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
@@ -17,6 +18,10 @@ import { useRouter } from "vue-router";
 const router = useRouter();
 
 const access = useTeamAccess();
+
+// The server refuses anything below Manager, so the form is shown read-only rather than
+// letting someone fill it in and lose the work to a 403 on save.
+const canCreate = computed(() => canCreateEvents(currentTeam.value?.team_role));
 
 // The picker is filtered to these, and the file that comes back is checked against the
 // same list: `accept` is a hint the OS may ignore, and a drag-drop never consults it.
@@ -72,7 +77,8 @@ const isSettling = computed(() => title.value.trim() !== settledTitle.value.trim
 // About is optional: an event needs a name, when it runs, and where.
 const canSave = computed(() =>
 	Boolean(
-		title.value.trim() &&
+		canCreate.value &&
+			title.value.trim() &&
 			startDate.value &&
 			startTime.value &&
 			endTime.value &&
@@ -156,6 +162,14 @@ watch(bannerImage, () => {
 				<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 			</header>
 
+			<Alert
+				v-if="!canCreate"
+				theme="yellow"
+				title="You cannot create events"
+				description="Ask an admin to make you a Manager to create events."
+				:dismissible="false"
+			/>
+
 			<FileUploader
 				:file-types="BANNER_IMAGE_TYPES"
 				:validate-file="validateBannerImage"
@@ -165,8 +179,9 @@ watch(bannerImage, () => {
 					<!-- The whole banner is the hit area; the button inside stays the -->
 					<!-- keyboard-reachable control, so its press must not fire twice. -->
 					<div
-						class="relative aspect-[3/1] cursor-pointer overflow-hidden rounded-xl border border-outline-gray-2"
-						@click="openFileSelector"
+						class="relative aspect-[3/1] overflow-hidden rounded-xl border border-outline-gray-2"
+						:class="canCreate ? 'cursor-pointer' : 'cursor-default'"
+						@click="canCreate && openFileSelector()"
 					>
 						<!-- The pattern gets a layer of its own so the blur below never
 							 reaches the image or the button. Overscaled because blur samples
@@ -201,6 +216,7 @@ watch(bannerImage, () => {
 								variant="subtle"
 								icon-left="lucide-image-up"
 								:label="bannerImage ? 'Change banner' : 'Add a banner'"
+								:disabled="!canCreate"
 								@click.stop="openFileSelector"
 							/>
 						</div>
@@ -216,7 +232,8 @@ watch(bannerImage, () => {
 				v-model="title"
 				aria-label="Event title"
 				placeholder="Name your event"
-				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none"
+				:disabled="!canCreate"
+				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5"
 			/>
 
 			<div class="grid gap-8 md:grid-cols-5">
@@ -232,6 +249,7 @@ watch(bannerImage, () => {
 							v-model="about"
 							:extensions="[RichTextKit]"
 							placeholder="What is this event about?"
+							:editable="canCreate"
 						>
 							<EditorContent
 								class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
@@ -246,6 +264,7 @@ watch(bannerImage, () => {
 							When
 						</h2>
 						<EventSchedule
+							:disabled="!canCreate"
 							v-model:start-date="startDate"
 							v-model:start-time="startTime"
 							v-model:end-date="endDate"
@@ -262,6 +281,7 @@ watch(bannerImage, () => {
 							v-model:venue="venue"
 							v-model:zoom-meeting="zoomMeeting"
 							:team="currentTeam?.name ?? ''"
+							:disabled="!canCreate"
 						/>
 					</section>
 				</div>

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -12,6 +12,14 @@ const routes: RouteRecordRaw[] = [
 			name: (await isTeamMember()) ? "manage" : "bookings-tab",
 		}),
 	},
+	// Declared before /manage: this one opts out of the manager shell, so it cannot be a
+	// child of the route that renders it.
+	{
+		path: "/manage/team/events/new",
+		name: "create-event",
+		meta: { fullBleed: true },
+		component: () => import("@/pages/manage/events/CreateEvent.vue"),
+	},
 	{
 		path: "/manage",
 		meta: { fullBleed: true },

--- a/dashboard/src/utils/eventBanner.test.ts
+++ b/dashboard/src/utils/eventBanner.test.ts
@@ -25,7 +25,7 @@ test("ring origins stay off centre", () => {
 
 test("ring spacing stays inside the readable range", () => {
 	for (const name of NAMES) {
-		const gap = Number(bannerPattern(name).match(/1px (\d+\.\d)px/)?.[1])
-		assert.ok(gap >= 9 && gap <= 12, `${name} drew a ${gap}px gap`)
+		const gap = Number(bannerPattern(name).match(/transparent \d+px (\d+\.\d)px/)?.[1])
+		assert.ok(gap >= 18 && gap <= 26, `${name} drew a ${gap}px gap`)
 	}
 })

--- a/dashboard/src/utils/eventBanner.ts
+++ b/dashboard/src/utils/eventBanner.ts
@@ -2,6 +2,7 @@
 // squash come from the event name, so an event always draws the same pattern.
 
 const LINE = "var(--outline-gray-2)"
+const LINE_WIDTH = 2
 const SURFACE = "var(--surface-gray-1)"
 
 /** FNV-1a seed, then xorshift — successive draws stay independent of each other. */
@@ -31,10 +32,11 @@ export function bannerPattern(seed: string): string {
 	// Squashing one axis is what keeps the rings from reading as a bullseye.
 	const width = Math.round(between(next(), 55, 110))
 	const height = Math.round(between(next(), 55, 110))
-	const gap = between(next(), 9, 12).toFixed(1)
+	const gap = between(next(), 18, 26).toFixed(1)
 
 	return (
 		`repeating-radial-gradient(ellipse ${width}% ${height}% at ${originX}% ${originY}%,` +
-		` ${LINE} 0 1px, transparent 1px ${gap}px), linear-gradient(${SURFACE}, ${SURFACE})`
+		` ${LINE} 0 ${LINE_WIDTH}px, transparent ${LINE_WIDTH}px ${gap}px),` +
+		` linear-gradient(${SURFACE}, ${SURFACE})`
 	)
 }

--- a/dashboard/src/utils/eventDates.test.ts
+++ b/dashboard/src/utils/eventDates.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { alignedEndDate } from "./eventDates.ts"
+
+test("an unset end date follows the start", () => {
+	assert.equal(alignedEndDate("2026-08-21", ""), "2026-08-21")
+})
+
+test("an end date behind the start is pulled up to it", () => {
+	assert.equal(alignedEndDate("2026-08-21", "2026-08-19"), "2026-08-21")
+})
+
+test("a multi-day span survives a start moved within it", () => {
+	assert.equal(alignedEndDate("2026-08-21", "2026-08-23"), "2026-08-23")
+})
+
+test("an end date on the start date stays put", () => {
+	assert.equal(alignedEndDate("2026-08-21", "2026-08-21"), "2026-08-21")
+})
+
+test("clearing the start leaves the end alone", () => {
+	assert.equal(alignedEndDate("", "2026-08-23"), "2026-08-23")
+})

--- a/dashboard/src/utils/eventDates.test.ts
+++ b/dashboard/src/utils/eventDates.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
-import { alignedEndDate } from "./eventDates.ts"
+import { alignedEndDate, isEndBeforeStart } from "./eventDates.ts"
 
 test("an unset end date follows the start", () => {
 	assert.equal(alignedEndDate("2026-08-21", ""), "2026-08-21")
@@ -20,4 +20,34 @@ test("an end date on the start date stays put", () => {
 
 test("clearing the start leaves the end alone", () => {
 	assert.equal(alignedEndDate("", "2026-08-23"), "2026-08-23")
+})
+
+test("an end time after the start on a single-day event is fine", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "", "09:00:00", "17:00:00"), false)
+})
+
+test("an end time before the start on a single-day event is caught", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "", "17:00:00", "09:00:00"), true)
+})
+
+test("an end time equal to the start is caught", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "", "09:00:00", "09:00:00"), true)
+})
+
+test("an explicit end date matching the start is still a single day", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "2026-08-21", "17:00:00", "09:00:00"), true)
+})
+
+test("a multi-day event may end earlier in the day than it started", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "2026-08-23", "17:00:00", "09:00:00"), false)
+})
+
+test("the short and long time formats compare the same", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "", "09:00", "17:00:00"), false)
+	assert.equal(isEndBeforeStart("2026-08-21", "", "17:00:00", "09:00"), true)
+})
+
+test("a half-filled schedule is not reported as invalid", () => {
+	assert.equal(isEndBeforeStart("2026-08-21", "", "", "09:00:00"), false)
+	assert.equal(isEndBeforeStart("2026-08-21", "", "09:00:00", ""), false)
 })

--- a/dashboard/src/utils/eventDates.ts
+++ b/dashboard/src/utils/eventDates.ts
@@ -12,3 +12,29 @@ export function alignedEndDate(startDate: string, endDate: string): string {
 	if (!startDate) return endDate
 	return !endDate || endDate < startDate ? startDate : endDate
 }
+
+/** `HH:mm` and `HH:mm:ss` both reach here; padded, they compare correctly as text. */
+function normalizedTime(time: string): string {
+	return time.length === 5 ? `${time}:00` : time
+}
+
+/**
+ * Whether an event would end before — or exactly when — it starts.
+ *
+ * Only single-day events can fail this: a span that runs into another day may well end
+ * earlier in the day than it began. An unset end date is a single day, which is what
+ * `alignedEndDate` leaves behind. Mirrors `validate_dates` on Buzz Event, which is what
+ * actually enforces it; this is only here so the form says so before the save does.
+ *
+ * A half-filled schedule is not an error yet — the organiser is still picking.
+ */
+export function isEndBeforeStart(
+	startDate: string,
+	endDate: string,
+	startTime: string,
+	endTime: string
+): boolean {
+	if (!startTime || !endTime) return false
+	if (endDate && endDate !== startDate) return false
+	return normalizedTime(endTime) <= normalizedTime(startTime)
+}

--- a/dashboard/src/utils/eventDates.ts
+++ b/dashboard/src/utils/eventDates.ts
@@ -1,0 +1,14 @@
+/**
+ * The end date an event should carry once its start date changes.
+ *
+ * An unset end date follows the start, so a single-day event needs one pick rather than
+ * two. An end date already past the start is left alone — a multi-day event keeps its
+ * span when the organiser shifts the start within it. Only an end that has fallen
+ * behind the start is pulled back into line.
+ *
+ * Dates are `YYYY-MM-DD`, which compares correctly as text.
+ */
+export function alignedEndDate(startDate: string, endDate: string): string {
+	if (!startDate) return endDate
+	return !endDate || endDate < startDate ? startDate : endDate
+}

--- a/dashboard/src/utils/teamRoles.test.ts
+++ b/dashboard/src/utils/teamRoles.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { canCreateEvents } from "./teamRoles.ts"
+
+test("a manager can create events", () => {
+	assert.equal(canCreateEvents("Manager"), true)
+})
+
+test("an admin and an owner can create events", () => {
+	assert.equal(canCreateEvents("Admin"), true)
+	assert.equal(canCreateEvents("Owner"), true)
+})
+
+test("a viewer cannot create events", () => {
+	assert.equal(canCreateEvents("Viewer"), false)
+})
+
+test("a frontdesk member cannot create events", () => {
+	assert.equal(canCreateEvents("Frontdesk"), false)
+})
+
+test("no team selected cannot create events", () => {
+	assert.equal(canCreateEvents(undefined), false)
+})

--- a/dashboard/src/utils/teamRoles.ts
+++ b/dashboard/src/utils/teamRoles.ts
@@ -1,0 +1,7 @@
+// Mirrors WRITE_ROLES in buzz/permissions.py, which is what the server actually enforces.
+const EVENT_WRITE_ROLES = ["Owner", "Admin", "Manager"]
+
+/** Whether a team role may create events. Used to gate the form, not to secure it. */
+export function canCreateEvents(teamRole: string | undefined): boolean {
+	return Boolean(teamRole && EVENT_WRITE_ROLES.includes(teamRole))
+}

--- a/dashboard/src/utils/timeZones.test.ts
+++ b/dashboard/src/utils/timeZones.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import {
+	allTimeZones,
+	canonicalZone,
+	zoneCity,
+	zoneCountry,
+	zoneGenericName,
+	zoneOffsetLabel,
+	zoneSearchText,
+} from "./timeZones.ts"
+
+// Mid-January and mid-July, so a zone that observes DST reads differently in each.
+const WINTER = new Date("2026-01-15T12:00:00Z")
+const SUMMER = new Date("2026-07-15T12:00:00Z")
+
+test("the zone list carries UTC and the region zones", () => {
+	const zones = allTimeZones()
+	for (const zone of ["UTC", "Europe/London", "America/New_York"]) {
+		assert.ok(zones.includes(zone), `${zone} missing from the list`)
+	}
+	assert.ok(zones.length > 100)
+})
+
+test("renamed zones reach the list under their current name", () => {
+	const zones = allTimeZones()
+	for (const [old_, current] of [
+		["Asia/Calcutta", "Asia/Kolkata"],
+		["Europe/Kiev", "Europe/Kyiv"],
+	]) {
+		assert.ok(zones.includes(current), `${current} missing from the list`)
+		assert.ok(!zones.includes(old_), `${old_} still in the list`)
+	}
+})
+
+test("a zone with no rename passes through", () => {
+	assert.equal(canonicalZone("Europe/London"), "Europe/London")
+})
+
+test("a renamed zone still labels correctly", () => {
+	assert.equal(zoneOffsetLabel("Asia/Kolkata", WINTER), "GMT+05:30")
+	assert.equal(zoneCity("Asia/Kolkata"), "Kolkata")
+})
+
+test("every zone in the list can be labelled", () => {
+	for (const zone of allTimeZones()) {
+		assert.match(zoneOffsetLabel(zone, WINTER), /^GMT[+-]\d{2}:\d{2}$/, zone)
+		assert.ok(zoneCity(zone).length > 0, zone)
+	}
+})
+
+test("a half-hour offset keeps its minutes", () => {
+	assert.equal(zoneOffsetLabel("Asia/Kolkata", WINTER), "GMT+05:30")
+})
+
+test("a zero offset spells out its sign and minutes", () => {
+	assert.equal(zoneOffsetLabel("UTC", WINTER), "GMT+00:00")
+	assert.equal(zoneOffsetLabel("Europe/London", WINTER), "GMT+00:00")
+})
+
+test("the offset follows daylight saving", () => {
+	assert.equal(zoneOffsetLabel("Europe/London", SUMMER), "GMT+01:00")
+	assert.equal(zoneOffsetLabel("America/New_York", WINTER), "GMT-05:00")
+	assert.equal(zoneOffsetLabel("America/New_York", SUMMER), "GMT-04:00")
+})
+
+test("the city drops the region and the underscores", () => {
+	assert.equal(zoneCity("Asia/Kolkata"), "Kolkata")
+	assert.equal(zoneCity("America/New_York"), "New York")
+	assert.equal(zoneCity("America/Argentina/Buenos_Aires"), "Buenos Aires")
+	assert.equal(zoneCity("UTC"), "UTC")
+})
+
+test("a zone reports the country it sits in", () => {
+	assert.equal(zoneCountry("Asia/Kolkata"), "India")
+	assert.equal(zoneCountry("Europe/London"), "United Kingdom")
+	assert.equal(zoneCountry("America/New_York"), "United States")
+	assert.equal(zoneCountry("Pacific/Auckland"), "New Zealand")
+})
+
+test("an unknown zone has no country rather than throwing", () => {
+	assert.equal(zoneCountry("Nowhere/Nothing"), "")
+})
+
+test("every zone on offer has a country", () => {
+	// UTC is ours, not a place, so it is the one entry with nowhere to belong.
+	const placeless = allTimeZones().filter((zone) => zone !== "UTC" && !zoneCountry(zone))
+	assert.deepEqual(placeless, [])
+})
+
+test("an unknown zone is labelled empty rather than throwing", () => {
+	assert.equal(zoneOffsetLabel("Nowhere/Nothing"), "")
+	assert.equal(zoneGenericName("Nowhere/Nothing"), "")
+})
+
+test("a zone carries an everyday name", () => {
+	assert.equal(zoneGenericName("Asia/Kolkata", WINTER), "India Standard Time")
+	assert.equal(zoneGenericName("America/New_York", WINTER), "Eastern Time")
+})
+
+test("search text carries city, country and everyday name", () => {
+	assert.equal(zoneSearchText("Asia/Kolkata"), "Kolkata, India, India Standard Time")
+	// The zone id is matched separately by Combobox, so it is not repeated here.
+	assert.ok(!zoneSearchText("Asia/Kolkata").includes("Asia/"))
+})
+
+test("search text drops the parts a zone has no answer for", () => {
+	assert.equal(zoneSearchText("Nowhere/Nothing"), "Nothing")
+})

--- a/dashboard/src/utils/timeZones.ts
+++ b/dashboard/src/utils/timeZones.ts
@@ -1,0 +1,136 @@
+// Buzz Event stores an IANA zone name; these turn one into the two lines the picker
+// shows. Everything comes from Intl, so the list tracks the browser's own tzdata.
+
+/**
+ * Zones IANA has renamed, which the runtime still reports under the old name.
+ *
+ * Neither `supportedValuesOf` nor `resolvedOptions` canonicalises, so without this an
+ * organiser in India picks a zone labelled "Calcutta". Both spellings resolve to the
+ * same zone in Python's `ZoneInfo`, so the rename is safe for what gets stored. Only
+ * the renames a reader would notice are listed; the rest of the list passes through.
+ */
+const RENAMED = {
+	"Asia/Calcutta": "Asia/Kolkata",
+	"Asia/Katmandu": "Asia/Kathmandu",
+	"Asia/Rangoon": "Asia/Yangon",
+	"Asia/Saigon": "Asia/Ho_Chi_Minh",
+	"Asia/Thimbu": "Asia/Thimphu",
+	"Europe/Kiev": "Europe/Kyiv",
+	"America/Godthab": "America/Nuuk",
+	"Atlantic/Faeroe": "Atlantic/Faroe",
+} as const
+
+export function canonicalZone(zone: string): string {
+	return RENAMED[zone as keyof typeof RENAMED] ?? zone
+}
+
+/** Every zone the browser knows, e.g. "Asia/Kolkata", with UTC in front. */
+export function allTimeZones(): string[] {
+	// UTC is absent from the runtime's list, hence the prepend.
+	return ["UTC", ...Intl.supportedValuesOf("timeZone").map(canonicalZone)]
+}
+
+export function currentTimeZone(): string {
+	return canonicalZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
+}
+
+/**
+ * Names a zone in one of Intl's styles.
+ *
+ * A zone the runtime does not recognise throws rather than returning nothing, and the
+ * stored zone on an old event may well be one of those, so an unknown zone reads as
+ * empty instead of taking the page down.
+ */
+function zoneName(zone: string, style: "longOffset" | "longGeneric", at: Date): string {
+	try {
+		return (
+			new Intl.DateTimeFormat("en-GB", { timeZone: zone, timeZoneName: style })
+				.formatToParts(at)
+				.find((part) => part.type === "timeZoneName")?.value ?? ""
+		)
+	} catch {
+		return ""
+	}
+}
+
+/** The zone's offset on a given date, e.g. "GMT+05:30" — DST-aware. */
+export function zoneOffsetLabel(zone: string, at: Date = new Date()): string {
+	const offset = zoneName(zone, "longOffset", at)
+	// Zero-offset zones format as a bare "GMT"; spell it out so every label reads alike.
+	return offset === "GMT" ? "GMT+00:00" : offset
+}
+
+/** The place the zone is named for, e.g. "Asia/Kolkata" → "Kolkata". */
+export function zoneCity(zone: string): string {
+	return zone.split("/").pop()?.replace(/_/g, " ") ?? zone
+}
+
+/**
+ * The zone's everyday name, e.g. "India Standard Time", "Eastern Time".
+ *
+ * The long form on purpose: it is the one that says "Eastern Time" rather than
+ * "New York Time", and people search for the region name they think in.
+ */
+export function zoneGenericName(zone: string, at: Date = new Date()): string {
+	return zoneName(zone, "longGeneric", at)
+}
+
+/**
+ * Country of each zone, built once on first use.
+ *
+ * There is no zone-to-country lookup in Intl, but the reverse exists: asking a region
+ * for its zones. Sweeping every two-letter code and inverting the result covers the
+ * whole list — brute force, but nothing to keep up to date as tzdata moves. Costs
+ * around 90ms, hence the memo.
+ */
+let zonesByCountry: Map<string, string> | null = null
+
+function countryMap(): Map<string, string> {
+	if (zonesByCountry) return zonesByCountry
+
+	zonesByCountry = new Map()
+	// Support for this is uneven; without it the picker simply shows no country.
+	// TS has no type for this yet; the runtime check above is the real guard.
+	type ZonedLocale = Intl.Locale & { getTimeZones?: () => string[] }
+	if (typeof (Intl.Locale.prototype as ZonedLocale).getTimeZones !== "function")
+		return zonesByCountry
+
+	const names = new Intl.DisplayNames(["en"], { type: "region" })
+
+	for (let first = 65; first <= 90; first++) {
+		for (let second = 65; second <= 90; second++) {
+			const code = String.fromCharCode(first, second)
+			let zones: string[] = []
+			try {
+				zones = (new Intl.Locale(`und-${code}`) as ZonedLocale).getTimeZones?.() ?? []
+			} catch {
+				// Not a region code the runtime knows — most of the 676 are not.
+			}
+			if (!zones.length) continue
+
+			const country = names.of(code) ?? code
+			// The sweep returns legacy names, the same as `supportedValuesOf`.
+			for (const zone of zones) zonesByCountry.set(canonicalZone(zone), country)
+		}
+	}
+
+	return zonesByCountry
+}
+
+/** The country a zone sits in, e.g. "India". Empty when the runtime cannot say. */
+export function zoneCountry(zone: string): string {
+	return countryMap().get(zone) ?? ""
+}
+
+/**
+ * Everything a zone should be findable by, as one string.
+ *
+ * Combobox matches on an option's label and value and nothing else, so the terms have
+ * to be folded into the label. What the reader sees comes from the `#item` slot
+ * instead, which is why this can afford to be a haystack rather than a caption.
+ */
+export function zoneSearchText(zone: string): string {
+	return [zoneCity(zone), zoneCountry(zone), zoneGenericName(zone)]
+		.filter(Boolean)
+		.join(", ")
+}


### PR DESCRIPTION
Stacked on `develop`.

## What changed

Creating an event needed Desk. This adds a create page at `/manage/team/events/new`,
reached from the Create Event button that has been inert on the team pages since they
shipped. It sits outside the manager shell, so the team comes from the route guard
rather than the layout.

- **`buzz.api.events.create_event`** — membership decides who may call it; anything
  below Manager is refused, as is a non-member.
- **Schedule** — start and end dates and times, plus a time zone picker searchable by
  city, country, everyday name or zone id.
- **Location** — one control for both kinds: the team's venues, searched as you type
  with an inline add, or a Zoom meeting under Virtual.
- **Banner** — the generated contour pattern, seeded by the title as you type. Opened
  up (wider spacing, 2px lines) since it moired at card size.

Worth a look during review:

- **Category and host are filled in by the server.** `Buzz Event` requires both and the
  form asks for neither. Host is the team's own, minted on first use. Category is
  `Meetups`, or `Zoom Meeting` when Zoom was chosen — that one isn't cosmetic, it's what
  marks an event Zoom-backed (`buzz/utils.py:13`).
- **Zoom is booked automatically after insert**, where Desk has a manual button. A
  failure leaves the event standing rather than rolling it back, since the call goes out
  to Zoom mid-request.
- **Time zone names come from the runtime**, which still reports renamed zones under
  their old names (`Asia/Calcutta`). The eight a reader would notice are mapped forward;
  both spellings resolve the same in `ZoneInfo`.
- **`fix(tests): stamp a team on the seeded test records` rides along.** `before_tests`
  seeds a venue, host and event without the team those doctypes made mandatory in the
  multi-tenancy work, so `bench run-tests` failed for *every* module before a single
  test ran. Nothing here could be tested without it. Happy to split it out.

Not done: no unsaved-changes guard, so Back discards a filled-in form silently; nothing
in the dashboard has been checked in dark mode; `medium` is derived server-side only, so
the picker no longer tracks it.

## Demo

The create page, filled in — the banner pattern is seeded by the title as you type:

<img width="1440" height="900" alt="create-event" src="https://github.com/user-attachments/assets/f18d0c66-9be2-4e44-8d29-d7cbdf73e047" />

One control for both kinds of location, venues and Zoom under the same picker:

<img width="1440" height="900" alt="create-event-location" src="https://github.com/user-attachments/assets/e5150c07-2379-4821-a93c-48ddd8c57075" />


Time zone search, by city rather than by zone id:
<img width="1440" height="900" alt="create-event-timezone" src="https://github.com/user-attachments/assets/b50806ab-e1cf-434d-9e31-aaf21afffec4" />


If the user is Viewer for the team
<img width="1440" height="900" alt="create-event-viewer" src="https://github.com/user-attachments/assets/a050fd7d-6415-4ce0-9813-1df1b019a222" />




