### PR TITLE
chore: v1.3.1

### DIFF
--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps the released line from `1.3.0` to `1.3.1` in `buzz/__init__.py` and `package.json`.

Both commits on `main` since `chore: v1.3.0` are fixes, with no features, so this is a patch rather than a minor:

- `fix(ticketing): render email templates without a permission check (backport #369)` (#370)
- `fix(booking): clarify OTP expiry, keep the dialog open on outside click` (#378)

Happy to retarget this at `1.4.0` if you'd rather keep the release lines on matching minors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzkF3gdn6eW2CQeSC4B9tF)_