### PR TITLE
fix(permissions): scope tickets and bookings by attendee, not row creator

### DIFF
--- a/buzz/api/tickets/services.py
+++ b/buzz/api/tickets/services.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 class TicketService:
-	"""Read or act on one Event Ticket on behalf of its attendee."""
+	"""Read or act on one Event Ticket on behalf of its attendee or whoever booked it."""
 
 	def __init__(self, ticket_id: str):
 		self.ticket_id = ticket_id
@@ -34,7 +34,9 @@ class TicketService:
 
 	def details(self) -> TicketDetailsResponse:
 		ticket = self.ticket
-		if frappe.session.user != "Administrator" and ticket.attendee_email != frappe.session.user:
+		# The read permission already covers attendee, booker and the event's team, so this
+		# page stays in step with the list the user opened it from.
+		if not frappe.has_permission("Event Ticket", "read", ticket):
 			TicketNotAccessible.throw()
 
 		event_id = ticket.event
@@ -97,7 +99,8 @@ class TicketService:
 			return None
 
 		booking = frappe.get_cached_doc("Event Booking", booking_id)
-		return booking if booking.owner == frappe.session.user else None
+		# A guest checkout runs as Administrator, so `user` is the buyer of record.
+		return booking if frappe.session.user in (booking.user, booking.owner) else None
 
 	def zoom_registration(self) -> dict:
 		registration_id = self.ticket.get("zoom_session_registration")

--- a/buzz/api/tickets/test_tickets.py
+++ b/buzz/api/tickets/test_tickets.py
@@ -199,6 +199,17 @@ class TestGetTicketDetails(TicketTestCase):
 
 		self.assertEqual(frappe.local.message_log[-1]["title"], "Not Permitted")
 
+	def test_booker_can_read_a_ticket_held_by_someone_else(self):
+		self.set_event_start(30)
+		booking = self.make_booking(user=OTHER_USER)
+		ticket = self.make_ticket(attendee_email="guest@example.com", booking=booking.name)
+		frappe.set_user(OTHER_USER)
+
+		details = get_ticket_details(ticket.name)
+
+		self.assertEqual(details.doc.name, ticket.name)
+		self.assertEqual(details.booking.name, booking.name)
+
 	def test_booking_is_withheld_from_an_attendee_who_did_not_book(self):
 		self.set_event_start(30)
 		booking = self.make_booking(user=OTHER_USER)

--- a/buzz/hooks.py
+++ b/buzz/hooks.py
@@ -198,11 +198,17 @@ after_migrate = "buzz.install.on_migrate"
 # 	"Event": "frappe.desk.doctype.event.event.has_permission",
 # }
 
+# Bookings and tickets are scoped to the person they name — the attendee, or the buyer —
+# rather than to whoever created the row, which is often neither of them.
 permission_query_conditions = {
+	"Event Booking": "buzz.permissions.owned_query_conditions",
+	"Event Ticket": "buzz.permissions.owned_query_conditions",
 	"Talk Proposal": "buzz.proposals.doctype.talk_proposal.talk_proposal.get_permission_query_conditions",
 }
 
 has_permission = {
+	"Event Booking": "buzz.permissions.owned_has_permission",
+	"Event Ticket": "buzz.permissions.owned_has_permission",
 	"Talk Proposal": "buzz.proposals.doctype.talk_proposal.talk_proposal.has_talk_proposal_permission",
 }
 

--- a/buzz/permissions.py
+++ b/buzz/permissions.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, BWH Studios and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.query_builder import Criterion
+
+# Roles that reach every row on these doctypes. Buzz User reaches only its own, which is
+# what the functions below work out; `if_owner` cannot, because it asks who created the row.
+PRIVILEGED_ROLES = frozenset({"System Manager", "Event Manager"})
+
+# The column naming who a row belongs to: a booking made on someone else's behalf, or a
+# guest checkout running as Administrator, leaves `owner` naming neither buyer nor attendee.
+IDENTITY_FIELDS = {"Event Booking": "user", "Event Ticket": "attendee_email"}
+
+
+def is_unrestricted(user: str) -> bool:
+	return user == "Administrator" or bool(PRIVILEGED_ROLES & set(frappe.get_roles(user)))
+
+
+def my_bookings(user: str):
+	booking = frappe.qb.DocType("Event Booking")
+	return (
+		frappe.qb.from_(booking).select(booking.name).where((booking.user == user) | (booking.owner == user))
+	)
+
+
+def belongs_to_user(doc, user: str) -> bool:
+	"""Whether `doc` names `user`, whether or not they are the one who created it."""
+	if doc.owner == user:
+		return True
+
+	if (identity_field := IDENTITY_FIELDS.get(doc.doctype)) and doc.get(identity_field) == user:
+		return True
+
+	# A ticket also belongs to whoever booked it, who is often not its attendee.
+	if doc.doctype == "Event Ticket" and doc.booking:
+		booking = frappe.db.get_value("Event Booking", doc.booking, ["user", "owner"], as_dict=True)
+		return bool(booking) and user in (booking.user, booking.owner)
+
+	return False
+
+
+def owned_query_conditions(user: str | None = None, doctype: str | None = None, **kwargs) -> Criterion | None:
+	user = user or frappe.session.user
+	if is_unrestricted(user):
+		return None
+
+	table = frappe.qb.DocType(doctype)
+	criterion = table.owner == user
+	if identity_field := IDENTITY_FIELDS.get(doctype):
+		criterion |= table[identity_field] == user
+	if doctype == "Event Ticket":
+		criterion |= table.booking.isin(my_bookings(user))
+
+	return criterion
+
+
+def owned_has_permission(doc, ptype: str = "read", user: str | None = None, **kwargs) -> bool:
+	user = user or frappe.session.user
+	return is_unrestricted(user) or belongs_to_user(doc, user)

--- a/buzz/test_permissions.py
+++ b/buzz/test_permissions.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, BWH Studios and contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.forms.test_forms import ensure_prompt_named_record
+from buzz.proposals.doctype.talk_proposal.test_talk_proposal import make_test_user
+
+ATTENDEE = "perm-attendee@example.com"
+BUYER = "perm-buyer@example.com"
+OUTSIDER = "perm-outsider@example.com"
+
+
+def create_event() -> str:
+	return (
+		frappe.get_doc(
+			{
+				"doctype": "Buzz Event",
+				"title": f"Perm Event {frappe.generate_hash(length=6)}",
+				"start_date": "2030-01-01",
+				"end_date": "2030-01-01",
+				"start_time": "10:00:00",
+				"end_time": "18:00:00",
+				"medium": "Online",
+				"category": ensure_prompt_named_record("Event Category", "Perm Category"),
+				"host": ensure_prompt_named_record("Event Host", "Perm Host"),
+				"is_published": 1,
+			}
+		)
+		.insert(ignore_permissions=True)
+		.name
+	)
+
+
+def create_ticket_type(event: str) -> str:
+	return (
+		frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": event,
+				"title": f"Type {frappe.generate_hash(length=6)}",
+				"price": 0,
+			}
+		)
+		.insert(ignore_permissions=True)
+		.name
+	)
+
+
+def create_booking(event: str, user: str, owner: str | None = None) -> str:
+	# Event Booking.validate prices the attendee rows, so it needs at least one.
+	booking = frappe.get_doc(
+		{
+			"doctype": "Event Booking",
+			"event": event,
+			"user": user,
+			"attendees": [
+				{"ticket_type": create_ticket_type(event), "first_name": "Attendee", "email": user}
+			],
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.set_value("Event Booking", booking.name, "owner", owner or user, update_modified=False)
+	return booking.name
+
+
+def create_ticket(
+	event: str, owner: str, attendee_email: str | None = None, booking: str | None = None
+) -> str:
+	ticket = frappe.get_doc(
+		{
+			"doctype": "Event Ticket",
+			"event": event,
+			"ticket_type": create_ticket_type(event),
+			"attendee_name": "Attendee",
+			"attendee_email": attendee_email or owner,
+			"booking": booking,
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.set_value("Event Ticket", ticket.name, "owner", owner, update_modified=False)
+	return ticket.name
+
+
+class TestOwnedPermissions(IntegrationTestCase):
+	"""Bookings and tickets belong to the person they name, not to whoever created the row."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.event = create_event()
+		for email in (ATTENDEE, BUYER, OUTSIDER):
+			make_test_user(email)
+
+	def setUp(self):
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def as_user(self, user: str):
+		frappe.set_user(user)
+
+	def test_attendee_lists_a_ticket_someone_else_created(self):
+		mine = create_ticket(self.event, owner=BUYER, attendee_email=ATTENDEE)
+
+		self.as_user(ATTENDEE)
+
+		self.assertIn(mine, frappe.get_list("Event Ticket", pluck="name"))
+
+	def test_booker_lists_a_ticket_held_by_someone_else(self):
+		booking = create_booking(self.event, user=BUYER)
+		theirs = create_ticket(
+			self.event, owner="Administrator", attendee_email="perm-guest@example.com", booking=booking
+		)
+
+		self.as_user(BUYER)
+
+		self.assertIn(theirs, frappe.get_list("Event Ticket", pluck="name"))
+
+	def test_an_unrelated_user_sees_neither_the_ticket_nor_the_booking(self):
+		booking = create_booking(self.event, user=BUYER)
+		by_attendee = create_ticket(self.event, owner=BUYER, attendee_email=ATTENDEE)
+		by_booking = create_ticket(self.event, owner=BUYER, attendee_email=ATTENDEE, booking=booking)
+
+		self.as_user(OUTSIDER)
+		tickets = frappe.get_list("Event Ticket", pluck="name")
+
+		self.assertNotIn(by_attendee, tickets)
+		self.assertNotIn(by_booking, tickets)
+		self.assertNotIn(booking, frappe.get_list("Event Booking", pluck="name"))
+
+	def test_an_unrelated_user_cannot_open_someone_elses_ticket(self):
+		theirs = create_ticket(self.event, owner=BUYER, attendee_email=ATTENDEE)
+
+		self.as_user(OUTSIDER)
+
+		with self.assertRaises(frappe.PermissionError):
+			frappe.get_doc("Event Ticket", theirs).check_permission("read")
+
+	def test_attendee_reads_but_cannot_write_their_ticket(self):
+		mine = create_ticket(self.event, owner=BUYER, attendee_email=ATTENDEE)
+
+		self.as_user(ATTENDEE)
+
+		self.assertTrue(frappe.has_permission("Event Ticket", "read", doc=mine))
+		self.assertFalse(frappe.has_permission("Event Ticket", "write", doc=mine))
+
+	def test_buyer_lists_a_guest_checkout_booking(self):
+		# Guest checkout runs as Administrator, so `owner` never names the buyer.
+		booking = create_booking(self.event, user=BUYER, owner="Administrator")
+
+		self.as_user(BUYER)
+
+		self.assertIn(booking, frappe.get_list("Event Booking", pluck="name"))
+
+	def test_buyer_writes_their_own_booking_but_nobody_elses(self):
+		mine = create_booking(self.event, user=BUYER, owner="Administrator")
+		theirs = create_booking(self.event, user=ATTENDEE)
+
+		self.as_user(BUYER)
+
+		self.assertTrue(frappe.has_permission("Event Booking", "write", doc=mine))
+		self.assertFalse(frappe.has_permission("Event Booking", "write", doc=theirs))
+
+	def test_nobody_deletes_a_booking_from_the_portal(self):
+		# Bookings are cancelled, never deleted — the role carries no delete at all, so this
+		# holds for the buyer's own row as much as for a stranger's.
+		mine = create_booking(self.event, user=BUYER)
+		guest_checkout = create_booking(self.event, user=BUYER, owner="Guest")
+		theirs = create_booking(self.event, user=ATTENDEE)
+
+		self.as_user(BUYER)
+
+		for booking in (mine, guest_checkout, theirs):
+			self.assertFalse(frappe.has_permission("Event Booking", "delete", doc=booking))
+			with self.assertRaises(frappe.PermissionError):
+				frappe.delete_doc("Event Booking", booking)
+
+	def test_an_event_manager_still_reads_every_row(self):
+		manager = make_test_user("perm-manager@example.com", roles=["Event Manager"])
+		theirs = create_ticket(self.event, owner=BUYER, attendee_email=ATTENDEE)
+
+		self.as_user(manager)
+
+		self.assertIn(theirs, frappe.get_list("Event Ticket", pluck="name"))
+		self.assertTrue(frappe.has_permission("Event Ticket", "read", doc=theirs))

--- a/buzz/ticketing/doctype/event_booking/event_booking.json
+++ b/buzz/ticketing/doctype/event_booking/event_booking.json
@@ -308,7 +308,7 @@
    "link_fieldname": "booking"
   }
  ],
- "modified": "2026-08-11 03:19:31.303090",
+ "modified": "2026-08-17 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "Event Booking",
@@ -347,10 +347,8 @@
   },
   {
    "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
-   "if_owner": 1,
    "print": 1,
    "read": 1,
    "report": 1,

--- a/buzz/ticketing/doctype/event_ticket/event_ticket.json
+++ b/buzz/ticketing/doctype/event_ticket/event_ticket.json
@@ -142,7 +142,7 @@
    "link_fieldname": "ticket"
   }
  ],
- "modified": "2025-12-30 13:25:40.498434",
+ "modified": "2026-08-17 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "Event Ticket",
@@ -181,7 +181,6 @@
   {
    "email": 1,
    "export": 1,
-   "if_owner": 1,
    "print": 1,
    "read": 1,
    "report": 1,

--- a/dashboard/src/pages/TicketsList.vue
+++ b/dashboard/src/pages/TicketsList.vue
@@ -40,7 +40,6 @@
 <script setup lang="ts">
 import { ListView, useList } from "frappe-ui";
 import { dayjsLocal } from "frappe-ui";
-import { session } from "../data/session";
 
 const columns = [
 	{ label: __("Attendee Name"), key: "attendee_name" },
@@ -62,8 +61,8 @@ const tickets = useList({
 		"event.start_date",
 		"creation",
 	],
+	// No attendee filter: the permission query already scopes this to the user's tickets.
 	filters: {
-		attendee_email: session.user,
 		docstatus: ["!=", 0],
 	},
 	orderBy: "creation desc",


### PR DESCRIPTION
Manual backport of #358 to `main`.

The Backport action failed on this one and it is not the action's fault. On `develop` the fix lives inside `buzz/permissions.py`, the team-multi-tenancy module from #312, which `main` does not have. The cherry-pick hit `CONFLICT (modify/delete): buzz/permissions.py deleted in HEAD`, so there was nothing to auto-resolve. Everything else in the commit applied cleanly.

This reimplements the same rule against `main`'s permission model instead.

## The bug

My Tickets showed nothing to the people the tickets belong to. `if_owner` on the Buzz User read permission decides "mine" by `owner` — whoever created the row. A ticket created by the booker, or a guest-checkout booking created as Administrator, names neither the attendee nor the buyer, so both were invisible.

## What changed

- `if_owner` comes off the Buzz User read permission on Event Ticket and Event Booking. Frappe ANDs it onto every query, so no attendee clause could ever have passed alongside it.
- New `buzz/permissions.py` with a `permission_query_conditions` / `has_permission` pair for both doctypes. Matches `owner`, plus the column naming the person (`Event Ticket.attendee_email`, `Event Booking.user`), plus tickets belonging to a booking the user made. System Manager, Event Manager and Administrator are unaffected — they short-circuit to full access.
- `TicketService.details` asked its own attendee-only question and would have rejected the rows the list now shows. It asks the read permission instead.
- `booking_owned_by_user` compared `owner`, so a guest-checkout buyer never got their own booking back.
- Delete comes off the Buzz User role on Event Booking. Bookings are cancelled, never deleted; with `if_owner` gone the grant would have let a buyer delete their own draft booking and its child rows through the document API.
- `TicketsList.vue` drops its `attendee_email` filter — the permission query does that now, and the filter would have hidden tickets the user booked for others.

## Not the same file as develop

`main`'s `buzz/permissions.py` is a stripped module: no teams, no `Buzz Team Membership`, just the ownership question. Function names match develop's (`belongs_to_user`, `my_bookings`, `IDENTITY_FIELDS`) so that whenever the teams stack lands on `main`, develop's version overwrites this one rather than merging against it.

`derived_has_permission`'s unstamped-event carve-out from #358 has no counterpart here — there are no team-stamped events on `main`.

## Verified

`bench --site buzz.localhost run-tests` on the ticketing, tickets API, guest booking, check-in, sponsorships and talk proposal modules, plus the 9 new tests in `buzz/test_permissions.py`. All green.