### PR TITLE
chore: v2.0.0-beta.2

### DIFF
--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0-beta.1"
+__version__ = "2.0.0-beta.2"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps the `develop` prerelease line from `2.0.0-beta.1` to `2.0.0-beta.2` in `buzz/__init__.py` and `package.json`.

`2.0.0` itself hasn't shipped, so the next step on this line is another beta rather than a `2.1.0` that would skip an unreleased version.

Notable work on `develop` since `2.0.0-beta.1`:

- The `/manage` dashboard: manager shell and team routing, events feed, team overview, team members, my tickets and my talk proposals timelines, event creation, the event workspace, and the guests page
- `feat(refunds)`: sync a booking's refunds from Razorpay
- `feat(check-in)`: link ticket ID to its desk record
- Permission and validation fixes: scope tickets and bookings by attendee, enforce event eligibility, server-side add-on price derivation, phone number validation, email template rendering without a permission check
- CI: UI demo check workflow, version bump workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzkF3gdn6eW2CQeSC4B9tF)_