### PR TITLE
feat(dashboard): a guests page for an event

### DIFF
--- a/buzz/api/events/__init__.py
+++ b/buzz/api/events/__init__.py
@@ -4,6 +4,7 @@ from buzz.api.events import services
 from buzz.api.events.schemas import (
 	CreatedEvent,
 	EventDetail,
+	EventGuestsResponse,
 	MyEventsResponse,
 	NewEvent,
 	RouteAvailability,
@@ -20,6 +21,12 @@ def get_my_events() -> MyEventsResponse:
 def get_event(event: str) -> EventDetail:
 	"""One event for the manage page, for someone who can edit it."""
 	return services.event_detail(event)
+
+
+@frappe.whitelist()
+def get_event_guests(event: str) -> EventGuestsResponse:
+	"""Everyone holding a submitted ticket to an event, with their add-ons."""
+	return services.event_guests(event)
 
 
 @frappe.whitelist()

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -1,5 +1,7 @@
 from datetime import date, timedelta
 
+from pydantic import Field
+
 from buzz.api.schemas import APIRequest, APIResponse
 
 
@@ -48,6 +50,27 @@ class EventDetail(APIResponse):
 	# The organiser's own link, or the one Zoom issued when the meeting was booked.
 	meeting_link: str | None = None
 	is_published: bool
+
+
+class GuestAddOn(APIResponse):
+	title: str
+	# The option the attendee picked, for an add-on that offers a choice.
+	value: str | None = None
+
+
+class EventGuest(APIResponse):
+	"""One ticket. A person who booked twice holds two, and appears twice."""
+
+	name: str
+	attendee_name: str | None = None
+	attendee_email: str | None = None
+	ticket_type: str | None = None
+	add_ons: list[GuestAddOn] = Field(default_factory=list)
+
+
+class EventGuestsResponse(APIResponse):
+	total: int
+	guests: list[EventGuest]
 
 
 class RouteAvailability(APIResponse):

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -69,6 +69,7 @@ class EventGuest(APIResponse):
 
 
 class EventGuestsResponse(APIResponse):
+	title: str | None = None
 	total: int
 	registrations_closed: bool
 	guests: list[EventGuest]

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -70,6 +70,7 @@ class EventGuest(APIResponse):
 
 class EventGuestsResponse(APIResponse):
 	total: int
+	registrations_closed: bool
 	guests: list[EventGuest]
 
 

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -4,6 +4,7 @@ from frappe.model.naming import append_number_if_name_exists
 from frappe.query_builder import Case
 from frappe.utils import getdate
 
+from buzz.api.booking.services import are_registrations_closed
 from buzz.api.events.exceptions import (
 	CannotCreateEvents,
 	CannotManageEvent,
@@ -174,7 +175,11 @@ def event_guests(event: str) -> EventGuestsResponse:
 		)
 		for ticket in tickets
 	]
-	return EventGuestsResponse(total=len(guests), guests=guests)
+	return EventGuestsResponse(
+		total=len(guests),
+		registrations_closed=are_registrations_closed(frappe.get_cached_doc("Buzz Event", event)),
+		guests=guests,
+	)
 
 
 def titles_of(doctype: str, names: set[str | None]) -> dict[str, str]:

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -13,7 +13,10 @@ from buzz.api.events.exceptions import (
 from buzz.api.events.schemas import (
 	CreatedEvent,
 	EventDetail,
+	EventGuest,
+	EventGuestsResponse,
 	EventVenue,
+	GuestAddOn,
 	MyEvent,
 	MyEventsResponse,
 	NewEvent,
@@ -138,6 +141,74 @@ def meeting_link_of(row) -> str | None:
 
 	meeting = frappe.db.get_value("Buzz Event", row.name, "zoom_meeting")
 	return frappe.db.get_value("Zoom Meeting", meeting, "zoom_link") if meeting else None
+
+
+def event_guests(event: str) -> EventGuestsResponse:
+	"""Everyone holding a ticket to an event.
+
+	A submitted ticket only — a draft belongs to a booking still being paid for. Read
+	access is the bar: this shows the team what it already sees through the doctype.
+	"""
+	team = frappe.db.get_value("Buzz Event", event, "team")
+	if not frappe.db.exists("Buzz Event", event):
+		EventNotFound.throw()
+
+	if not has_team_access(team, "read", frappe.session.user):
+		CannotManageEvent.throw()
+
+	tickets = frappe.get_all(
+		"Event Ticket",
+		filters={"event": event, "docstatus": 1},
+		fields=["name", "attendee_name", "attendee_email", "ticket_type"],
+		order_by="attendee_name asc",
+	)
+
+	by_ticket = add_ons_by_ticket([ticket.name for ticket in tickets])
+	# Event Ticket Type is autonamed, so the link value is a number nobody recognises.
+	type_titles = titles_of("Event Ticket Type", {ticket.ticket_type for ticket in tickets})
+
+	guests = [
+		EventGuest(
+			**ticket | {"ticket_type": type_titles.get(ticket.ticket_type) or ticket.ticket_type},
+			add_ons=by_ticket.get(ticket.name, []),
+		)
+		for ticket in tickets
+	]
+	return EventGuestsResponse(total=len(guests), guests=guests)
+
+
+def titles_of(doctype: str, names: set[str | None]) -> dict[str, str]:
+	"""Name-to-title map for a set of links, in one query."""
+	wanted = [name for name in names if name]
+	if not wanted:
+		return {}
+
+	rows = frappe.get_all(doctype, filters={"name": ("in", wanted)}, fields=["name", "title"], as_list=True)
+	# An autonamed doctype comes back with integer names, while every link to it travels
+	# as a string — without this the map never matches.
+	return {str(name): title for name, title in rows}
+
+
+def add_ons_by_ticket(tickets: list[str]) -> dict[str, list[GuestAddOn]]:
+	"""Add-ons for every ticket at once, rather than a query per row."""
+	if not tickets:
+		return {}
+
+	# Query builder rather than get_all: a child doctype has no standalone permission of
+	# its own, and the team check above is the authorization.
+	value = frappe.qb.DocType("Ticket Add-on Value")
+	rows = (
+		frappe.qb.from_(value)
+		.select(value.parent, value.add_on, value.value)
+		.where((value.parenttype == "Event Ticket") & value.parent.isin(tickets))
+	).run(as_dict=True)
+	titles = titles_of("Ticket Add-on", {row.add_on for row in rows})
+
+	by_ticket: dict[str, list[GuestAddOn]] = {}
+	for row in rows:
+		add_on = GuestAddOn(title=titles.get(row.add_on) or row.add_on, value=row.value)
+		by_ticket.setdefault(row.parent, []).append(add_on)
+	return by_ticket
 
 
 def route_availability(route: str, event: str | None = None) -> RouteAvailability:

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -175,9 +175,11 @@ def event_guests(event: str) -> EventGuestsResponse:
 		)
 		for ticket in tickets
 	]
+	doc = frappe.get_cached_doc("Buzz Event", event)
 	return EventGuestsResponse(
+		title=doc.title,
 		total=len(guests),
-		registrations_closed=are_registrations_closed(frappe.get_cached_doc("Buzz Event", event)),
+		registrations_closed=are_registrations_closed(doc),
 		guests=guests,
 	)
 

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -490,6 +490,18 @@ class TestGetEventGuests(IntegrationTestCase):
 		self.assertEqual(guests.total, 0)
 		self.assertEqual(guests.guests, [])
 
+	def test_reports_registrations_closed_once_the_cutoff_has_passed(self):
+		event = create_event("Closed Event", self.team, registrations_close_at="2020-01-01 00:00:00")
+		frappe.set_user(self.owner)
+
+		self.assertTrue(get_event_guests(event).registrations_closed)
+
+	def test_reports_registrations_open_before_the_event_ends(self):
+		event = create_event("Open Event", self.team)
+		frappe.set_user(self.owner)
+
+		self.assertFalse(get_event_guests(event).registrations_closed)
+
 	def test_a_non_member_cannot_read_the_guest_list(self):
 		event = create_event("Private Guests", self.team)
 		issue_ticket(event, "private-guest@example.com")

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -502,6 +502,17 @@ class TestGetEventGuests(IntegrationTestCase):
 
 		self.assertFalse(get_event_guests(event).registrations_closed)
 
+	def test_names_the_event_for_a_member_who_cannot_edit_it(self):
+		"""The header labels the page off this payload, so read access has to be enough."""
+		event = create_event("Named Event", self.team)
+		viewer = create_user("guests-viewer@example.com", "Viewer")
+		add_member(self.team, viewer, "Viewer")
+		frappe.set_user(viewer)
+
+		self.assertEqual(get_event_guests(event).title, "Event Named Event")
+		with self.assertRaises(CannotManageEvent):
+			get_event(event)
+
 	def test_a_non_member_cannot_read_the_guest_list(self):
 		event = create_event("Private Guests", self.team)
 		issue_ticket(event, "private-guest@example.com")

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, today
 
-from buzz.api.events import check_event_route, get_event, get_my_events
+from buzz.api.events import check_event_route, get_event, get_event_guests, get_my_events
 from buzz.api.events import create_event as create_event_endpoint
 from buzz.api.events.exceptions import (
 	CannotCreateEvents,
@@ -408,3 +408,98 @@ class TestCheckEventRoute(IntegrationTestCase):
 		frappe.set_user(self.owner)
 
 		self.assertFalse(check_event_route("   ").available)
+
+
+class TestGetEventGuests(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+		cls.owner = create_user("guests-owner@example.com", "Owner")
+		cls.stranger = create_user("guests-stranger@example.com", "Stranger")
+		cls.team = create_owned_team("Guests Team", cls.owner)
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def test_counts_and_lists_the_submitted_tickets(self):
+		event = create_event("Guested Event", self.team)
+		issue_ticket(event, "guest-one@example.com")
+		issue_ticket(event, "guest-two@example.com")
+		frappe.set_user(self.owner)
+
+		guests = get_event_guests(event).__json__()
+
+		self.assertEqual(guests["total"], 2)
+		self.assertEqual(len(guests["guests"]), 2)
+		emails = {guest["attendee_email"] for guest in guests["guests"]}
+		self.assertEqual(emails, {"guest-one@example.com", "guest-two@example.com"})
+
+	def test_leaves_out_a_ticket_that_was_never_submitted(self):
+		event = create_event("Draft Ticket Event", self.team)
+		create_ticket(event, "draft-guest@example.com")
+		frappe.set_user(self.owner)
+
+		self.assertEqual(get_event_guests(event).total, 0)
+
+	def test_carries_the_add_ons_a_ticket_holds(self):
+		event = create_event("Add-on Event", self.team)
+		ticket = issue_ticket(event, "addon-guest@example.com")
+		add_on = frappe.get_doc(
+			{"doctype": "Ticket Add-on", "event": event, "title": "T-Shirt", "price": 0}
+		).insert(ignore_permissions=True)
+		# Submitted, so the row goes on through db_insert rather than a save.
+		frappe.get_doc(
+			{
+				"doctype": "Ticket Add-on Value",
+				"parenttype": "Event Ticket",
+				"parentfield": "add_ons",
+				"parent": ticket,
+				"add_on": add_on.name,
+				"value": "Large",
+			}
+		).db_insert()
+		frappe.set_user(self.owner)
+
+		guest = get_event_guests(event).guests[0]
+
+		self.assertEqual(len(guest.add_ons), 1)
+		self.assertEqual(guest.add_ons[0].title, "T-Shirt")
+		self.assertEqual(guest.add_ons[0].value, "Large")
+
+	def test_names_the_ticket_type_rather_than_its_docname(self):
+		event = create_event("Typed Ticket Event", self.team)
+		ticket = issue_ticket(event, "typed-guest@example.com")
+		ticket_type = frappe.db.get_value("Event Ticket", ticket, "ticket_type")
+		title = frappe.db.get_value("Event Ticket Type", ticket_type, "title")
+		frappe.set_user(self.owner)
+
+		guest = get_event_guests(event).guests[0]
+
+		self.assertEqual(guest.ticket_type, title)
+		self.assertNotEqual(guest.ticket_type, ticket_type)
+
+	def test_an_event_with_no_guests_is_empty_rather_than_an_error(self):
+		event = create_event("Quiet Event", self.team)
+		frappe.set_user(self.owner)
+
+		guests = get_event_guests(event)
+
+		self.assertEqual(guests.total, 0)
+		self.assertEqual(guests.guests, [])
+
+	def test_a_non_member_cannot_read_the_guest_list(self):
+		event = create_event("Private Guests", self.team)
+		issue_ticket(event, "private-guest@example.com")
+		frappe.set_user(self.stranger)
+
+		with self.assertRaises(CannotManageEvent):
+			get_event_guests(event)
+
+	def test_an_unknown_event_is_not_found(self):
+		frappe.set_user(self.owner)
+
+		with self.assertRaises(EventNotFound):
+			get_event_guests("999999999")

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -33,6 +33,7 @@ declare module 'vue' {
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
     EventLocation: typeof import('./src/components/dashboard/events/EventLocation.vue')['default']
     EventMedium: typeof import('./src/components/dashboard/events/EventMedium.vue')['default']
+    EventPageHeader: typeof import('./src/components/dashboard/events/EventPageHeader.vue')['default']
     EventRoute: typeof import('./src/components/dashboard/events/EventRoute.vue')['default']
     EventSchedule: typeof import('./src/components/dashboard/events/EventSchedule.vue')['default']
     EventSelector: typeof import('./src/components/EventSelector.vue')['default']

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -31,6 +31,7 @@ declare module 'vue' {
     EventBanner: typeof import('./src/components/dashboard/events/EventBanner.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
+    EventGuestItem: typeof import('./src/components/dashboard/events/EventGuestItem.vue')['default']
     EventLocation: typeof import('./src/components/dashboard/events/EventLocation.vue')['default']
     EventMedium: typeof import('./src/components/dashboard/events/EventMedium.vue')['default']
     EventPageHeader: typeof import('./src/components/dashboard/events/EventPageHeader.vue')['default']

--- a/dashboard/src/components/dashboard/events/EventGuestItem.vue
+++ b/dashboard/src/components/dashboard/events/EventGuestItem.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { EventGuest } from "@/types";
+import { Avatar, Badge } from "frappe-ui";
+
+const props = defineProps<{ guest: EventGuest }>();
+
+// A ticket can be issued before anyone is named on it, so the email is the fallback
+// and the row never renders blank.
+const name = props.guest.attendee_name || props.guest.attendee_email || "Unnamed guest";
+</script>
+
+<template>
+	<li class="flex items-center gap-3 py-3">
+		<Avatar :label="name" size="lg" />
+
+		<div class="min-w-0 flex-1">
+			<p class="truncate text-base font-medium text-ink-gray-8">{{ name }}</p>
+			<p v-if="guest.attendee_email" class="truncate text-sm text-ink-gray-5">
+				{{ guest.attendee_email }}
+			</p>
+		</div>
+
+		<div class="flex shrink-0 items-center gap-1.5">
+			<Badge
+				v-for="addOn in guest.add_ons"
+				:key="addOn.title"
+				theme="blue"
+				variant="subtle"
+				:label="addOn.value ? `${addOn.title}: ${addOn.value}` : addOn.title"
+			/>
+			<Badge v-if="guest.ticket_type" variant="outline" :label="guest.ticket_type" />
+		</div>
+	</li>
+</template>

--- a/dashboard/src/components/dashboard/events/EventGuestItem.vue
+++ b/dashboard/src/components/dashboard/events/EventGuestItem.vue
@@ -10,14 +10,16 @@ const name = props.guest.attendee_name || props.guest.attendee_email || "Unnamed
 </script>
 
 <template>
-	<li class="flex items-center gap-3 py-3">
+	<li class="flex items-center gap-3 px-4 py-3">
 		<Avatar :label="name" size="lg" />
 
-		<div class="min-w-0 flex-1">
-			<p class="truncate text-base font-medium text-ink-gray-8">{{ name }}</p>
-			<p v-if="guest.attendee_email" class="truncate text-sm text-ink-gray-5">
+		<!-- Name and email on one line: the email is how you tell two Harshes apart, so it
+			 belongs beside the name rather than under it. -->
+		<div class="flex min-w-0 flex-1 items-baseline gap-2">
+			<span class="shrink-0 truncate text-base font-medium text-ink-gray-8">{{ name }}</span>
+			<span v-if="guest.attendee_email" class="truncate text-base text-ink-gray-5">
 				{{ guest.attendee_email }}
-			</p>
+			</span>
 		</div>
 
 		<div class="flex shrink-0 items-center gap-1.5">

--- a/dashboard/src/components/dashboard/events/EventPageHeader.vue
+++ b/dashboard/src/components/dashboard/events/EventPageHeader.vue
@@ -4,7 +4,7 @@ import { computed } from "vue";
 
 // The event, then the section of it being looked at. Neither crumb is a link: the
 // event on its own resolves to whichever section is open.
-const props = defineProps<{ title: string | undefined; section: string }>();
+const props = defineProps<{ title: string | null | undefined; section: string }>();
 
 const items = computed(() => [{ label: props.title || "Event" }, { label: props.section }]);
 </script>

--- a/dashboard/src/components/dashboard/events/EventPageHeader.vue
+++ b/dashboard/src/components/dashboard/events/EventPageHeader.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { Breadcrumbs, PageHeader } from "frappe-ui";
+import { computed } from "vue";
+
+// The event, then the section of it being looked at. Neither crumb is a link: the
+// event on its own resolves to whichever section is open.
+const props = defineProps<{ title: string | undefined; section: string }>();
+
+const items = computed(() => [{ label: props.title || "Event" }, { label: props.section }]);
+</script>
+
+<template>
+	<PageHeader class="border-none pt-2 bg-surface-elevation-1">
+		<Breadcrumbs :items="items" />
+		<slot />
+	</PageHeader>
+</template>

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -33,3 +33,24 @@ export const updateEvent = createResource({ url: "frappe.client.set_value" })
 
 /** Whether an event can take a route. Routes are the public URL namespace, so they are unique. */
 export const checkEventRoute = createResource({ url: "buzz.api.events.check_event_route" })
+
+/**
+ * Everyone holding a ticket to an event.
+ *
+ * Event Ticket is the attendee record, and only a submitted one counts — a draft is a
+ * booking still being paid for. The team permission hooks scope the query, so this needs
+ * no endpoint of its own.
+ */
+export function eventGuests(event: string) {
+	return createResource<{ name: string; attendee_name: string }[]>({
+		url: "frappe.client.get_list",
+		params: {
+			doctype: "Event Ticket",
+			filters: { event, docstatus: 1 },
+			fields: ["name", "attendee_name"],
+			order_by: "attendee_name asc",
+			limit_page_length: 0,
+		},
+		auto: true,
+	})
+}

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -1,4 +1,4 @@
-import type { EventDetail, MyEvents } from "@/types"
+import type { EventDetail, EventGuests, MyEvents } from "@/types"
 import { createResource, useCall } from "frappe-ui"
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
@@ -34,23 +34,11 @@ export const updateEvent = createResource({ url: "frappe.client.set_value" })
 /** Whether an event can take a route. Routes are the public URL namespace, so they are unique. */
 export const checkEventRoute = createResource({ url: "buzz.api.events.check_event_route" })
 
-/**
- * Everyone holding a ticket to an event.
- *
- * Event Ticket is the attendee record, and only a submitted one counts — a draft is a
- * booking still being paid for. The team permission hooks scope the query, so this needs
- * no endpoint of its own.
- */
+/** Everyone holding a submitted ticket to an event, with their add-ons and the total. */
 export function eventGuests(event: string) {
-	return createResource<{ name: string; attendee_name: string }[]>({
-		url: "frappe.client.get_list",
-		params: {
-			doctype: "Event Ticket",
-			filters: { event, docstatus: 1 },
-			fields: ["name", "attendee_name"],
-			order_by: "attendee_name asc",
-			limit_page_length: 0,
-		},
+	return createResource<EventGuests>({
+		url: "buzz.api.events.get_event_guests",
+		params: { event },
 		auto: true,
 	})
 }

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -43,9 +43,9 @@ const eventItems = computed(() => [
 		to: `/manage/events/${eventId.value}/details`,
 	},
 	{
-		label: "Attendees",
+		label: "Guests",
 		icon: "lucide-users-round",
-		to: `/manage/events/${eventId.value}/attendees`,
+		to: `/manage/events/${eventId.value}/guests`,
 	},
 	{
 		label: "Talks",

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import EventBanner from "@/components/dashboard/events/EventBanner.vue";
 import EventMedium from "@/components/dashboard/events/EventMedium.vue";
+import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue";
 import EventRoute from "@/components/dashboard/events/EventRoute.vue";
 import EventSchedule from "@/components/dashboard/events/EventSchedule.vue";
 import { eventDetail, updateEvent } from "@/data/events";
 import type { EventDetail, FrappeError } from "@/types";
-import { Breadcrumbs, Button, ErrorMessage, PageHeader, Textarea, toast } from "frappe-ui";
+import { Button, ErrorMessage, Textarea, toast } from "frappe-ui";
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor";
 import { computed, reactive, ref, watch } from "vue";
 import { useRoute } from "vue-router";
@@ -65,8 +66,6 @@ watch(
 
 const isDirty = computed(() => JSON.stringify(form) !== saved.value);
 
-const items = computed(() => [{ label: event.data?.title || "Event" }, { label: "Details" }]);
-
 // createResource types its error as {}, so the message needs narrowing.
 const errorMessage = computed(() =>
 	(updateEvent.error as FrappeError | null)?.messages?.join("\n")
@@ -87,8 +86,7 @@ async function save() {
 </script>
 
 <template>
-	<PageHeader class="border-none pt-2 bg-surface-elevation-1">
-		<Breadcrumbs :items="items" />
+	<EventPageHeader :title="event.data?.title" section="Details">
 		<Button
 			v-if="isDirty"
 			variant="solid"
@@ -96,7 +94,7 @@ async function save() {
 			:loading="updateEvent.loading"
 			@click="save"
 		/>
-	</PageHeader>
+	</EventPageHeader>
 
 	<div v-if="event.data" class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
 		<ErrorMessage v-if="errorMessage" :message="errorMessage" />

--- a/dashboard/src/pages/manage/events/EventGuests.vue
+++ b/dashboard/src/pages/manage/events/EventGuests.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import EventGuestItem from "@/components/dashboard/events/EventGuestItem.vue";
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue";
 import { eventDetail, eventGuests } from "@/data/events";
 import { LoadingText } from "frappe-ui";
@@ -17,16 +18,17 @@ const guests = eventGuests(eventId);
 	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
 		<h1 class="font-semibold text-4xl">Event guests</h1>
 
+		<section class="rounded-xl border border-outline-gray-2 px-4 py-3">
+			<p class="text-sm text-ink-gray-5">Registrations</p>
+			<p class="text-2xl font-semibold tabular-nums text-ink-gray-9">
+				{{ guests.data?.total ?? "—" }}
+			</p>
+		</section>
+
 		<LoadingText v-if="guests.loading" text="Loading guests…" />
 
-		<ul v-else-if="guests.data?.length" class="divide-y divide-outline-gray-1">
-			<li
-				v-for="guest in guests.data"
-				:key="guest.name"
-				class="py-3 text-base text-ink-gray-8"
-			>
-				{{ guest.attendee_name }}
-			</li>
+		<ul v-else-if="guests.data?.guests.length" class="divide-y divide-outline-gray-1">
+			<EventGuestItem v-for="guest in guests.data.guests" :key="guest.name" :guest="guest" />
 		</ul>
 
 		<p v-else class="text-base text-ink-gray-5">No guests yet.</p>

--- a/dashboard/src/pages/manage/events/EventGuests.vue
+++ b/dashboard/src/pages/manage/events/EventGuests.vue
@@ -18,7 +18,8 @@ const guests = eventGuests(eventId);
 	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
 		<h1 class="font-semibold text-4xl">Event guests</h1>
 
-		<section class="rounded-xl border border-outline-gray-2 px-4 py-3">
+		<!-- A stat, not a card: the number is the thing, the border was packaging. -->
+		<section class="w-fit">
 			<p class="text-sm text-ink-gray-5">Registrations</p>
 			<p class="text-2xl font-semibold tabular-nums text-ink-gray-9">
 				{{ guests.data?.total ?? "—" }}

--- a/dashboard/src/pages/manage/events/EventGuests.vue
+++ b/dashboard/src/pages/manage/events/EventGuests.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue";
+import { eventDetail, eventGuests } from "@/data/events";
+import { LoadingText } from "frappe-ui";
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+const eventId = route.params.eventId as string;
+
+const event = eventDetail(eventId);
+const guests = eventGuests(eventId);
+</script>
+
+<template>
+	<EventPageHeader :title="event.data?.title" section="Guests" />
+
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
+		<h1 class="font-semibold text-4xl">Event guests</h1>
+
+		<LoadingText v-if="guests.loading" text="Loading guests…" />
+
+		<ul v-else-if="guests.data?.length" class="divide-y divide-outline-gray-1">
+			<li
+				v-for="guest in guests.data"
+				:key="guest.name"
+				class="py-3 text-base text-ink-gray-8"
+			>
+				{{ guest.attendee_name }}
+			</li>
+		</ul>
+
+		<p v-else class="text-base text-ink-gray-5">No guests yet.</p>
+	</div>
+</template>

--- a/dashboard/src/pages/manage/events/EventGuests.vue
+++ b/dashboard/src/pages/manage/events/EventGuests.vue
@@ -2,7 +2,8 @@
 import EventGuestItem from "@/components/dashboard/events/EventGuestItem.vue";
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue";
 import { eventDetail, eventGuests } from "@/data/events";
-import { LoadingText } from "frappe-ui";
+import { FormControl, LoadingText } from "frappe-ui";
+import { computed, ref } from "vue";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
@@ -10,28 +11,70 @@ const eventId = route.params.eventId as string;
 
 const event = eventDetail(eventId);
 const guests = eventGuests(eventId);
+
+const query = ref("");
+
+// Filtered here rather than server-side: the whole list is already loaded, so a round
+// trip per keystroke would be slower than the search it replaces.
+const matches = computed(() => {
+	const term = query.value.trim().toLowerCase();
+	const all = guests.data?.guests ?? [];
+	if (!term) return all;
+	return all.filter((guest) =>
+		[guest.attendee_name, guest.attendee_email].some((field) =>
+			field?.toLowerCase().includes(term)
+		)
+	);
+});
 </script>
 
 <template>
 	<EventPageHeader :title="event.data?.title" section="Guests" />
 
-	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
-		<h1 class="font-semibold text-4xl">Event guests</h1>
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
+		<section class="space-y-2">
+			<h1 class="text-xl font-semibold text-ink-gray-9">How it's going</h1>
 
-		<!-- A stat, not a card: the number is the thing, the border was packaging. -->
-		<section class="w-fit">
-			<p class="text-sm text-ink-gray-5">Registrations</p>
-			<p class="text-2xl font-semibold tabular-nums text-ink-gray-9">
-				{{ guests.data?.total ?? "—" }}
+			<p class="flex items-baseline gap-1.5">
+				<span class="text-2xl font-semibold tabular-nums text-ink-gray-9">
+					{{ guests.data?.total ?? "—" }}
+				</span>
+				<span class="text-base text-ink-gray-5">registered</span>
 			</p>
+
+			<p v-if="guests.data?.registrations_closed" class="text-sm text-ink-red-3">
+				Registrations have closed
+			</p>
+			<p v-else-if="guests.data" class="text-sm text-ink-gray-5">Registrations are open</p>
 		</section>
 
-		<LoadingText v-if="guests.loading" text="Loading guests…" />
+		<section class="space-y-3">
+			<h2 class="text-xl font-semibold text-ink-gray-9">Guest list</h2>
 
-		<ul v-else-if="guests.data?.guests.length" class="divide-y divide-outline-gray-1">
-			<EventGuestItem v-for="guest in guests.data.guests" :key="guest.name" :guest="guest" />
-		</ul>
+			<FormControl
+				v-model="query"
+				type="text"
+				placeholder="Search by name or email"
+				aria-label="Search guests"
+			>
+				<template #prefix>
+					<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
+				</template>
+			</FormControl>
 
-		<p v-else class="text-base text-ink-gray-5">No guests yet.</p>
+			<LoadingText v-if="guests.loading" text="Loading guests…" />
+
+			<ul
+				v-else-if="matches.length"
+				class="divide-y divide-outline-gray-1 overflow-hidden rounded-xl border border-outline-gray-2"
+			>
+				<EventGuestItem v-for="guest in matches" :key="guest.name" :guest="guest" />
+			</ul>
+
+			<p v-else-if="query" class="text-base text-ink-gray-5">
+				Nobody here matches “{{ query }}”.
+			</p>
+			<p v-else class="text-base text-ink-gray-5">No guests yet.</p>
+		</section>
 	</div>
 </template>

--- a/dashboard/src/pages/manage/events/EventGuests.vue
+++ b/dashboard/src/pages/manage/events/EventGuests.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import EventGuestItem from "@/components/dashboard/events/EventGuestItem.vue";
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue";
-import { eventDetail, eventGuests } from "@/data/events";
+import { eventGuests } from "@/data/events";
 import { FormControl, LoadingText } from "frappe-ui";
 import { computed, ref } from "vue";
 import { useRoute } from "vue-router";
@@ -9,7 +9,6 @@ import { useRoute } from "vue-router";
 const route = useRoute();
 const eventId = route.params.eventId as string;
 
-const event = eventDetail(eventId);
 const guests = eventGuests(eventId);
 
 const query = ref("");
@@ -29,7 +28,7 @@ const matches = computed(() => {
 </script>
 
 <template>
-	<EventPageHeader :title="event.data?.title" section="Guests" />
+	<EventPageHeader :title="guests.data?.title" section="Guests" />
 
 	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
 		<section class="space-y-2">

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -45,6 +45,11 @@ const routes: RouteRecordRaw[] = [
 				component: () => import("@/pages/manage/events/EventDetails.vue"),
 			},
 			{
+				path: "events/:eventId/guests",
+				name: "event-guests",
+				component: () => import("@/pages/manage/events/EventGuests.vue"),
+			},
+			{
 				path: "events/:eventId/:section",
 				component: () => import("@/pages/manage/WorkInProgress.vue"),
 			},

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -140,6 +140,7 @@ export interface EventGuest {
 }
 
 export interface EventGuests {
+	title: string | null
 	total: number
 	registrations_closed: boolean
 	guests: EventGuest[]

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -125,6 +125,25 @@ export interface MyEvents {
 	past: MyEvent[]
 }
 
+export interface GuestAddOn {
+	title: string
+	value: string | null
+}
+
+// buzz.api.events.get_event_guests: one row per submitted ticket, not per person.
+export interface EventGuest {
+	name: string
+	attendee_name: string | null
+	attendee_email: string | null
+	ticket_type: string | null
+	add_ons: GuestAddOn[]
+}
+
+export interface EventGuests {
+	total: number
+	guests: EventGuest[]
+}
+
 export interface EventVenueDetail {
 	name: string
 	address: string | null

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -141,6 +141,7 @@ export interface EventGuest {
 
 export interface EventGuests {
 	total: number
+	registrations_closed: boolean
 	guests: EventGuest[]
 }
 

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -77,11 +77,18 @@ test.describe("Event workspace", () => {
 
 		await expect(page).toHaveURL(/\/b\/manage\/events\/\d+\/guests$/);
 		await expect(page.getByRole("heading", { name: "Event guests", level: 1 })).toBeVisible();
-		// The shared event is the one tickets.setup.ts books against, so it has guests,
-		// and each row is a name rather than a blank.
-		const names = page.getByRole("list").getByRole("listitem");
-		await expect(names.first()).toBeVisible({ timeout: 15000 });
-		await expect(names.first()).not.toBeEmpty();
+		// The shared event is the one tickets.setup.ts books against, so it has guests.
+		const rows = page.getByRole("list").getByRole("listitem");
+		await expect(rows.first()).toBeVisible({ timeout: 15000 });
+
+		// The count is the number of rows under it, not a separate claim.
+		const registrations = Number(await page.getByText(/^\d+$/).first().textContent());
+		expect(registrations).toBe(await rows.count());
+
+		// A row carries the person and the ticket they hold, named rather than numbered.
+		await expect(rows.first()).toContainText("@");
+		const badge = rows.first().locator("div").last();
+		await expect(badge).not.toHaveText(/^\d+$/);
 	});
 
 	test("moves between sections", async ({ page }) => {

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -66,10 +66,22 @@ test.describe("Event workspace", () => {
 	});
 
 	test("swaps the sidebar for the event's own destinations", async ({ page }) => {
-		for (const label of ["Back", "Details", "Attendees", "Talks"]) {
+		for (const label of ["Back", "Details", "Guests", "Talks"]) {
 			await expect(page.getByRole("link", { name: label })).toBeVisible({ timeout: 15000 });
 		}
 		await expect(page.getByRole("link", { name: "My Tickets" })).toHaveCount(0);
+	});
+
+	test("lists the event's guests", async ({ page }) => {
+		await page.getByRole("link", { name: "Guests" }).click();
+
+		await expect(page).toHaveURL(/\/b\/manage\/events\/\d+\/guests$/);
+		await expect(page.getByRole("heading", { name: "Event guests", level: 1 })).toBeVisible();
+		// The shared event is the one tickets.setup.ts books against, so it has guests,
+		// and each row is a name rather than a blank.
+		const names = page.getByRole("list").getByRole("listitem");
+		await expect(names.first()).toBeVisible({ timeout: 15000 });
+		await expect(names.first()).not.toBeEmpty();
 	});
 
 	test("moves between sections", async ({ page }) => {

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -72,25 +72,6 @@ test.describe("Event workspace", () => {
 		await expect(page.getByRole("link", { name: "My Tickets" })).toHaveCount(0);
 	});
 
-	test("lists the event's guests", async ({ page }) => {
-		await page.getByRole("link", { name: "Guests" }).click();
-
-		await expect(page).toHaveURL(/\/b\/manage\/events\/\d+\/guests$/);
-		await expect(page.getByRole("heading", { name: "Event guests", level: 1 })).toBeVisible();
-		// The shared event is the one tickets.setup.ts books against, so it has guests.
-		const rows = page.getByRole("list").getByRole("listitem");
-		await expect(rows.first()).toBeVisible({ timeout: 15000 });
-
-		// The count is the number of rows under it, not a separate claim.
-		const registrations = Number(await page.getByText(/^\d+$/).first().textContent());
-		expect(registrations).toBe(await rows.count());
-
-		// A row carries the person and the ticket they hold, named rather than numbered.
-		await expect(rows.first()).toContainText("@");
-		const badge = rows.first().locator("div").last();
-		await expect(badge).not.toHaveText(/^\d+$/);
-	});
-
 	test("moves between sections", async ({ page }) => {
 		await page.getByRole("link", { name: "Talks" }).click();
 
@@ -191,6 +172,109 @@ test.describe("Claiming a route", () => {
 		// Reserved so an event cannot shadow /b/account.
 		await field.fill("account");
 		await expect(page.getByText("reserved")).toBeVisible();
+	});
+});
+
+// Nothing seeds a ticket against the shared event, so a guest list read off it is empty
+// in CI. This block seeds the guests it asserts on.
+test.describe("Guest list", () => {
+	const TICKET_TYPE = "Guest List Ticket";
+	const ADD_ON = "Guest List T-Shirt";
+	const GUESTS = [
+		{ name: "Ada Lovelace", email: "ada@example.com" },
+		{ name: "Grace Hopper", email: "grace@example.com" },
+	];
+
+	let eventId: string;
+
+	test.beforeEach(async ({ page, request }) => {
+		const team = await ensureTestTeam(request);
+		const event = await callMethod<{ name: string }>(request, "buzz.api.events.create_event", {
+			event: {
+				team,
+				title: `Guest List Event ${Date.now()}`,
+				start_date: "2030-01-01",
+				start_time: "09:00:00",
+				end_time: "17:00:00",
+			},
+		});
+		eventId = String(event.name);
+
+		const ticketType = await createDoc<{ name: string }>(request, "Event Ticket Type", {
+			event: eventId,
+			title: TICKET_TYPE,
+			price: 0,
+			currency: "INR",
+			is_published: 1,
+		});
+		const addOn = await createDoc<{ name: string }>(request, "Ticket Add-on", {
+			event: eventId,
+			title: ADD_ON,
+			user_selects_option: 1,
+			options: ["Small", "Large"].join("\n"),
+			price: 0,
+			currency: "INR",
+		});
+
+		for (const [index, guest] of GUESTS.entries()) {
+			const ticket = await createDoc(request, "Event Ticket", {
+				event: eventId,
+				ticket_type: ticketType.name,
+				attendee_name: guest.name,
+				attendee_email: guest.email,
+				// Only the first guest holds one, so the badges belong to a row rather than
+				// to every row alike.
+				add_ons:
+					index === 0 ? [{ add_on: addOn.name, value: "Large", price: 0, currency: "INR" }] : [],
+			});
+			// A draft ticket belongs to a booking still being paid for; only a submitted
+			// one is somebody coming.
+			await callMethod(request, "frappe.client.submit", { doc: ticket });
+		}
+
+		await page.goto(`/b/manage/events/${eventId}/details`);
+	});
+
+	test("lists the event's guests", async ({ page }) => {
+		await page.getByRole("link", { name: "Guests" }).click();
+
+		await expect(page).toHaveURL(new RegExp(`/b/manage/events/${eventId}/guests$`));
+		await expect(page.getByRole("heading", { name: "Guest list" })).toBeVisible();
+		const rows = page.getByRole("list").getByRole("listitem");
+		await expect(rows).toHaveCount(GUESTS.length, { timeout: 15000 });
+
+		// The count is the number of rows under it, not a separate claim.
+		const registrations = Number(await page.getByText(/^\d+$/).first().textContent());
+		expect(registrations).toBe(GUESTS.length);
+		await expect(page.getByText(/Registrations (are open|have closed)/)).toBeVisible();
+
+		// Sorted by name, so Ada is first, and she is the one holding the add-on. Both the
+		// ticket type and the add-on are autonamed, so a docname here would read as a bare
+		// number.
+		await expect(rows.first()).toContainText(GUESTS[0].email);
+		await expect(rows.first()).toContainText(TICKET_TYPE);
+		await expect(rows.first()).toContainText(ADD_ON);
+		await expect(rows.last()).not.toContainText(ADD_ON);
+	});
+
+	test("narrows the guest list by search", async ({ page }) => {
+		await page.goto(`/b/manage/events/${eventId}/guests`);
+
+		const rows = page.getByRole("list").getByRole("listitem");
+		await expect(rows).toHaveCount(GUESTS.length, { timeout: 15000 });
+
+		const search = page.getByRole("textbox", { name: "Search guests" });
+		await search.fill(GUESTS[1].email);
+		await expect(rows).toHaveCount(1);
+		await expect(rows.first()).toContainText(GUESTS[1].email);
+
+		// By name as well as by email.
+		await search.fill("Ada");
+		await expect(rows).toHaveCount(1);
+		await expect(rows.first()).toContainText(GUESTS[0].email);
+
+		await search.fill("");
+		await expect(rows).toHaveCount(GUESTS.length);
 	});
 });
 


### PR DESCRIPTION
## What changed

The event workspace's second section: who is coming. **Guests** replaces the Attendees
placeholder in the event sidebar, and points at a real page at
`/manage/events/<id>/guests`.

- **The turnout** — how many have registered, and whether registrations are still open.
  Closed is the booking flow's own rule (`are_registrations_closed`), reused rather than
  restated: an explicit cutoff if the event sets one, otherwise the end of the event.
- **The guest list** — one row per submitted ticket: avatar, name, email beside the name,
  the add-ons that ticket holds as badges, and its ticket type. Search filters the list
  already loaded, so a keystroke costs nothing.

Only submitted tickets count. A draft belongs to a booking still being paid for, not to
somebody coming.

New endpoint, `buzz.api.events.get_event_guests` (GET). Read access is the bar, not write —
the list shows the team what the doctype already shows it, and it carries the event's title so
the header needs nothing from the write-gated `get_event`. Add-ons live in a child table a
plain list query cannot reach, which is what the endpoint is for.

Two things that bite, both covered by tests: `Event Ticket Type` and `Ticket Add-on` are
autonamed, so the link value alone is a docname nobody recognises (`18213`) — both are
resolved to titles, one batched query each. And an autonamed doctype comes back from
`get_all` with **integer** names while every link to it travels as a **string**, so the
title map is keyed by `str(name)`; without that it silently never matches.

No capacity bar, unlike the reference design: `create_event` gives every event a published
ticket type with no limit, so capacity resolves to "uncapped" on essentially every event and
the bar would never draw. Left out rather than shipped as decoration.

## Demo

<!-- Screenshot of the guest list goes here. -->
<img width="1440" height="900" alt="356-guest-list" src="https://github.com/user-attachments/assets/68ae112c-a5ca-4b6e-8b37-051794b95c10" />


## Testing

- `buzz.api.events.test_events` — 39 tests, 38 pass and 1 skipped (Zoom, pre-existing).
  10 are new: the count and list, a draft ticket excluded, add-ons carried through, the
  ticket type named rather than numbered, an empty event, registrations open and closed, a
  non-member refused, an unknown event, and the title reaching a member who cannot edit.
- `e2e/tests/manage-event.spec.ts` — 12 specs. The two new ones seed their own event,
  ticket type, add-on and two submitted tickets rather than reading off the shared event,
  which has ticket types but nobody holding one. They cover the count matching the row
  count, the add-on landing on the row that holds it, and search narrowing by both email
  and name.
- `yarn typecheck`, `yarn test:unit` (103 pass) and `yarn build` clean.

Known, not addressed here: one row per ticket, so somebody who booked six tickets under one
name appears six times. Grouping by person is a separate decision.

