### PR TITLE
feat(ci): Add UI demo check workflow and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What changed
+
+<!-- A short description of the change and why it is needed. -->
+
+## Demo
+
+<!--
+Required for UI changes (anything under `dashboard/src/`): drag in a screenshot
+or a short screen recording. Before/after images are ideal for visual tweaks.
+Apply the `skip-demo` label if a visual makes no sense here.
+-->
+
+## Testing
+
+<!-- How you verified this: tests added, manual steps, e2e run. -->

--- a/.github/workflows/pr-demo-check.yml
+++ b/.github/workflows/pr-demo-check.yml
@@ -97,7 +97,7 @@ jobs:
             if (skipped.length) return pass(`skipped via the \`${skipped[0]}\` label`);
 
             const uiFiles = await changedUiFiles();
-            if (!uiFiles.length) return core.info('No UI changes, skipping.');
+            if (!uiFiles.length) return pass('no UI changes');
             if (hasMedia(pr.body)) return pass('a screenshot or demo is attached');
 
             await stickyComment([

--- a/.github/workflows/pr-demo-check.yml
+++ b/.github/workflows/pr-demo-check.yml
@@ -31,7 +31,7 @@ jobs:
       # The path test happens here instead, and exits green when no UI file moved.
       - name: Require a screenshot or demo on UI changes
         if: github.event_name != 'merge_group'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const UI_PATH = /^dashboard\/src\//;

--- a/.github/workflows/pr-demo-check.yml
+++ b/.github/workflows/pr-demo-check.yml
@@ -1,0 +1,112 @@
+name: UI Demo Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
+  # Report on the queue commit (the step below no-ops there).
+  merge_group:
+
+concurrency:
+  group: pr-demo-check-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  require-demo:
+    runs-on: ubuntu-slim
+    steps:
+      # Deliberately no workflow-level `paths:` filter: a filtered workflow never
+      # reports on non-UI PRs, which leaves a required check pending forever.
+      # The path test happens here instead, and exits green when no UI file moved.
+      - name: Require a screenshot or demo on UI changes
+        if: github.event_name != 'merge_group'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const UI_PATH = /^dashboard\/src\//;
+            const SKIP_LABELS = ['skip-demo', 'backport'];
+            const MEDIA = [
+              /!\[[^\]]*\]\([^)]+\)/,
+              /<(img|video)\b/i,
+              /https:\/\/github\.com\/user-attachments\/assets\/\S+/i,
+              /https?:\/\/\S+\.(png|jpe?g|gif|webp|mp4|mov|webm)\b/i,
+            ];
+            const MARKER = '<!-- ui-demo-check -->';
+
+            const pull = { owner: context.repo.owner, repo: context.repo.repo,
+                           pull_number: context.payload.pull_request.number };
+
+            // The event payload body is stale on `synchronize`, so read it fresh.
+            const { data: pr } = await github.rest.pulls.get(pull);
+
+            const hasMedia = (body) => {
+              const text = (body || '').replace(/<!--[\s\S]*?-->/g, '');
+              return MEDIA.some((pattern) => pattern.test(text));
+            };
+
+            const changedUiFiles = async () => {
+              const files = await github.paginate(github.rest.pulls.listFiles, pull);
+              return files.filter((file) => UI_PATH.test(file.filename));
+            };
+
+            const findComment = async () => {
+              const comments = await github.paginate(github.rest.issues.listComments,
+                { ...context.repo, issue_number: pull.pull_number });
+              return comments.find((comment) => (comment.body || '').includes(MARKER));
+            };
+
+            // Only ever keep one comment: created on failure, flipped in place on
+            // a later pass so a fixed pull request does not keep a red comment.
+            const stickyComment = async (body, { createIfMissing }) => {
+              const existing = await findComment();
+              const payload = { ...context.repo, body: `${MARKER}\n${body}` };
+              if (existing) {
+                await github.rest.issues.updateComment({ ...payload, comment_id: existing.id });
+              } else if (createIfMissing) {
+                await github.rest.issues.createComment({ ...payload, issue_number: pull.pull_number });
+              }
+            };
+
+            const pass = async (reason) => {
+              core.info(`Demo check passed: ${reason}`);
+              await stickyComment(`✅ **UI Demo Check** — ${reason}.`, { createIfMissing: false });
+            };
+
+            const labels = pr.labels.map((label) => label.name);
+            const skipped = SKIP_LABELS.filter((label) => labels.includes(label));
+
+            if (pr.draft) return core.info('Draft pull request, skipping.');
+            if (skipped.length) return pass(`skipped via the \`${skipped[0]}\` label`);
+
+            const uiFiles = await changedUiFiles();
+            if (!uiFiles.length) return core.info('No UI changes, skipping.');
+            if (hasMedia(pr.body)) return pass('a screenshot or demo is attached');
+
+            await stickyComment([
+              '### ❌ UI Demo Check failed',
+              '',
+              `This pull request changes the UI (${uiFiles.length} file(s) under \`dashboard/src/\`),`,
+              'but the description has no screenshot or demo. Reviewers should be able to see the',
+              'change without checking out the branch.',
+              '',
+              '### 🛠️ How to fix',
+              '',
+              '- **Edit the description** and drag a screenshot or a short screen recording into it.',
+              '  Before/after images are ideal for visual tweaks.',
+              '- Or apply the **`skip-demo`** label if a visual makes no sense here',
+              '  (pure refactor, copy change, dependency bump).',
+              '',
+              'Either one re-runs this check automatically.',
+            ].join('\n'), { createIfMissing: true });
+
+            core.setFailed('UI changes need a screenshot or demo in the pull request description.');

--- a/.github/workflows/pr-demo-check.yml
+++ b/.github/workflows/pr-demo-check.yml
@@ -10,6 +10,7 @@ on:
       - labeled
       - unlabeled
       - ready_for_review
+      - converted_to_draft
   # Report on the queue commit (the step below no-ops there).
   merge_group:
 
@@ -56,7 +57,10 @@ jobs:
 
             const changedUiFiles = async () => {
               const files = await github.paginate(github.rest.pulls.listFiles, pull);
-              return files.filter((file) => UI_PATH.test(file.filename));
+              // A rename reports the destination in `filename` and the origin in
+              // `previous_filename`; moving a file out of the tree still counts.
+              return files.filter((file) =>
+                UI_PATH.test(file.filename) || UI_PATH.test(file.previous_filename || ''));
             };
 
             const findComment = async () => {
@@ -85,7 +89,11 @@ jobs:
             const labels = pr.labels.map((label) => label.name);
             const skipped = SKIP_LABELS.filter((label) => labels.includes(label));
 
-            if (pr.draft) return core.info('Draft pull request, skipping.');
+            if (pr.draft) {
+              core.info('Draft pull request, skipping.');
+              return stickyComment('⏸️ **UI Demo Check** — paused while this is a draft.',
+                { createIfMissing: false });
+            }
             if (skipped.length) return pass(`skipped via the \`${skipped[0]}\` label`);
 
             const uiFiles = await changedUiFiles();


### PR DESCRIPTION
## What changed

Added automated enforcement for UI demo requirements in pull requests. This includes a GitHub Actions workflow that validates UI changes have accompanying screenshots or demos, and a pull request template to guide contributors.

## Key changes

- **UI Demo Check workflow** (`.github/workflows/pr-demo-check.yml`): Automatically validates that pull requests modifying files under `dashboard/src/` include a screenshot or demo in the description. The check:
  - Runs on PR open, reopen, synchronize, edit, label changes, and ready-for-review events
  - Skips draft PRs and PRs with `skip-demo` or `backport` labels
  - Detects media (images, videos, attachments) in PR descriptions
  - Posts a sticky comment that updates in place as the PR is fixed
  - Provides clear guidance on how to resolve failures

- **Pull request template** (`.github/pull_request_template.md`): Provides structure for contributors with sections for:
  - What changed (description and rationale)
  - Demo (required for UI changes, with guidance on skip-demo label)
  - Testing (verification approach)

## Implementation details

The workflow uses GitHub Script to:
- Parse PR description and detect media patterns (markdown images, HTML tags, GitHub asset URLs, direct image/video links)
- List changed files and filter for UI paths (`dashboard/src/`)
- Manage a single sticky comment that persists across PR updates
- Exit cleanly (no-op) for non-UI changes to avoid blocking required checks

https://claude.ai/code/session_015HZvcqjoDDcuDjwjZDrkrL