### PR TITLE
feat(events): give a new event an address and open it

### DIFF
--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -259,6 +259,9 @@ DEFAULT_CATEGORY = "Meetups"
 # Zoom-backed, so the meeting the organiser asked for is the one the event gets.
 ZOOM_CATEGORY = "Zoom Meeting"
 
+# Long enough to be unguessable, short enough to paste into a chat.
+ROUTE_HASH_LENGTH = 12
+
 
 def create_event(new: NewEvent) -> CreatedEvent:
 	"""Create an event for a team from the dashboard's create form."""
@@ -286,6 +289,9 @@ def create_event(new: NewEvent) -> CreatedEvent:
 			"medium": "Online" if new.zoom_meeting else "In Person",
 			"category": ZOOM_CATEGORY if new.zoom_meeting else DEFAULT_CATEGORY,
 			"host": host_for(new.team),
+			# A hash rather than the title: the event has an address to publish at from the
+			# off, and two events of the same name never collide. The details page renames it.
+			"route": frappe.generate_hash(length=ROUTE_HASH_LENGTH),
 		}
 	).insert()
 

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -224,6 +224,15 @@ class TestCreateEvent(IntegrationTestCase):
 		self.assertEqual(event.medium, "In Person")
 		self.assertEqual(event.category, "Meetups")
 
+	def test_takes_a_hash_route_and_stays_unpublished(self):
+		first = frappe.get_doc("Buzz Event", create_event_endpoint(self.payload()).name)
+		second = frappe.get_doc("Buzz Event", create_event_endpoint(self.payload()).name)
+
+		self.assertFalse(first.is_published)
+		self.assertNotEqual(first.route, second.route)
+		# The title never reaches the route, so two events of the same name do not collide.
+		self.assertNotIn("frappeverse", first.route)
+
 	def test_mints_one_host_per_team_and_reuses_it(self):
 		first = frappe.get_doc("Buzz Event", create_event_endpoint(self.payload()).name)
 		second = frappe.get_doc("Buzz Event", create_event_endpoint(self.payload(title="Second")).name)

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -85,7 +85,7 @@ async function save() {
 	if (createEvent.error) return;
 
 	toast.success(`${createEvent.data?.title} created`);
-	router.push({ name: "team-events" });
+	router.push({ name: "event-details", params: { eventId: createEvent.data?.name } });
 }
 </script>
 


### PR DESCRIPTION
Two chores around creating an event from the dashboard.

An event's route was derived from its title, and only when it was published —
so two events called the same thing collided on the way in, and an unpublished
event had no address at all. `create_event` now sets a 12-character
`frappe.generate_hash` route on insert. The event stays unpublished; the details
page is still where the organiser gives it a readable address and publishes it.

The create form also used to send the organiser back to the team's event list.
It now pushes `event-details` for the event they just made.

Gotchas:
- `validate_route` only derives a route from the title when the event is
  published and has none, so an explicit route on an unpublished event survives
  untouched. Desk-created events are unaffected.
- The hash is not a secret — an unpublished event refuses to render either way.

Not changed: publishing, the reserved-route check, or the desk form.