### PR TITLE
feat(refunds): sync a booking's refunds from Razorpay

### DIFF
--- a/buzz/payments.py
+++ b/buzz/payments.py
@@ -4,6 +4,8 @@ from frappe.utils import flt
 from payments.utils import get_payment_gateway_controller
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
+from buzz.ticketing.doctype.event_booking_refund.event_booking_refund import record_gateway_refund
+
 
 class RefundNotification(BaseModel):
 	"""The refund a Razorpay `refund.processed` or `refund.failed` webhook carries.
@@ -209,21 +211,13 @@ def handle_refund_notification(doctype: str, docname: str) -> None:
 		return
 
 	# The same event arrives more than once, so the refund is keyed on its id.
-	existing = frappe.db.exists("Event Booking Refund", {"refund_id": notification.refund_id})
-	if existing:
-		refund_doc = frappe.get_doc("Event Booking Refund", existing)
-	else:
-		refund_doc = frappe.get_doc(
-			{
-				"doctype": "Event Booking Refund",
-				"booking": payment.reference_docname,
-				"payment": payment.name,
-				"refund_id": notification.refund_id,
-				"currency": frappe.db.get_value("Event Booking", payment.reference_docname, "currency"),
-			}
-		).insert(ignore_permissions=True)
-
-	refund_doc.apply_gateway_status(gateway_status=notification.status, amount=notification.amount)
+	record_gateway_refund(
+		booking=payment.reference_docname,
+		payment=payment.name,
+		refund_id=notification.refund_id,
+		status=notification.status,
+		amount=notification.amount,
+	)
 
 	frappe.db.set_value(
 		doctype,

--- a/buzz/ticketing/doctype/event_booking/event_booking.js
+++ b/buzz/ticketing/doctype/event_booking/event_booking.js
@@ -33,10 +33,17 @@ frappe.ui.form.on("Event Booking", {
 		if (
 			frappe.user.has_role("System Manager") &&
 			frm.doc.docstatus === 1 &&
-			frm.doc.payment_status === "Paid" &&
-			frm.doc.refund_status !== "Refunded"
+			frm.doc.payment_status === "Paid"
 		) {
-			frm.add_custom_button(__("Issue Refund"), () => showRefundDialog(frm), __("Actions"));
+			if (frm.doc.refund_status !== "Refunded") {
+				frm.add_custom_button(
+					__("Issue Refund"),
+					() => showRefundDialog(frm),
+					__("Refunds")
+				);
+			}
+
+			frm.add_custom_button(__("Sync Refund Status"), () => syncRefunds(frm), __("Refunds"));
 		}
 
 		renderRefunds(frm);
@@ -115,6 +122,22 @@ async function renderRefunds(frm) {
 			</thead>
 			<tbody>${rows}</tbody>
 		</table>`);
+}
+
+async function syncRefunds(frm) {
+	const { message } = await frm.call("sync_refunds");
+
+	frappe.show_alert({
+		message: message.refunds
+			? __("Razorpay has {0} refund(s) on this payment, {1} new here.", [
+					message.refunds,
+					message.created,
+			  ])
+			: __("Razorpay has no refunds on this payment."),
+		indicator: "blue",
+	});
+
+	frm.reload_doc();
 }
 
 async function showRefundDialog(frm) {

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -14,6 +14,7 @@ from buzz.permissions import has_team_access
 from buzz.ticketing.doctype.event_booking_refund.event_booking_refund import (
 	get_committed_refunds,
 	get_committed_tickets,
+	record_gateway_refund,
 )
 
 RAZORPAY = "Razorpay"
@@ -480,6 +481,34 @@ class EventBooking(Document):
 		self.set_refund_status()
 
 		return self.refund_status
+
+	@frappe.whitelist()
+	def sync_refunds(self) -> dict:
+		"""Reconcile this booking's refunds against what Razorpay actually holds."""
+		frappe.only_for("System Manager")
+
+		payment = self.get_received_payment()
+		if payment.payment_gateway != RAZORPAY:
+			frappe.throw(_("Refunds are only supported for Razorpay at the moment"))
+
+		# Razorpay lists the newest refund first, and each one recorded moves what
+		# is left to refund, so they are applied in the order they were raised.
+		refunds = list(reversed(get_controller(payment.payment_gateway).fetch_refunds(payment.payment_id)))
+
+		return {
+			"refunds": len(refunds),
+			"created": sum(self.record_refund(payment, refund) for refund in refunds),
+		}
+
+	def record_refund(self, payment, gateway_refund: dict) -> bool:
+		"""Record one gateway refund against this booking. True when it was new."""
+		return record_gateway_refund(
+			booking=self.name,
+			payment=payment.name,
+			refund_id=gateway_refund.get("id"),
+			status=gateway_refund.get("status"),
+			amount=flt(gateway_refund.get("amount")) / 100,
+		)
 
 	def validate_refund(self, amount: float, tickets: list[str] | None = None) -> None:
 		summary = self.get_refund_summary()

--- a/buzz/ticketing/doctype/event_booking/test_event_booking_refund.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking_refund.py
@@ -684,6 +684,39 @@ class TestSyncRefunds(BookingRefundTestCase):
 		self.assertEqual(self.refunds()[0].status, "Failed")
 		self.assertEqual(self.booking.refunded_amount, 0)
 
+	def test_a_refund_the_webhook_recorded_is_not_duplicated_by_a_sync(self):
+		log = frappe.get_doc(
+			{
+				"doctype": "Integration Request",
+				"integration_request_service": "Razorpay",
+				"request_description": "Refund Notification",
+				"is_remote_request": 1,
+				"status": "Queued",
+				"data": frappe.as_json(
+					{
+						"payload": {
+							"refund": {
+								"entity": {
+									"id": self.refund_id(),
+									"status": "processed",
+									"amount": int(CHARGED_PER_TICKET * 100),
+									"payment_id": "pay_123",
+								}
+							}
+						}
+					}
+				),
+			}
+		).insert(ignore_permissions=True)
+		with patch("frappe.sendmail"):
+			handle_refund_notification("Integration Request", log.name)
+
+		result = self.sync(self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET))
+
+		self.assertEqual(result, {"refunds": 1, "created": 0})
+		self.assertEqual(len(self.refunds()), 1)
+		self.assertEqual(self.booking.refunded_amount, CHARGED_PER_TICKET)
+
 	def test_syncing_twice_does_not_count_the_same_refund_twice(self):
 		refund = self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET)
 
@@ -703,6 +736,21 @@ class TestSyncRefunds(BookingRefundTestCase):
 			[row.ticket for row in self.refunds()[0].tickets],
 			[tickets[1]["ticket"]],
 		)
+
+	def test_two_refunds_in_one_batch_cancel_the_tickets_once_they_cover_the_total(self):
+		# Neither half covers the booking on its own; the second one, seeing the
+		# first already recorded, is what pays back the last of it.
+		self.sync(
+			self.gateway_refund(self.refund_id("1"), "processed", CHARGED_PER_TICKET),
+			self.gateway_refund(self.refund_id("2"), "processed", CHARGED_PER_TICKET),
+		)
+
+		refunds = self.refunds()
+		self.assertEqual(len(refunds), 2)
+		self.assertEqual(refunds[0].tickets, [])
+		self.assertEqual(len(refunds[1].tickets), 2)
+		self.assertEqual(self.booking.refund_status, "Refunded")
+		self.assertEqual([request.docstatus for request in self.cancellation_requests()], [1])
 
 	def test_sync_is_refused_when_the_gateway_is_not_razorpay(self):
 		frappe.db.set_value(

--- a/buzz/ticketing/doctype/event_booking/test_event_booking_refund.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking_refund.py
@@ -308,6 +308,26 @@ class TestRefundNotification(BookingRefundTestCase):
 		self.assertEqual(self.booking.refund_status, "Partially Refunded")
 		self.assertEqual(self.booking.refunded_amount, CHARGED_PER_TICKET)
 
+	def test_a_full_refund_buzz_never_raised_cancels_every_remaining_ticket(self):
+		# Raised on the Razorpay dashboard: the webhook is the first Buzz hears of
+		# it, and it carries no tickets.
+		self.notify(self.refund_id("1"), "processed", self.booking.total_amount)
+
+		self.assertEqual(self.booking.refund_status, "Refunded")
+		self.assertEqual(len(self.refunds()[0].tickets), 2)
+		self.assertEqual(
+			frappe.db.get_value(
+				"Ticket Cancellation Request", self.refunds()[0].cancellation_request, "docstatus"
+			),
+			1,
+		)
+
+	def test_a_partial_refund_buzz_never_raised_cancels_nothing(self):
+		self.notify(self.refund_id("1"), "processed", CHARGED_PER_TICKET)
+
+		self.assertEqual(self.refunds()[0].tickets, [])
+		self.assertFalse(frappe.db.exists("Ticket Cancellation Request", {"booking": self.booking.name}))
+
 	def test_the_same_event_arriving_twice_is_not_counted_twice(self):
 		self.initiate(self.refund_id("1"), CHARGED_PER_TICKET)
 
@@ -554,3 +574,150 @@ class TestRefundCeiling(IntegrationTestCase):
 		self.booking.reload()
 
 		self.assertEqual(len(self.booking.get_refund_summary()["tickets"]), 2)
+
+
+class TestSyncRefunds(BookingRefundTestCase):
+	def setUp(self):
+		super().setUp()
+		self.make_payment()
+
+	def gateway_refund(self, refund_id: str, status: str, amount: float) -> dict:
+		return {"id": refund_id, "status": status, "amount": int(amount * 100)}
+
+	def sync(self, *gateway_refunds: dict) -> dict:
+		client = MagicMock()
+		client.fetch_refunds.return_value = list(gateway_refunds)
+
+		with (
+			patch("buzz.ticketing.doctype.event_booking.event_booking.get_controller", return_value=client),
+			patch("frappe.sendmail"),
+		):
+			result = self.booking.sync_refunds()
+
+		self.booking.reload()
+		return result
+
+	def initiate(self, refund_id: str, amount: float, tickets: list[str] | None = None) -> None:
+		client = MagicMock()
+		client.refund_payment.return_value = {
+			"id": refund_id,
+			"status": "pending",
+			"amount": int(amount * 100),
+		}
+
+		with patch("buzz.ticketing.doctype.event_booking.event_booking.get_controller", return_value=client):
+			self.booking.refund(amount=amount, tickets=tickets)
+
+		self.booking.reload()
+
+	def cancellation_requests(self) -> list:
+		return frappe.get_all(
+			"Ticket Cancellation Request",
+			filters={"booking": self.booking.name},
+			fields=["name", "docstatus"],
+		)
+
+	def test_a_refund_raised_outside_buzz_is_recorded(self):
+		result = self.sync(self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET))
+
+		self.assertEqual(result, {"refunds": 1, "created": 1})
+		self.assertEqual(len(self.refunds()), 1)
+		self.assertEqual(self.refunds()[0].status, "Processed")
+		self.assertEqual(self.booking.refunded_amount, CHARGED_PER_TICKET)
+		self.assertEqual(self.booking.refund_status, "Partially Refunded")
+
+	def test_a_payment_with_no_refunds_records_nothing(self):
+		result = self.sync()
+
+		self.assertEqual(result, {"refunds": 0, "created": 0})
+		self.assertEqual(self.refunds(), [])
+		self.assertEqual(self.booking.refund_status, "")
+
+	def test_a_full_refund_raised_outside_buzz_cancels_every_remaining_ticket(self):
+		self.sync(self.gateway_refund(self.refund_id(), "processed", self.booking.total_amount))
+
+		self.assertEqual(self.booking.refund_status, "Refunded")
+		self.assertEqual(len(self.refunds()[0].tickets), 2)
+		self.assertEqual([request.docstatus for request in self.cancellation_requests()], [1])
+
+	def test_a_partial_refund_raised_outside_buzz_cancels_nothing(self):
+		self.sync(self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET))
+
+		self.assertEqual(self.refunds()[0].tickets, [])
+		self.assertEqual(self.cancellation_requests(), [])
+
+	def test_a_refund_the_gateway_still_calls_pending_is_initiated(self):
+		self.sync(self.gateway_refund(self.refund_id(), "pending", self.booking.total_amount))
+
+		self.assertEqual(self.refunds()[0].status, "Initiated")
+		self.assertEqual(self.booking.refund_status, "Refund Initiated")
+		self.assertEqual(self.booking.refunded_amount, 0)
+		self.assertEqual(self.cancellation_requests(), [])
+
+	def test_a_refund_buzz_already_holds_is_updated_not_duplicated(self):
+		ticket = self.booking.get_refund_summary()["tickets"][0]["ticket"]
+		self.initiate(self.refund_id(), CHARGED_PER_TICKET, tickets=[ticket])
+
+		result = self.sync(self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET))
+
+		self.assertEqual(result, {"refunds": 1, "created": 0})
+		self.assertEqual(len(self.refunds()), 1)
+		self.assertEqual(self.refunds()[0].status, "Processed")
+		self.assertEqual([row.ticket for row in self.refunds()[0].tickets], [ticket])
+		self.assertEqual(self.booking.refunded_amount, CHARGED_PER_TICKET)
+
+	def test_a_settled_refund_is_not_knocked_back_by_a_stale_pending(self):
+		self.sync(self.gateway_refund(self.refund_id(), "processed", self.booking.total_amount))
+
+		self.sync(self.gateway_refund(self.refund_id(), "pending", self.booking.total_amount))
+
+		self.assertEqual(self.refunds()[0].status, "Processed")
+		self.assertEqual(self.booking.refund_status, "Refunded")
+		self.assertEqual(self.booking.refunded_amount, self.booking.total_amount)
+		self.assertEqual(len(self.cancellation_requests()), 1)
+
+	def test_a_failed_refund_is_not_revived_by_a_later_sighting(self):
+		self.sync(self.gateway_refund(self.refund_id(), "failed", CHARGED_PER_TICKET))
+
+		self.sync(self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET))
+
+		self.assertEqual(self.refunds()[0].status, "Failed")
+		self.assertEqual(self.booking.refunded_amount, 0)
+
+	def test_syncing_twice_does_not_count_the_same_refund_twice(self):
+		refund = self.gateway_refund(self.refund_id(), "processed", CHARGED_PER_TICKET)
+
+		self.sync(refund)
+		self.sync(refund)
+
+		self.assertEqual(len(self.refunds()), 1)
+		self.assertEqual(self.booking.refunded_amount, CHARGED_PER_TICKET)
+
+	def test_a_checked_in_ticket_is_never_cancelled_by_a_synced_refund(self):
+		tickets = self.booking.get_refund_summary()["tickets"]
+		self.check_in(tickets[0]["ticket"])
+
+		self.sync(self.gateway_refund(self.refund_id(), "processed", self.booking.total_amount))
+
+		self.assertEqual(
+			[row.ticket for row in self.refunds()[0].tickets],
+			[tickets[1]["ticket"]],
+		)
+
+	def test_sync_is_refused_when_the_gateway_is_not_razorpay(self):
+		frappe.db.set_value(
+			"Event Payment",
+			{"reference_docname": self.booking.name},
+			"payment_gateway",
+			"PayPal",
+		)
+
+		with self.assertRaises(frappe.ValidationError) as raised:
+			self.booking.sync_refunds()
+
+		self.assertIn("Razorpay", str(raised.exception))
+
+	def test_sync_is_refused_without_a_received_payment(self):
+		frappe.db.set_value("Event Payment", {"reference_docname": self.booking.name}, "payment_received", 0)
+
+		self.assertRaises(frappe.ValidationError, self.booking.sync_refunds)

--- a/buzz/ticketing/doctype/event_booking_refund/event_booking_refund.py
+++ b/buzz/ticketing/doctype/event_booking_refund/event_booking_refund.py
@@ -93,6 +93,11 @@ def record_gateway_refund(
 	Used for refunds the gateway reports, from the webhook or a sync — never for
 	one raised from the Desk, which records the tickets an operator picked.
 	"""
+	# The webhook job and a Desk sync can both be recording refunds on this
+	# booking. Serialising them here is what lets the reads below see every
+	# refund that came before, rather than a picture from an instant ago.
+	frappe.db.get_value("Event Booking", booking, "name", for_update=True)
+
 	existing = frappe.db.exists("Event Booking Refund", {"refund_id": refund_id})
 	if existing:
 		refund = frappe.get_doc("Event Booking Refund", existing)

--- a/buzz/ticketing/doctype/event_booking_refund/event_booking_refund.py
+++ b/buzz/ticketing/doctype/event_booking_refund/event_booking_refund.py
@@ -9,6 +9,11 @@ from frappe.utils import flt
 # A refund that the gateway has not rejected still holds money and tickets.
 COMMITTED_STATUSES = ("Initiated", "Processed")
 
+# What the gateway settled on. Anything else is still in flight.
+FINAL_STATUSES = ("Processed", "Failed")
+
+GATEWAY_STATUSES = {"processed": "Processed", "failed": "Failed"}
+
 
 class EventBookingRefund(Document):
 	# begin: auto-generated types
@@ -35,8 +40,13 @@ class EventBookingRefund(Document):
 
 	def apply_gateway_status(self, gateway_status: str, amount: float) -> None:
 		"""Record what the gateway settled on this refund."""
+		# A settled refund does not un-settle: a sync can read a stale `pending`,
+		# or arrive behind the webhook that already recorded the outcome.
+		if self.status in FINAL_STATUSES:
+			return
+
 		self.amount = flt(amount)
-		self.status = "Failed" if gateway_status == "failed" else "Processed"
+		self.status = GATEWAY_STATUSES.get(gateway_status, "Initiated")
 
 		# Runs as Guest out of the webhook job; the signature already authenticated it.
 		self.flags.ignore_permissions = True
@@ -73,6 +83,48 @@ class EventBookingRefund(Document):
 
 	def on_update(self):
 		frappe.get_doc("Event Booking", self.booking).set_refund_status()
+
+
+def record_gateway_refund(
+	booking: str, payment: str | None, refund_id: str, status: str, amount: float
+) -> bool:
+	"""Create or update the refund `refund_id` names. True when it was new.
+
+	Used for refunds the gateway reports, from the webhook or a sync — never for
+	one raised from the Desk, which records the tickets an operator picked.
+	"""
+	existing = frappe.db.exists("Event Booking Refund", {"refund_id": refund_id})
+	if existing:
+		refund = frappe.get_doc("Event Booking Refund", existing)
+	else:
+		refund = frappe.get_doc(
+			{
+				"doctype": "Event Booking Refund",
+				"booking": booking,
+				"payment": payment,
+				"refund_id": refund_id,
+				"currency": frappe.db.get_value("Event Booking", booking, "currency"),
+				"tickets": [{"ticket": ticket} for ticket in tickets_a_refund_covers(booking, amount)],
+			}
+		).insert(ignore_permissions=True)
+
+	refund.apply_gateway_status(gateway_status=status, amount=amount)
+
+	return not existing
+
+
+def tickets_a_refund_covers(booking: str, amount: float) -> list[str]:
+	"""The tickets a refund raised outside Buzz pays back for: what is left, or nothing."""
+	# Read before the refund is recorded: `remaining` is already net of every
+	# refund the booking holds, so a refund counts itself out once it is stored.
+	doc = frappe.get_doc("Event Booking", booking)
+	summary = doc.get_refund_summary()
+	precision = doc.precision("total_amount")
+
+	if flt(amount, precision) < flt(summary["remaining"], precision):
+		return []
+
+	return [ticket["ticket"] for ticket in summary["tickets"]]
 
 
 def get_committed_refunds(booking: str) -> list[frappe._dict]:


### PR DESCRIPTION
The refund webhook was the only path that settled a refund. A missing webhook secret, a dropped delivery, or a refund raised straight on the Razorpay dashboard left the booking showing stale money and live tickets, with nothing in the Desk to correct it.

### Changed

- **`Event Booking.sync_refunds()`** — asks Razorpay what refunds it holds against the booking's payment and records them. System Manager, Razorpay only, same guards as `refund`. Applies them oldest-first, since each one recorded moves what is left to refund.
- **Desk buttons** — group renamed `Actions` → `Refunds`; `Sync Refund Status` added beside `Issue Refund`. Sync shows even on a fully refunded booking, since discovering an unknown refund is the point.
- **One upsert for gateway refunds** — `record_gateway_refund()`, keyed on `refund_id`, now serves both the webhook and the sync. A refund is never duplicated, and a refund raised outside Buzz picks its tickets the same way whichever path sees it first: it cancels every remaining ticket when it covers what is still owed, nothing when it is partial. Previously a webhook-delivered full refund cancelled nothing at all — that is the bug this closes, not just the missing button.
- **Status is monotonic** — `Processed` and `Failed` are final, so a sync reading a stale `pending`, or landing behind the webhook, is a no-op. `pending` maps to `Initiated`; it used to be read as `Processed`, which only stayed harmless because the webhook never sends it.

### Not changed

`Event Payment` is not reconciled — refunds only. Ticket cancellation still waits for the gateway to settle; an `Initiated` refund cancels nothing.

### Tests

14 new, in the existing refund suite: refunds discovered outside Buzz, full vs partial ticket handling on both paths, no duplicate rows for a known `refund_id`, no regression from a stale sighting, checked-in tickets never cancelled. 43 pass.

Depends on frappe/payments#251 for `fetch_refunds`. Buzz CI mocks the controller, so it is green without it; the Desk flow needs it installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)