### PR TITLE
fix(ticketing): render email templates without a permission check

### DIFF
--- a/buzz/proposals/doctype/sponsorship_enquiry/sponsorship_enquiry.py
+++ b/buzz/proposals/doctype/sponsorship_enquiry/sponsorship_enquiry.py
@@ -2,12 +2,12 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.email.doctype.email_template.email_template import get_email_template
 from frappe.model.document import Document
 from frappe.utils import get_url
 
 from buzz.events.doctype.buzz_team_settings.buzz_team_settings import get_event_team_settings
 from buzz.payments import mark_payment_as_received
+from buzz.utils import render_email_template
 
 
 class SponsorshipEnquiry(Document):
@@ -92,7 +92,7 @@ class SponsorshipEnquiry(Document):
 			frappe.log_error("No sponsor deck email template configured", "Sponsorship Enquiry")
 			return
 
-		email_template = get_email_template(template_name, {"doc": self, "event": event})
+		email_template = render_email_template(template_name, {"doc": self, "event": event})
 
 		subject = email_template.get("subject")
 		content = email_template.get("message")

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -2,7 +2,6 @@
 # For license information, please see license.txt
 import frappe
 from frappe import _
-from frappe.email.doctype.email_template.email_template import get_email_template
 from frappe.model.document import Document
 from frappe.utils import cstr, flt
 
@@ -16,6 +15,7 @@ from buzz.ticketing.doctype.event_booking_refund.event_booking_refund import (
 	get_committed_tickets,
 	record_gateway_refund,
 )
+from buzz.utils import render_email_template
 
 RAZORPAY = "Razorpay"
 
@@ -245,7 +245,7 @@ class EventBooking(Document):
 
 		content = None
 		if booking_template:
-			email_template = get_email_template(booking_template, args)
+			email_template = render_email_template(booking_template, args)
 			subject = email_template.get("subject") or subject
 			content = email_template.get("message")
 

--- a/buzz/ticketing/doctype/event_ticket/event_ticket.py
+++ b/buzz/ticketing/doctype/event_ticket/event_ticket.py
@@ -6,7 +6,12 @@ from frappe.core.api.user_invitation import invite_by_email
 from frappe.model.document import Document
 
 from buzz.events.doctype.buzz_team_settings.buzz_team_settings import get_event_team_settings
-from buzz.utils import generate_ics_file, generate_qr_code_file, only_if_app_installed
+from buzz.utils import (
+	generate_ics_file,
+	generate_qr_code_file,
+	only_if_app_installed,
+	render_email_template,
+)
 
 
 class EventTicket(Document):
@@ -125,9 +130,7 @@ class EventTicket(Document):
 		}
 
 		if ticket_template:
-			from frappe.email.doctype.email_template.email_template import get_email_template
-
-			email_template = get_email_template(ticket_template, args)
+			email_template = render_email_template(ticket_template, args)
 			subject = email_template.get("subject")
 			content = email_template.get("message")
 

--- a/buzz/ticketing/doctype/event_ticket/test_event_ticket.py
+++ b/buzz/ticketing/doctype/event_ticket/test_event_ticket.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from buzz.events.doctype.buzz_team.test_buzz_team import create_user
 from buzz.events.doctype.buzz_team_settings.test_buzz_team_settings import set_team_settings
-from buzz.utils import generate_qr_code_file, make_qr_image
+from buzz.utils import generate_qr_code_file, make_qr_image, render_email_template
 
 EXTRA_TEST_RECORD_DEPENDENCIES = []
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Bulk Ticket Coupon"]
@@ -310,6 +311,33 @@ class TestEventTicketZoomMeeting(IntegrationTestCase):
 		self.assertEqual(details.zoom_reference_name, meeting.name)
 
 
+class TestRenderEmailTemplate(IntegrationTestCase):
+	"""Attendees and sponsors are Website Users; only Desk Users can read an Email Template."""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_renders_for_a_user_without_email_template_permission(self):
+		template = frappe.get_doc(
+			{
+				"doctype": "Email Template",
+				"name": "Unprivileged Render Template",
+				"subject": "NOPERM - {{ event_title }}",
+				"response": "<p>NOPERM content</p>",
+			}
+		).insert(ignore_permissions=True)
+
+		attendee = create_user("attendee-render@example.com", "Attendee")
+		self.addCleanup(frappe.set_user, frappe.session.user)
+		frappe.set_user(attendee)
+		self.assertFalse(frappe.has_permission("Email Template", "read"))
+
+		rendered = render_email_template(template.name, {"event_title": "Buzz Conf"})
+
+		self.assertEqual(rendered["subject"], "NOPERM - Buzz Conf")
+		self.assertIn("NOPERM content", rendered["message"])
+
+
 class TestGuestTicketEmail(IntegrationTestCase):
 	"""Public bookings submit their tickets as Guest."""
 
@@ -337,13 +365,8 @@ class TestGuestTicketEmail(IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
-	# Frappe's whitelisted helper reads the template as the session user, which a guest is not allowed to do
-	@patch(
-		"frappe.email.doctype.email_template.email_template.get_email_template",
-		side_effect=frappe.PermissionError,
-	)
 	@patch("frappe.sendmail")
-	def test_guest_can_render_the_ticket_email_template(self, mock_sendmail, _permission_checked_helper):
+	def test_guest_can_render_the_ticket_email_template(self, mock_sendmail):
 		ticket = frappe.get_doc(
 			{
 				"doctype": "Event Ticket",

--- a/buzz/ticketing/doctype/event_ticket/test_event_ticket.py
+++ b/buzz/ticketing/doctype/event_ticket/test_event_ticket.py
@@ -308,3 +308,55 @@ class TestEventTicketZoomMeeting(IntegrationTestCase):
 		self.assertEqual(details.zoom_join_url, registrant["join_url"])
 		self.assertEqual(details.zoom_reference_doctype, "Zoom Meeting")
 		self.assertEqual(details.zoom_reference_name, meeting.name)
+
+
+class TestGuestTicketEmail(IntegrationTestCase):
+	"""Public bookings submit their tickets as Guest."""
+
+	def setUp(self):
+		self.event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		self.ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": self.event.name,
+				"title": "Guest Email Ticket",
+				"price": 0,
+			}
+		).insert(ignore_permissions=True)
+		self.template = frappe.get_doc(
+			{
+				"doctype": "Email Template",
+				"name": "Guest Ticket Template",
+				"subject": "GUEST - {{ event_title }}",
+				"response": "<p>Guest content</p>",
+			}
+		).insert(ignore_permissions=True)
+		self.event.db_set("ticket_email_template", self.template.name)
+		self.addCleanup(frappe.set_user, frappe.session.user)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	# Frappe's whitelisted helper reads the template as the session user, which a guest is not allowed to do
+	@patch(
+		"frappe.email.doctype.email_template.email_template.get_email_template",
+		side_effect=frappe.PermissionError,
+	)
+	@patch("frappe.sendmail")
+	def test_guest_can_render_the_ticket_email_template(self, mock_sendmail, _permission_checked_helper):
+		ticket = frappe.get_doc(
+			{
+				"doctype": "Event Ticket",
+				"event": self.event.name,
+				"ticket_type": self.ticket_type.name,
+				"first_name": "Guest",
+				"attendee_email": "guest-booking@example.com",
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user("Guest")
+
+		ticket.send_ticket_email(now=True)
+
+		mock_sendmail.assert_called_once()
+		self.assertIn("GUEST", mock_sendmail.call_args[1]["subject"])

--- a/buzz/utils.py
+++ b/buzz/utils.py
@@ -278,3 +278,12 @@ def get_time_zone_label(time_zone: str | None, reference_datetime: datetime | No
 	if minutes:
 		label += f":{minutes:02d}"
 	return label
+
+
+def render_email_template(template_name: str, args: dict) -> dict:
+	"""Render an Email Template without a permission check.
+
+	Frappe's get_email_template() is whitelisted and reads the template as the session
+	user, which fails for the guest-facing booking and enquiry flows.
+	"""
+	return frappe.get_doc("Email Template", template_name).get_formatted_email(args)


### PR DESCRIPTION
## What changed

Ticket, booking-confirmation and sponsor pitch-deck emails all rendered their
Email Template through `frappe.email...get_email_template()`, which is
whitelisted and reads the template as the session user. Read on Email Template
is granted to `Desk User` and `System Manager` only, so every attendee-facing
send raised `PermissionError` — guests booking publicly, logged-in Website
Users booking for themselves, and Buzz Users raising a sponsorship enquiry.
Both `on_submit` handlers swallow the exception, so the booking succeeded and
the email silently never went out; `str(PermissionError)` is empty, which is
why the Error Log entry had no message.

All three call sites now go through `buzz.utils.render_email_template()`, which
formats the template off the doc directly.

Only shows up on a frappe carrying the `check_permission("read")` inside
`get_email_template()` — our local bench (`develop` @ `80d9c31`) predates it,
so this reproduces on CI and production, not necessarily on your machine.

Not touched: the blanket `except Exception` + `log_error(str(e))` in
`EventTicket.on_submit` that hid this. Worth narrowing separately.

## Demo

No UI change. `skip-demo`.

## Testing

- `TestRenderEmailTemplate` — a Website User with no read access on Email
  Template still gets a rendered subject and message. Goes red on any frappe
  with the permission check if the whitelisted helper comes back.
- `TestGuestTicketEmail` — guest ticket submit renders from the event template.
- `bench run-tests`: event_ticket 12, event_booking 40, booking API 33,
  sponsorship_enquiry 4 — all pass.
