### PR TITLE
fix(booking): clarify OTP expiry, keep the dialog open on outside click

### DIFF
--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -19,6 +19,8 @@
 			<p class="text-sm text-ink-gray-6 mb-4">
 				{{ __("Enter the 6-digit code sent to") }}
 				<strong>{{ isPhoneOtp ? guestPhone : guestEmail }}</strong>
+				<br />
+				{{ __("The code expires in 10 minutes.") }}
 			</p>
 			<FormControl
 				v-model="otpCode"
@@ -40,7 +42,7 @@
 			>
 				{{
 					resendCooldown > 0
-						? __("Resend code in {0}s", [resendCooldown])
+						? __("Didn't get the code? Resend in {0}s", [resendCooldown])
 						: __("Resend code")
 				}}
 			</Button>

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -15,6 +15,7 @@
 			v-model="showOtpModal"
 			:title="isPhoneOtp ? __('Verify Your Phone') : __('Verify Your Email')"
 			size="sm"
+			:dismissible="false"
 		>
 			<p class="text-sm text-ink-gray-6 mb-4">
 				{{ __("Enter the 6-digit code sent to") }}


### PR DESCRIPTION
## What changed

Two problems in the guest booking verification dialog, both reported by a customer as "the OTP stops working after 30 seconds".

**Copy.** The dialog showed a single number — the 30 second resend countdown — and guests read it as the code's lifetime. The code is valid for 10 minutes, which is what the OTP email and SMS both say.

- The dialog now states the expiry under the address: "The code expires in 10 minutes."
- The resend countdown reads "Didn't get the code? Resend in 28s" instead of "Resend code in 28s", so the number reads as a throttle rather than a deadline. At zero it stays "Resend code".

**Dismissal.** One click anywhere outside the dialog closed it. There is no way to reopen it — `showOtpModal` is only set from `sendOtpResource.onSuccess` — so the guest had to resubmit the booking form, which issues a fresh code, invalidates the one already sitting in their inbox, and spends one of the five sends allowed per hour. A guest who clicked away to check their email came back to a closed dialog and a dead code. Set `:dismissible="false"`, which frappe-ui's Dialog already supports; Cancel and the close button still work.

Verified after the change:

```
after OUTSIDE click  -> visible: true | value kept: "1234"
after ESCAPE         -> visible: true | value kept: "1234"
after CANCEL         -> visible: false
```

The 30s cooldown and the 600s cache TTL are both unchanged — neither was wrong, they were just unlabelled.

Used `<br />` rather than a trailing period after the address: prettier reformats `</strong>.` into a dangling `</strong\n>.`, which is worse to read than the tag.

Two things this deliberately does not fix, both pre-existing:

- "10 minutes" is now hardcoded in three places against a TTL that lives as `expires_in_sec=600` twice in `buzz/api/booking/guests.py`. Worth a shared constant next time that file is open.
- `send_guest_booking_otp` is rate limited to 5/hour per identifier, so a guest clicking resend every 30s is locked out in ~2.5 minutes with a still-valid code in cache.

## Demo

<img width="384" height="319" alt="otp-modal-cooldown" src="https://github.com/user-attachments/assets/814ba9c2-f98d-4042-93c4-8287c0f1a454" />
<img width="384" height="319" alt="otp-modal-ready" src="https://github.com/user-attachments/assets/5d17235c-2c78-4b25-8574-461af316052e" />


## Testing

Manually walked the guest Email OTP flow against the seeded `guest-email-otp-e2e` event: captured both resend button states, confirmed the input stays editable well past 30s, and confirmed outside-click and Escape no longer close the dialog while Cancel does. Clicking Resend does not close the dialog either.

Existing e2e (`e2e/tests/guest-booking.spec.ts`) does not assert on either string and does not dismiss the dialog, so it is unaffected. No new test — copy plus one prop, no branch logic added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)