### PR TITLE
chore: allow Loom and Cap links in PR demo check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,8 @@
 
 <!--
 Required for UI changes (anything under `dashboard/src/`): drag in a screenshot
-or a short screen recording. Before/after images are ideal for visual tweaks.
+or a short screen recording, or paste a Loom / Cap link.
+Before/after images are ideal for visual tweaks.
 Apply the `skip-demo` label if a visual makes no sense here.
 -->
 

--- a/.github/workflows/pr-demo-check.yml
+++ b/.github/workflows/pr-demo-check.yml
@@ -41,6 +41,10 @@ jobs:
               /<(img|video)\b/i,
               /https:\/\/github\.com\/user-attachments\/assets\/\S+/i,
               /https?:\/\/\S+\.(png|jpe?g|gif|webp|mp4|mov|webm)\b/i,
+              // Hosted screen recordings: Loom and Cap.
+              /https?:\/\/(www\.)?loom\.com\/(share|embed)\/\w+/i,
+              /https?:\/\/(www\.)?cap\.so\/s\/\w+/i,
+              /https?:\/\/cap\.link\/\w+/i,
             ];
             const MARKER = '<!-- ui-demo-check -->';
 
@@ -110,7 +114,7 @@ jobs:
               '### 🛠️ How to fix',
               '',
               '- **Edit the description** and drag a screenshot or a short screen recording into it.',
-              '  Before/after images are ideal for visual tweaks.',
+              '  Before/after images are ideal for visual tweaks. A Loom or Cap link works too.',
               '- Or apply the **`skip-demo`** label if a visual makes no sense here',
               '  (pure refactor, copy change, dependency bump).',
               '',


### PR DESCRIPTION
## What changed

Updated the PR demo check workflow and template to accept hosted screen recording links (Loom and Cap) in addition to direct image/video uploads.

**Changes:**
- Added regex patterns to recognize Loom (`loom.com/share`, `loom.com/embed`) and Cap (`cap.so/s`, `cap.link`) URLs as valid demo content
- Updated PR template and workflow instructions to mention these alternatives alongside screenshots and screen recordings
- Clarified that "Before/after images are ideal for visual tweaks" while noting that hosted recording links also work

## Demo

N/A

## Testing

No testing needed — configuration change to CI workflow and documentation.

https://claude.ai/code/session_015yFSjicQ4288PCZRjz9ds2