### PR TITLE
feat(check-in): link ticket ID to its desk record

### DIFF
--- a/dashboard/src/components/TicketDetailsModal.vue
+++ b/dashboard/src/components/TicketDetailsModal.vue
@@ -51,9 +51,15 @@
 						<h3 class="text-sm-medium text-gray-700 dark:text-gray-300">
 							{{ __("Ticket ID") }}
 						</h3>
-						<p class="text-sm font-mono text-gray-900 dark:text-white">
+						<a
+							:href="`/app/event-ticket/${validationResult?.ticket?.id}`"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1 text-sm font-mono text-ink-blue-6 hover:underline"
+						>
 							{{ validationResult?.ticket?.id }}
-						</p>
+							<LucideExternalLink class="w-3.5 h-3.5" />
+						</a>
 					</div>
 				</div>
 
@@ -157,6 +163,7 @@ import { useTicketValidation } from "@/composables/useTicketValidation";
 import { formatPriceOrFree } from "@/utils/currency";
 import { Button, Dialog } from "frappe-ui";
 import LucideCheckCircle from "~icons/lucide/check-circle";
+import LucideExternalLink from "~icons/lucide/external-link";
 import LucideUserCheck from "~icons/lucide/user-check";
 import LucideXCircle from "~icons/lucide/x-circle";
 


### PR DESCRIPTION
## What changed

Front-desk staff scanning at `/b/check-in` had to copy the ticket ID out of the
validation dialog and navigate to Desk by hand to inspect a ticket mid-queue.
The **Ticket ID** in `TicketDetailsModal.vue` is now an anchor to
`/app/event-ticket/<id>` in a new tab, with an external-link icon. Same pattern
as the Zoom link in `TicketDetails.vue`.

Presentation-only — the id is already in the `CheckinResponse` payload, and the
modal serves both pre- and post-check-in states, so one edit covers both.

No role gate on the link: the page is already `Frontdesk Manager`-only, and a
user without Desk access lands on Frappe's own permission screen. Add a guard
later if that confuses staff.

## Demo

`skip-demo` — nine lines of template, no Chrome available to capture locally.

## Testing

No test; prettier and `vue-tsc --noEmit` clean. Not clicked through in a browser
locally (no Chrome for the automation here) — worth eyeballing that the link
lands on the right record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)