### PR TITLE
feat(booking): acknowledge offline bookings before verification

### DIFF
--- a/buzz/api/booking/services.py
+++ b/buzz/api/booking/services.py
@@ -242,7 +242,20 @@ class BookingService:
 		booking.flags.ignore_permissions = True
 		booking.save()
 		self.attach_payment_proof(booking)
+		self.acknowledge_offline_booking(booking)
 		return OfflineBookingResponse(booking_name=booking.name, offline_payment=True)
+
+	def acknowledge_offline_booking(self, booking: "EventBooking") -> None:
+		"""The booking is only a draft until an approval verifies the payment, so this
+		acknowledgement is the booker's only receipt until then."""
+		try:
+			booking.send_offline_acknowledgement_email()
+		except Exception:
+			frappe.log_error(
+				title="Offline booking acknowledgement email failed",
+				reference_doctype=booking.doctype,
+				reference_name=booking.name,
+			)
 
 	def offline_method(self) -> dict:
 		filters = {"event": self.request.event, "enabled": 1}

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -260,6 +260,19 @@ class TestProcessBooking(BookingTestCase):
 		self.assertEqual(booking.status, "Approval Pending")
 		self.assertEqual(booking.payment_status, "Verification Pending")
 
+	def test_gateway_booking_is_not_acknowledged(self):
+		"""The acknowledgement belongs to the offline path only: a gateway booking is
+		still unpaid at this point and gets its confirmation after the payment lands."""
+		request = self.make_paid_request()
+
+		with (
+			patch("buzz.api.booking.services.get_payment_link_for_booking", return_value="/pay"),
+			patch("frappe.sendmail") as sendmail,
+		):
+			process_booking(request)
+
+		sendmail.assert_not_called()
+
 	def test_offline_booking_acknowledges_then_confirms(self):
 		"""Offline is a two-stage conversation: an acknowledgement while the payment is
 		unverified, the existing confirmation only once an approval submits the booking."""

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -260,6 +260,42 @@ class TestProcessBooking(BookingTestCase):
 		self.assertEqual(booking.status, "Approval Pending")
 		self.assertEqual(booking.payment_status, "Verification Pending")
 
+	def test_offline_booking_acknowledges_then_confirms(self):
+		"""Offline is a two-stage conversation: an acknowledgement while the payment is
+		unverified, the existing confirmation only once an approval submits the booking."""
+		self.set_event({"send_ticket_email": 0})
+		if not frappe.db.exists("User", BOOKER):
+			frappe.get_doc(
+				{"doctype": "User", "email": BOOKER, "first_name": "Booking", "send_welcome_email": 0}
+			).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": "Offline Payment Method",
+				"event": self.event.name,
+				"title": f"Bank Transfer {frappe.generate_hash(length=6)}",
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+		request = self.make_paid_request(is_offline=True)
+
+		frappe.set_user(BOOKER)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+		with patch("frappe.sendmail") as sendmail:
+			booking_name = process_booking(request).booking_name
+
+			sendmail.assert_called_once()
+			self.assertEqual(sendmail.call_args[1]["template"], "offline_booking_acknowledgement")
+			self.assertIn(BOOKER, sendmail.call_args[1]["recipients"])
+			self.assertFalse(frappe.db.exists("Event Ticket", {"booking": booking_name}))
+
+			frappe.set_user("Administrator")
+			frappe.get_doc("Event Booking", booking_name).approve_booking()
+
+			self.assertEqual(sendmail.call_args[1]["template"], "booking_confirmation")
+
+		self.assertTrue(frappe.db.exists("Event Ticket", {"booking": booking_name}))
+
 
 class TestBookingAddOnPricing(BookingTestCase):
 	"""The add-on price is server-authoritative: it comes from the Ticket Add-on catalog,

--- a/buzz/events/doctype/buzz_event/buzz_event.json
+++ b/buzz/events/doctype/buzz_event/buzz_event.json
@@ -77,6 +77,7 @@
   "booking_confirmation_email_section",
   "send_booking_confirmation_email",
   "booking_confirmation_email_template",
+  "offline_acknowledgement_email_template",
   "talks_section",
   "allow_editing_talks_after_acceptance",
   "custom_forms_tab",
@@ -298,7 +299,7 @@
   },
   {
    "default": "1",
-   "description": "Send a confirmation email with a booking summary to the person who made the booking.",
+   "description": "Send booking emails to the person who made the booking: an acknowledgement while an offline payment awaits verification, and a confirmation once the booking is confirmed.",
    "fieldname": "send_booking_confirmation_email",
    "fieldtype": "Check",
    "label": "Send Booking Confirmation Email"
@@ -308,6 +309,14 @@
    "fieldname": "booking_confirmation_email_template",
    "fieldtype": "Link",
    "label": "Booking Confirmation Email Template",
+   "options": "Email Template"
+  },
+  {
+   "depends_on": "eval:doc.send_booking_confirmation_email;",
+   "description": "Sent when a booking is made with an offline payment method, before the payment is verified.",
+   "fieldname": "offline_acknowledgement_email_template",
+   "fieldtype": "Link",
+   "label": "Offline Payment Acknowledgement Email Template",
    "options": "Email Template"
   },
   {
@@ -621,7 +630,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-08-14 13:08:24.523151",
+ "modified": "2026-08-27 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Buzz Event",

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -50,6 +50,7 @@ class BuzzEvent(Document):
 		attach_email_ticket: DF.Check
 		auto_send_pitch_deck: DF.Check
 		banner_image: DF.AttachImage | None
+		booking_confirmation_email_template: DF.Link | None
 		card_image: DF.AttachImage | None
 		category: DF.Link
 		custom_forms: DF.Table[BuzzEventForm]
@@ -63,14 +64,17 @@ class BuzzEvent(Document):
 		host: DF.Link
 		is_published: DF.Check
 		medium: DF.Literal["In Person", "Online"]
+		meeting_link: DF.Data | None
 		meta_image: DF.AttachImage | None
 		name: DF.Int | None
+		offline_acknowledgement_email_template: DF.Link | None
 		payment_gateways: DF.Table[EventPaymentGateway]
 		proposal: DF.Link | None
 		registration_url: DF.Data | None
 		registrations_close_at: DF.Datetime | None
 		route: DF.Data | None
 		schedule: DF.Table[ScheduleItem]
+		send_booking_confirmation_email: DF.Check
 		send_ticket_email: DF.Check
 		short_description: DF.SmallText | None
 		show_sponsorship_section: DF.Check

--- a/buzz/templates/emails/offline_booking_acknowledgement.html
+++ b/buzz/templates/emails/offline_booking_acknowledgement.html
@@ -60,8 +60,7 @@
                 <tr>
                   <td>
                     <p style="color:rgb(75,85,99);font-size:15px;margin:0px;line-height:24px">
-                      Your payment is currently awaiting verification, so your
-                      {% if event_doc.free_event %}registration is{% else %}tickets are{% endif %}
+                      Your payment is currently awaiting verification, so your tickets are
                       <strong>not confirmed yet</strong>. You will receive a separate confirmation
                       email once the verification is completed.
                     </p>

--- a/buzz/templates/emails/offline_booking_acknowledgement.html
+++ b/buzz/templates/emails/offline_booking_acknowledgement.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+  </head>
+  <body
+    style='background-color:rgb(243,244,246);font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";padding-top:40px;padding-bottom:40px'>
+    <div
+      style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
+      data-skip-in-text="true">
+      We received your booking for {{ event_title }}. Your payment is awaiting verification.
+    </div>
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="background-color:rgb(255,255,255);border-radius:8px;max-width:600px;margin-left:auto;margin-right:auto;overflow:hidden">
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <!-- Header -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="background-color:rgb(180,83,9);padding-left:40px;padding-right:40px;padding-top:32px;padding-bottom:32px;text-align:center">
+              <tbody>
+                <tr>
+                  <td>
+                    <h1
+                      style="color:rgb(255,255,255);font-size:28px;font-weight:700;margin:0px;margin-bottom:8px">
+                      ⏳ Payment Verification Pending
+                    </h1>
+                    <p
+                      style="color:rgb(254,243,199);font-size:16px;margin:0px;line-height:24px">
+                      We have received your booking and offline payment details.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- What happens next -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:28px;padding-bottom:4px">
+              <tbody>
+                <tr>
+                  <td>
+                    <p style="color:rgb(75,85,99);font-size:15px;margin:0px;line-height:24px">
+                      Your payment is currently awaiting verification, so your
+                      {% if event_doc.free_event %}registration is{% else %}tickets are{% endif %}
+                      <strong>not confirmed yet</strong>. You will receive a separate confirmation
+                      email once the verification is completed.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Event + booking meta -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:24px;padding-bottom:8px">
+              <tbody>
+                <tr>
+                  <td>
+                    <h2
+                      style="color:rgb(31,41,55);font-size:22px;font-weight:700;margin:0px;margin-bottom:8px">
+                      {{ event_title }}
+                    </h2>
+                    <p
+                      style="color:rgb(75,85,99);font-size:14px;margin:0px;line-height:22px">
+                      📅 {{ frappe.format_date(event_doc.start_date) }}
+                      {% if event_doc.start_date != event_doc.end_date %}
+                        - {{ frappe.format_date(event_doc.end_date) }}
+                      {% endif %}
+                      {% if venue %}&nbsp;&nbsp;·&nbsp;&nbsp;📍 {{ venue }}{% endif %}
+                    </p>
+                    <p
+                      style="color:rgb(75,85,99);font-size:14px;margin-top:12px;margin-bottom:0px;line-height:22px">
+                      Booking ID:
+                      <span style='font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;color:rgb(31,41,55);font-weight:600'>{{ doc.name }}</span>
+                      {% if doc.offline_payment_method %}
+                        &nbsp;&nbsp;·&nbsp;&nbsp;Paid via: <strong>{{ doc.offline_payment_method }}</strong>
+                      {% endif %}
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Attendees / tickets -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:16px;padding-bottom:8px">
+              <tbody>
+                <tr>
+                  <td>
+                    <p
+                      style="color:rgb(75,85,99);font-size:13px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin:0px;margin-bottom:8px">
+                      Participants ({{ attendee_rows | length }})
+                    </p>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="border-top:1px solid rgb(229,231,235)">
+                      <tbody>
+                        {% for attendee in attendee_rows %}
+                        <tr>
+                          <td
+                            style="padding-top:12px;padding-bottom:12px;border-bottom:1px solid rgb(229,231,235);vertical-align:top">
+                            <p
+                              style="color:rgb(31,41,55);font-size:15px;font-weight:600;margin:0px;line-height:20px">
+                              {{ attendee.full_name }}
+                            </p>
+                            <p
+                              style="color:rgb(107,114,128);font-size:13px;margin:2px 0px 0px 0px;line-height:18px">
+                              {{ attendee.ticket_type_title }}
+                              {% if attendee.number_of_add_ons %}
+                                &nbsp;·&nbsp; {{ attendee.number_of_add_ons }} add-on(s)
+                              {% endif %}
+                            </p>
+                          </td>
+                          <td
+                            style="padding-top:12px;padding-bottom:12px;border-bottom:1px solid rgb(229,231,235);text-align:right;vertical-align:top;white-space:nowrap">
+                            <p
+                              style="color:rgb(31,41,55);font-size:15px;font-weight:500;margin:0px;line-height:20px">
+                              {{ frappe.utils.fmt_money(attendee.amount, currency=doc.currency) }}
+                            </p>
+                          </td>
+                        </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Totals -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:8px;padding-bottom:24px">
+              <tbody>
+                <tr>
+                  <td>
+                    <table
+                      align="right"
+                      width="60%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation">
+                      <tbody>
+                        <tr>
+                          <td style="padding:4px 0px;color:rgb(75,85,99);font-size:14px">Subtotal</td>
+                          <td style="padding:4px 0px;color:rgb(31,41,55);font-size:14px;text-align:right">
+                            {{ frappe.utils.fmt_money(doc.net_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                        {% if doc.discount_amount %}
+                        <tr>
+                          <td style="padding:4px 0px;color:rgb(22,163,74);font-size:14px">
+                            Discount{% if doc.coupon_code %} ({{ doc.coupon_code }}){% endif %}
+                          </td>
+                          <td style="padding:4px 0px;color:rgb(22,163,74);font-size:14px;text-align:right">
+                            &minus; {{ frappe.utils.fmt_money(doc.discount_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                        {% endif %}
+                        {% if doc.tax_amount %}
+                        <tr>
+                          <td style="padding:4px 0px;color:rgb(75,85,99);font-size:14px">
+                            {{ doc.tax_label or "Tax" }}{% if doc.tax_percentage %} ({{ doc.tax_percentage }}%){% endif %}
+                          </td>
+                          <td style="padding:4px 0px;color:rgb(31,41,55);font-size:14px;text-align:right">
+                            {{ frappe.utils.fmt_money(doc.tax_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                        {% endif %}
+                        <tr>
+                          <td style="padding:10px 0px 0px 0px;border-top:2px solid rgb(229,231,235);color:rgb(31,41,55);font-size:16px;font-weight:700">
+                            Amount to verify
+                          </td>
+                          <td style="padding:10px 0px 0px 0px;border-top:2px solid rgb(229,231,235);color:rgb(31,41,55);font-size:16px;font-weight:700;text-align:right">
+                            {{ frappe.utils.fmt_money(doc.total_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            {% if support_email %}
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:20px;padding-bottom:20px;text-align:center;border-top:1px solid rgb(229,231,235)">
+              <tbody>
+                <tr>
+                  <td>
+                    <p style="color:rgb(75,85,99);font-size:14px;margin:0px;margin-bottom:12px;line-height:22px">
+                      Something look wrong? Contact our support team.
+                    </p>
+                    <a
+                      href="mailto:{{ support_email }}"
+                      style="background-color:rgb(37,99,235);color:rgb(255,255,255);padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;text-decoration-line:none"
+                      target="_blank">Contact Support</a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            {% endif %}
+
+            <!-- Footer -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="background-color:rgb(31,41,55);padding-left:40px;padding-right:40px;padding-top:24px;padding-bottom:24px;text-align:center">
+              <tbody>
+                <tr>
+                  <td>
+                    <p style="color:rgb(209,213,219);font-size:14px;margin:0px;line-height:22px">
+                      Powered by <a href="https://github.com/BuildWithHussain/buzz" style="color:rgb(209,213,219)">Buzz</a>. Built on <a href="https://frappe.io/framework" style="color:rgb(209,213,219)">Frappe Framework</a>.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -188,27 +188,76 @@ class EventBooking(Document):
 			)
 
 	def send_booking_confirmation_email(self):
-		# Never email system/placeholder users — they are not real recipients.
-		if self.user in ("Administrator", "Guest"):
-			return
-
 		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
-		if not event_doc.send_booking_confirmation_email:
-			return
+		team_settings = get_event_team_settings(self.event)
+		# Fallback to the team default if event-level not set
+		self.send_booking_email(
+			template=(
+				event_doc.booking_confirmation_email_template
+				or team_settings.default_booking_confirmation_email_template
+			),
+			builtin="booking_confirmation",
+			subject=_("Your booking for {0} is confirmed ✅").format(event_doc.title),
+		)
 
-		recipient = frappe.db.get_value("User", self.user, "email") or self.user
+	def send_offline_acknowledgement_email(self):
+		"""Tell the booker their offline payment is awaiting verification. Sent while the
+		booking is still a draft, so the confirmation above stays the approval's job."""
+		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
+		self.send_booking_email(
+			template=event_doc.offline_acknowledgement_email_template,
+			builtin="offline_booking_acknowledgement",
+			subject=_("We received your booking for {0} — payment verification pending").format(
+				event_doc.title
+			),
+		)
+
+	def send_booking_email(self, template: str | None, builtin: str, subject: str) -> None:
+		recipient = self.get_booking_email_recipient()
 		if not recipient:
 			return
 
-		team_settings = get_event_team_settings(self.event)
-		# Fallback to the team default if event-level not set
-		booking_template = (
-			event_doc.booking_confirmation_email_template
-			or team_settings.default_booking_confirmation_email_template
+		args = self.get_booking_email_args()
+
+		content = None
+		if template:
+			email_template = render_email_template(template, args)
+			subject = email_template.get("subject") or subject
+			content = email_template.get("message")
+
+		frappe.sendmail(
+			recipients=[recipient],
+			subject=subject,
+			content=content,
+			template=None if template else builtin,
+			args=args,
+			reference_doctype=self.doctype,
+			reference_name=self.name,
 		)
 
-		subject = _("Your booking for {0} is confirmed ✅").format(event_doc.title)
+	def get_booking_email_recipient(self) -> str | None:
+		"""Who to email about this booking, or None when nobody should be emailed."""
+		# Never email system/placeholder users — they are not real recipients.
+		if self.user in ("Administrator", "Guest"):
+			return None
 
+		if not frappe.get_cached_value("Buzz Event", self.event, "send_booking_confirmation_email"):
+			return None
+
+		return frappe.db.get_value("User", self.user, "email") or self.user
+
+	def get_booking_email_args(self) -> dict:
+		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
+		return {
+			"doc": self,
+			"event_doc": event_doc,
+			"event_title": event_doc.title,
+			"venue": event_doc.venue,
+			"attendee_rows": self.get_attendee_email_rows(),
+			"support_email": get_event_team_settings(self.event).support_email,
+		}
+
+	def get_attendee_email_rows(self) -> list[dict]:
 		# Pre-fetch ticket type titles in a single query so the email template
 		# loop stays a pure display operation (no per-attendee DB round-trips).
 		ticket_type_names = list({attendee.ticket_type for attendee in self.attendees})
@@ -223,7 +272,7 @@ class EventBooking(Document):
 				)
 			}
 
-		attendee_rows = [
+		return [
 			{
 				"full_name": attendee.full_name
 				or " ".join(part for part in (attendee.first_name, attendee.last_name) if part),
@@ -233,31 +282,6 @@ class EventBooking(Document):
 			}
 			for attendee in self.attendees
 		]
-
-		args = {
-			"doc": self,
-			"event_doc": event_doc,
-			"event_title": event_doc.title,
-			"venue": event_doc.venue,
-			"attendee_rows": attendee_rows,
-			"support_email": team_settings.support_email,
-		}
-
-		content = None
-		if booking_template:
-			email_template = render_email_template(booking_template, args)
-			subject = email_template.get("subject") or subject
-			content = email_template.get("message")
-
-		frappe.sendmail(
-			recipients=[recipient],
-			subject=subject,
-			content=content,
-			template=None if booking_template else "booking_confirmation",
-			args=args,
-			reference_doctype=self.doctype,
-			reference_name=self.name,
-		)
 
 	def validate_coupon_availability(self):
 		"""Re-validate coupon with lock to prevent race condition."""

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -263,8 +263,10 @@ class EventBooking(Document):
 		ticket_type_names = list({attendee.ticket_type for attendee in self.attendees})
 		ticket_type_titles = {}
 		if ticket_type_names:
+			# Ticket types autoname to integers but arrive off the attendee row as
+			# strings, so both sides of the lookup are cast before they are compared.
 			ticket_type_titles = {
-				row.name: row.title
+				str(row.name): row.title
 				for row in frappe.get_all(
 					"Event Ticket Type",
 					filters={"name": ["in", ticket_type_names]},
@@ -276,7 +278,7 @@ class EventBooking(Document):
 			{
 				"full_name": attendee.full_name
 				or " ".join(part for part in (attendee.first_name, attendee.last_name) if part),
-				"ticket_type_title": ticket_type_titles.get(attendee.ticket_type, attendee.ticket_type),
+				"ticket_type_title": ticket_type_titles.get(str(attendee.ticket_type), attendee.ticket_type),
 				"number_of_add_ons": attendee.number_of_add_ons,
 				"amount": (attendee.amount or 0) + (attendee.add_on_total or 0),
 			}

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1486,6 +1486,9 @@ class TestOfflineAcknowledgementEmail(IntegrationTestCase):
 		self.assertEqual(args["doc"].name, booking.name)
 		self.assertEqual(args["event_title"], self.test_event.title)
 		self.assertEqual(len(args["attendee_rows"]), 1)
+		# Ticket types autoname to integers and arrive off the row as strings, so a
+		# title lookup keyed on the raw value silently prints the id instead.
+		self.assertEqual(args["attendee_rows"][0]["ticket_type_title"], self.ticket_type.title)
 
 	def test_builtin_template_renders(self):
 		"""The template is only exercised end-to-end here: every other test mocks the
@@ -1499,6 +1502,7 @@ class TestOfflineAcknowledgementEmail(IntegrationTestCase):
 		self.assertIn("Payment Verification Pending", html)
 		self.assertIn(booking.name, html)
 		self.assertIn(booking.offline_payment_method, html)
+		self.assertIn(self.ticket_type.title, html)
 
 	@patch("frappe.sendmail")
 	def test_uses_event_template_when_set(self, mock_sendmail):

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1385,6 +1385,166 @@ class TestBookingConfirmationEmail(IntegrationTestCase):
 		self.assertNotIn("TEAM", mock_sendmail.call_args[1]["subject"])
 
 
+class TestOfflineAcknowledgementEmail(IntegrationTestCase):
+	"""Acknowledgement sent when an offline booking is created, before verification."""
+
+	BOOKER_EMAIL = "offline-booker@example.com"
+
+	def setUp(self):
+		self.test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		self.test_event.apply_tax = False
+		self.test_event.send_booking_confirmation_email = 1
+		self.test_event.booking_confirmation_email_template = None
+		self.test_event.offline_acknowledgement_email_template = None
+		self.test_event.send_ticket_email = 0
+		self.test_event.save()
+
+		set_team_settings(self.test_event.team, default_booking_confirmation_email_template=None)
+		self.addCleanup(frappe.clear_document_cache, "Buzz Team Settings", self.test_event.team)
+
+		if not frappe.db.exists("User", self.BOOKER_EMAIL):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": self.BOOKER_EMAIL,
+					"first_name": "Offline",
+					"enabled": 1,
+					"user_type": "Website User",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+
+		self.ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": self.test_event.name,
+				"title": "Offline Acknowledgement Ticket",
+				"price": 100,
+			}
+		).insert()
+
+	def tearDown(self):
+		frappe.delete_doc("Event Ticket Type", self.ticket_type.name, force=True)
+
+	def _make_offline_booking(self, user):
+		"""A booking in the state offline_booking_response leaves behind: a draft
+		awaiting verification, with no tickets."""
+		booking = frappe.get_doc(
+			{
+				"doctype": "Event Booking",
+				"event": self.test_event.name,
+				"user": user,
+				"payment_method": "Offline",
+				"offline_payment_method": "Bank Transfer",
+				"status": "Approval Pending",
+				"payment_status": "Verification Pending",
+				"attendees": [
+					{
+						"ticket_type": self.ticket_type.name,
+						"first_name": "John",
+						"email": "john-offline@example.com",
+					}
+				],
+			}
+		).insert()
+		return booking
+
+	def _create_template(self, name, subject_prefix):
+		if frappe.db.exists("Email Template", name):
+			frappe.delete_doc("Email Template", name, force=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Email Template",
+				"name": name,
+				"subject": f"{subject_prefix} - {{{{ event_title }}}}",
+				"response": f"<p>{subject_prefix} content</p>",
+			}
+		).insert()
+
+	@patch("frappe.sendmail")
+	def test_sends_acknowledgement_to_booker(self, mock_sendmail):
+		booking = self._make_offline_booking(self.BOOKER_EMAIL)
+		booking.send_offline_acknowledgement_email()
+
+		mock_sendmail.assert_called_once()
+		self.assertIn(self.BOOKER_EMAIL, mock_sendmail.call_args[1]["recipients"])
+		self.assertEqual(mock_sendmail.call_args[1]["reference_doctype"], "Event Booking")
+		self.assertEqual(mock_sendmail.call_args[1]["reference_name"], booking.name)
+
+	@patch("frappe.sendmail")
+	def test_uses_inline_template_when_none_configured(self, mock_sendmail):
+		self._make_offline_booking(self.BOOKER_EMAIL).send_offline_acknowledgement_email()
+
+		self.assertEqual(mock_sendmail.call_args[1]["template"], "offline_booking_acknowledgement")
+
+	@patch("frappe.sendmail")
+	def test_carries_the_booking_summary(self, mock_sendmail):
+		booking = self._make_offline_booking(self.BOOKER_EMAIL)
+		booking.send_offline_acknowledgement_email()
+
+		args = mock_sendmail.call_args[1]["args"]
+		self.assertEqual(args["doc"].name, booking.name)
+		self.assertEqual(args["event_title"], self.test_event.title)
+		self.assertEqual(len(args["attendee_rows"]), 1)
+
+	def test_builtin_template_renders(self):
+		"""The template is only exercised end-to-end here: every other test mocks the
+		send, so a broken Jinja tag would otherwise reach production silently."""
+		booking = self._make_offline_booking(self.BOOKER_EMAIL)
+
+		html = frappe.render_template(
+			"templates/emails/offline_booking_acknowledgement.html", booking.get_booking_email_args()
+		)
+
+		self.assertIn("Payment Verification Pending", html)
+		self.assertIn(booking.name, html)
+		self.assertIn(booking.offline_payment_method, html)
+
+	@patch("frappe.sendmail")
+	def test_uses_event_template_when_set(self, mock_sendmail):
+		template = self._create_template("Offline Acknowledgement Event Template", "OFFLINE")
+		self.test_event.offline_acknowledgement_email_template = template.name
+		self.test_event.save()
+
+		self._make_offline_booking(self.BOOKER_EMAIL).send_offline_acknowledgement_email()
+
+		mock_sendmail.assert_called_once()
+		self.assertIn("OFFLINE", mock_sendmail.call_args[1]["subject"])
+
+	@patch("frappe.sendmail")
+	def test_ignores_the_confirmation_template(self, mock_sendmail):
+		"""The acknowledgement has its own template field; the confirmation's, event-level
+		or team-level, must not leak into it."""
+		event_template = self._create_template("Offline Acknowledgement Confirmation Template", "EVENT")
+		team_template = self._create_template("Offline Acknowledgement Team Template", "TEAM")
+		self.test_event.booking_confirmation_email_template = event_template.name
+		self.test_event.save()
+		set_team_settings(
+			self.test_event.team, default_booking_confirmation_email_template=team_template.name
+		)
+
+		self._make_offline_booking(self.BOOKER_EMAIL).send_offline_acknowledgement_email()
+
+		self.assertEqual(mock_sendmail.call_args[1]["template"], "offline_booking_acknowledgement")
+
+	@patch("frappe.sendmail")
+	def test_respects_event_toggle_off(self, mock_sendmail):
+		self.test_event.send_booking_confirmation_email = 0
+		self.test_event.save()
+
+		self._make_offline_booking(self.BOOKER_EMAIL).send_offline_acknowledgement_email()
+
+		mock_sendmail.assert_not_called()
+
+	@patch("frappe.sendmail")
+	def test_skips_system_users(self, mock_sendmail):
+		for user in ("Administrator", "Guest"):
+			with self.subTest(user=user):
+				self._make_offline_booking(user).send_offline_acknowledgement_email()
+
+		mock_sendmail.assert_not_called()
+
+
 class TestZoomBackedCategoryBooking(IntegrationTestCase):
 	"""Zoom needs a last name on every registrant, for meetings as much as webinars."""
 

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -58,8 +58,46 @@
 			</template>
 		</Dialog>
 
+		<!-- Pending State for Guest Offline Booking -->
+		<div v-if="bookingSuccess && bookingPendingVerification" class="text-center py-12 px-4">
+			<div class="bg-yellow-50 border border-yellow-200 rounded-xl p-8 max-w-md mx-auto">
+				<LucideClock class="w-16 h-16 text-yellow-500 mx-auto mb-4" />
+				<h2 class="text-3xl-semibold text-yellow-800 mb-2">
+					{{ __("Booking Received!") }}
+				</h2>
+				<p class="text-yellow-700 mb-4">
+					{{
+						__(
+							"We have received your booking and offline payment details. Your payment is awaiting verification.",
+						)
+					}}
+				</p>
+				<p class="text-sm text-yellow-700 mb-2">
+					{{
+						isZoomEvent
+							? __("Your registration is not confirmed yet.")
+							: __("Your tickets are not confirmed yet.")
+					}}
+					{{ __("We will email") }}
+					<strong>{{ guestEmail }}</strong>
+					{{ __("once the payment is verified.") }}
+				</p>
+				<p class="text-xs text-ink-gray-5 mb-6">
+					{{ __("Booking reference") }}: <strong>{{ successBookingName }}</strong>
+				</p>
+				<div class="space-y-3">
+					<p class="text-xs text-ink-gray-5">
+						{{ __("Want to manage your bookings?") }}
+					</p>
+					<Button variant="outline" @click="openLoginDialog()">
+						{{ __("Log in to your account") }}
+					</Button>
+				</div>
+			</div>
+		</div>
+
 		<!-- Success State for Guest Booking -->
-		<div v-if="bookingSuccess" class="text-center py-12 px-4">
+		<div v-else-if="bookingSuccess" class="text-center py-12 px-4">
 			<div class="bg-green-50 border border-green-200 rounded-xl p-8 max-w-md mx-auto">
 				<LucideCheckCircle class="w-16 h-16 text-green-500 mx-auto mb-4" />
 				<h2 class="text-3xl-semibold text-green-800 mb-2">
@@ -374,6 +412,7 @@ import { useRoute, useRouter } from "vue-router"
 import LucideAlertCircle from "~icons/lucide/alert-circle"
 import LucideCheck from "~icons/lucide/check"
 import LucideCheckCircle from "~icons/lucide/check-circle"
+import LucideClock from "~icons/lucide/clock"
 import LucideGift from "~icons/lucide/gift"
 import LucideX from "~icons/lucide/x"
 
@@ -521,6 +560,7 @@ const couponData = ref<CouponData | null>(null)
 // Success state for guest bookings
 const bookingSuccess = ref(false)
 const successBookingName = ref("")
+const bookingPendingVerification = ref(false)
 
 // OTP verification state for guest bookings
 const showOtpModal = ref(false)
@@ -1287,6 +1327,7 @@ function submitBooking(
 				} else if (action.type === "guest-inline") {
 					bookingSuccess.value = true
 					successBookingName.value = action.bookingName
+					bookingPendingVerification.value = action.pendingVerification
 				} else {
 					router.replace(action.path)
 				}

--- a/dashboard/src/utils/bookingSuccessRedirect.test.ts
+++ b/dashboard/src/utils/bookingSuccessRedirect.test.ts
@@ -29,7 +29,23 @@ test("redirect_to routes to booking-success for a logged-in user", () => {
 
 test("guest with no redirect_to and no payment_link falls back to inline confirmation", () => {
 	const action = resolveBookingSuccessAction({ booking_name: "B-0003" }, { isGuestMode: true })
-	assert.deepEqual(action, { type: "guest-inline", bookingName: "B-0003" })
+	assert.deepEqual(action, {
+		type: "guest-inline",
+		bookingName: "B-0003",
+		pendingVerification: false,
+	})
+})
+
+test("guest offline booking stays inline but is pending verification", () => {
+	const action = resolveBookingSuccessAction(
+		{ booking_name: "B-0006", offline_payment: true },
+		{ isGuestMode: true },
+	)
+	assert.deepEqual(action, {
+		type: "guest-inline",
+		bookingName: "B-0006",
+		pendingVerification: true,
+	})
 })
 
 test("logged-in offline booking routes to bookings page with offline flag", () => {

--- a/dashboard/src/utils/bookingSuccessRedirect.ts
+++ b/dashboard/src/utils/bookingSuccessRedirect.ts
@@ -14,7 +14,7 @@ export interface BookingSubmitResponse {
 export type BookingSuccessAction =
 	| { type: "external"; url: string }
 	| { type: "route"; path: string }
-	| { type: "guest-inline"; bookingName: string }
+	| { type: "guest-inline"; bookingName: string; pendingVerification: boolean }
 
 export function resolveBookingSuccessAction(
 	data: BookingSubmitResponse,
@@ -35,8 +35,10 @@ export function resolveBookingSuccessAction(
 		throw new Error("Booking response carried neither a payment link nor a booking name")
 	}
 
+	// A guest has no session to read /bookings/<name> with, so an offline booking stays
+	// inline and says so instead of claiming tickets were sent.
 	if (isGuestMode) {
-		return { type: "guest-inline", bookingName }
+		return { type: "guest-inline", bookingName, pendingVerification: !!data.offline_payment }
 	}
 
 	if (data.offline_payment) {


### PR DESCRIPTION
## What changed

Closes #387.

An offline booking sits as a draft until an Event Manager verifies the payment, but nothing told the booker that. No email went out until approval, and a guest was shown the generic success panel claiming their tickets had already been sent — while the booking had no tickets at all.

Now the booking sends an acknowledgement the moment it is created: booking reference, event and participant details, offline method and amount, and a plain statement that the tickets are not confirmed yet and a separate confirmation will follow. The wording is overridable per event through a new **Offline Payment Acknowledgement Email Template** field; the existing *Send Booking Confirmation Email* check gates both booking emails, so there is no second toggle to keep in sync and no new Team Settings default.

The confirmation email's recipient resolution, argument building and send now live in shared methods both emails call, so the two cannot drift.

For guests the inline panel gains a pending variant carrying the booking reference — guests have no session to open `/bookings/<name>` with. Logged-in users already landed on the "Payment Confirmation Pending" booking page and are untouched, as is everything after approval: payment marked paid, booking submitted, tickets generated, existing confirmation and ticket emails sent.

Second commit is a bug the render turned up: ticket types autoname to integers while the Link field hands back a string, so the title map never matched and every attendee row in the booking confirmation email has printed the ticket type's id since it shipped.

Not in scope, all pre-existing: no email on rejection, approval still lives only in Desk, and offline bookings still record no Event Payment so they cannot be refunded.

## Demo

<img width="1280" height="900" alt="01-offline-dialog" src="https://github.com/user-attachments/assets/ce873f04-2efa-4090-999a-58238ec74aa8" />
<img width="1280" height="900" alt="02-guest-pending" src="https://github.com/user-attachments/assets/01b93af7-3e42-48d3-b166-cad8baad198b" />
<img width="800" height="1200" alt="03-ack-email" src="https://github.com/user-attachments/assets/3561b245-726e-4a4d-ad6a-e2885004b9fe" />


## Testing

- `TestOfflineAcknowledgementEmail` (9 cases): recipient and reference fields, built-in template, args payload, per-event template override, the confirmation template must not leak in, event toggle off, Administrator/Guest skipped, plus one test that actually renders the new HTML — every other email test mocks `frappe.sendmail`, so a broken Jinja tag would otherwise ship.
- `test_offline_booking_acknowledges_then_confirms`: creation sends exactly one mail and no tickets; approval then sends the confirmation and generates them.
- `bookingSuccessRedirect.test.ts`: guest + offline is pending, guest without offline is not, logged-in offline unchanged.
- Full suite green on a local site (600 + 69 Python, 104 dashboard unit tests); manual run of the guest offline flow end to end, with the acknowledgement landing in the Email Queue.
