### PR TITLE
ci: fetch payments by URL instead of by bare name

### DIFF
--- a/.github/actions/setup-bench/action.yml
+++ b/.github/actions/setup-bench/action.yml
@@ -82,7 +82,7 @@ runs:
         EXTRA_APP_URL: ${{ inputs.extra-app-url }}
       run: |
         # buzz lists frappe/payments in required_apps, so it must precede install-app.
-        bench get-app --skip-assets payments
+        bench get-app --skip-assets https://github.com/frappe/payments
 
         if [ -n "$EXTRA_APP_URL" ]; then
           bench get-app --skip-assets "$EXTRA_APP_URL"


### PR DESCRIPTION
`bench get-app payments` doesn't just clone a URL — a bare app name sends bench through `find_org()`, which asks api.github.com whether `frappe/payments` or `erpnext/payments` exists. The runners make that call anonymously and share an IP pool, so a rate-limit 403 comes back looking identical to a missing repo:

```
ERROR: payments not found under frappe or erpnext GitHub accounts
bench.exceptions.InvalidRemoteException: payments not found under frappe or erpnext GitHub accounts
```

That kills `Setup Bench` before a single test runs, and it hits whichever job draws the unlucky minute — one branch failed while four sibling branches queued in the same minute went green. `frappe/payments` is alive and unarchived the whole time.

Passing the full URL skips `find_org` and goes straight to the clone bench would have run anyway. Same app directory, same resulting bench.

Not changed:
- `bench init` already defaults to `https://github.com/frappe/frappe.git`, so it never took this path.
- `zoom_integration` and `buzz` were already fetched by URL and path.
- `--skip-assets` stays as-is. It only skips the bundler pass, and the jobs that need built assets get them from the separate `bench build`.

This is a reliability fix, not a speed one: the lookup it removes is ~0.4s of a ~99s `Setup Bench`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)