### PR TITLE
chore: v1.3.0

### DIFF
--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What changed

Bumps `__version__` and `package.json` to 1.3.0 on the stable line, ahead of the
v1.3.0 tag. Ten commits have landed on `main` since v1.2.0, three of them
features, so this is a minor bump.

Generated by the [Version Bump workflow](https://github.com/bwhtech/buzz/actions/runs/32255266828).

## Demo

Not a UI change. `skip-demo`.

## Testing

Nothing to test beyond CI — the diff is two version strings, and the workflow
fails itself if either file misses the bump.
