### PR TITLE
chore(dashboard): upgrade frappe-ui to 1.0.0-beta.55 (backport #394)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,11 +15,11 @@
 		"fmt:check": "oxfmt --check"
 	},
 	"dependencies": {
-		"@vueuse/core": "^13.6.0",
-		"@vueuse/router": "^13.6.0",
+		"@vueuse/core": "^14.4.0",
+		"@vueuse/router": "^14.4.0",
 		"canvas-confetti": "^1.9.3",
 		"feather-icons": "^4.29.2",
-		"frappe-ui": "1.0.0-beta.25",
+		"frappe-ui": "1.0.0-beta.55",
 		"socket.io-client": "^4.7.2",
 		"vue": "^3.5.13",
 		"vue-router": "^4.5.0"

--- a/dashboard/src/components/AttendeeFormControl.vue
+++ b/dashboard/src/components/AttendeeFormControl.vue
@@ -1,7 +1,7 @@
 <!-- AttendeeCard.vue -->
 <template>
 	<div
-		class="bg-surface-base border border-outline-gray-3 rounded-xl p-4 md:p-6 mb-6 shadow-sm relative"
+		class="bg-surface-base border border-outline-gray-3 rounded-7 p-4 md:p-6 mb-6 shadow-sm relative"
 	>
 		<!-- Remove Button -->
 

--- a/dashboard/src/components/BaseCustomEventForm.vue
+++ b/dashboard/src/components/BaseCustomEventForm.vue
@@ -5,7 +5,7 @@
 		</div>
 
 		<div v-else-if="submitted" class="text-center">
-			<div class="bg-surface-green-1 border border-outline-green-1 rounded-lg p-8">
+			<div class="bg-surface-green-1 border border-outline-green-1 rounded-6 p-8">
 				<LucideCheckCircle class="w-16 h-16 text-ink-green-6 mx-auto mb-4" />
 				<h2 class="text-ink-green-6 text-2xl-semibold mb-2">
 					{{ formData?.success_title }}
@@ -24,7 +24,7 @@
 		<LoginRequired v-else-if="loginRequired" :message="__('Please log in to submit this form.')" />
 
 		<div v-else-if="formData?.closed" class="text-center">
-			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-lg p-8">
+			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-6 p-8">
 				<LucideAlertCircle class="w-16 h-16 text-ink-amber-6 mx-auto mb-4" />
 				<h2 class="text-ink-amber-6 text-2xl-semibold mb-2">
 					{{ formData.closed_title }}
@@ -39,7 +39,7 @@
 			<EventDetailsHeader :event-details="formData.event" />
 
 			<form
-				class="bg-surface-base border border-outline-gray-1 rounded-lg p-6"
+				class="bg-surface-base border border-outline-gray-1 rounded-6 p-6"
 				@submit.prevent="handleSubmit"
 			>
 				<h1 class="text-ink-gray-9 text-3xl-bold mb-6">
@@ -57,7 +57,7 @@
 									<div
 										v-for="(row, idx) in tableData[field.fieldname]"
 										:key="idx"
-										class="flex items-center justify-between gap-2 border border-outline-gray-2 rounded-md px-3 py-2"
+										class="flex items-center justify-between gap-2 border border-outline-gray-2 rounded-5 px-3 py-2"
 									>
 										<span class="text-sm text-ink-gray-7 min-w-0 truncate">
 											{{ getTableRowSummary(row) }}
@@ -111,7 +111,7 @@
 		</div>
 
 		<div v-else-if="loadError" class="text-center">
-			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-lg p-8">
+			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-6 p-8">
 				<LucideAlertCircle class="w-16 h-16 text-ink-amber-6 mx-auto mb-4" />
 				<h2 class="text-ink-amber-6 text-2xl-semibold mb-2">
 					{{ __("Not Found") }}

--- a/dashboard/src/components/BillingDetails.vue
+++ b/dashboard/src/components/BillingDetails.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="bg-surface-base border border-outline-gray-3 rounded-xl p-4 md:p-6 mb-6 shadow-sm">
+	<div class="bg-surface-base border border-outline-gray-3 rounded-7 p-4 md:p-6 mb-6 shadow-sm">
 		<h3 class="text-base-medium text-ink-gray-8 border-b pb-2 mb-4">
 			{{ __("Billing Details") }}
 		</h3>

--- a/dashboard/src/components/BookingEventInfo.vue
+++ b/dashboard/src/components/BookingEventInfo.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6">
+	<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6">
 		<div class="mb-8 flex items-center justify-between">
 			<h3 class="text-lg-semibold text-ink-gray-9">{{ event.title }}</h3>
 

--- a/dashboard/src/components/BookingFinancialSummary.vue
+++ b/dashboard/src/components/BookingFinancialSummary.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6">
+	<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6">
 		<div class="flex items-center justify-between mb-4">
 			<h3 class="text-lg-semibold text-ink-gray-9">{{ __("Payment Summary") }}</h3>
 			<Badge
@@ -113,7 +113,7 @@ const paymentBadge = computed(() => {
 	} else if (status === "Verification Pending") {
 		return {
 			label: __("Verification Pending"),
-			theme: "orange" as const,
+			theme: "amber" as const,
 			icon: LucideClock,
 		}
 	}

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -60,7 +60,7 @@
 
 		<!-- Pending State for Guest Offline Booking -->
 		<div v-if="bookingSuccess && bookingPendingVerification" class="text-center py-12 px-4">
-			<div class="bg-yellow-50 border border-yellow-200 rounded-xl p-8 max-w-md mx-auto">
+			<div class="bg-yellow-50 border border-yellow-200 rounded-7 p-8 max-w-md mx-auto">
 				<LucideClock class="w-16 h-16 text-yellow-500 mx-auto mb-4" />
 				<h2 class="text-3xl-semibold text-yellow-800 mb-2">
 					{{ __("Booking Received!") }}
@@ -98,7 +98,7 @@
 
 		<!-- Success State for Guest Booking -->
 		<div v-else-if="bookingSuccess" class="text-center py-12 px-4">
-			<div class="bg-green-50 border border-green-200 rounded-xl p-8 max-w-md mx-auto">
+			<div class="bg-green-50 border border-green-200 rounded-7 p-8 max-w-md mx-auto">
 				<LucideCheckCircle class="w-16 h-16 text-green-500 mx-auto mb-4" />
 				<h2 class="text-3xl-semibold text-green-800 mb-2">
 					{{ isZoomEvent ? __("Registration Confirmed!") : __("Booking Confirmed!") }}
@@ -151,7 +151,7 @@
 					<!-- Guest Contact Section -->
 					<div
 						v-if="props.isGuestMode"
-						class="bg-surface-base border border-outline-gray-3 rounded-xl p-4 md:p-6 mb-6 shadow-sm"
+						class="bg-surface-base border border-outline-gray-3 rounded-7 p-4 md:p-6 mb-6 shadow-sm"
 					>
 						<h3 class="text-sm-semibold text-ink-gray-8 mb-4">
 							{{ __("Your Details") }}
@@ -195,7 +195,7 @@
 					<!-- Booking-level Custom Fields -->
 					<div
 						v-if="bookingCustomFields.length > 0"
-						class="bg-surface-base border border-outline-gray-3 rounded-xl p-4 md:p-6 mb-6 shadow-sm"
+						class="bg-surface-base border border-outline-gray-3 rounded-7 p-4 md:p-6 mb-6 shadow-sm"
 					>
 						<CustomFieldsSection
 							v-model="bookingCustomFieldsData"
@@ -244,7 +244,7 @@
 						<!-- Coupon Code Section -->
 						<div
 							v-if="finalTotal > 0 || couponApplied"
-							class="bg-surface-base border border-outline-gray-3 rounded-xl p-4 mb-4"
+							class="bg-surface-base border border-outline-gray-3 rounded-7 p-4 mb-4"
 						>
 							<h3 class="text-xs-medium text-ink-gray-6 uppercase tracking-wide mb-2">
 								{{ __("Coupon Code") }}
@@ -267,7 +267,7 @@
 							<!-- Applied state -->
 							<div v-else-if="couponData">
 								<div
-									class="inline-flex flex-col bg-green-50 border border-green-200 rounded-lg px-3 py-2"
+									class="inline-flex flex-col bg-green-50 border border-green-200 rounded-6 px-3 py-2"
 								>
 									<div class="flex items-center gap-2">
 										<LucideCheck class="w-4 h-4 text-green-600" />
@@ -311,7 +311,7 @@
 								>
 									<!-- Compact info grid -->
 									<div class="grid grid-cols-2 gap-2 text-xs">
-										<div class="bg-surface-gray-2 rounded px-2 py-1.5">
+										<div class="bg-surface-gray-2 rounded-4 px-2 py-1.5">
 											<span class="text-ink-gray-5">{{ __("Ticket") }}</span>
 											<div class="text-ink-gray-8 font-medium truncate">
 												{{
@@ -320,7 +320,7 @@
 												}}
 											</div>
 										</div>
-										<div class="bg-surface-gray-2 rounded px-2 py-1.5">
+										<div class="bg-surface-gray-2 rounded-4 px-2 py-1.5">
 											<span class="text-ink-gray-5">{{ __("Available") }}</span>
 											<div class="text-ink-gray-8 font-medium">
 												{{ couponData.remaining_tickets }}
@@ -329,7 +329,7 @@
 									</div>
 
 									<!-- Eligibility indicator -->
-									<div class="flex items-center justify-between bg-green-50 rounded px-2 py-1.5">
+									<div class="flex items-center justify-between bg-green-50 rounded-4 px-2 py-1.5">
 										<span class="text-green-700 text-xs">{{ __("Eligible attendees") }}</span>
 										<span class="text-green-700 text-sm-semibold">
 											{{ matchingAttendeesCount }}/{{ attendees.length }}
@@ -357,7 +357,7 @@
 
 							<div
 								v-if="couponError"
-								class="mt-2 flex items-start gap-2 p-2.5 bg-amber-50 border border-amber-200 rounded-lg"
+								class="mt-2 flex items-start gap-2 p-2.5 bg-amber-50 border border-amber-200 rounded-6"
 							>
 								<LucideAlertCircle class="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
 								<span class="text-sm text-amber-800">{{ couponError }}</span>

--- a/dashboard/src/components/BookingSummary.vue
+++ b/dashboard/src/components/BookingSummary.vue
@@ -1,6 +1,6 @@
 <!-- BookingSummary.vue -->
 <template>
-	<div class="bg-surface-gray-1 border border-outline-gray-1 rounded-lg p-4">
+	<div class="bg-surface-gray-1 border border-outline-gray-1 rounded-6 p-4">
 		<h2 class="text-2xl-bold text-ink-gray-9 mb-4">{{ __("Booking Summary") }}</h2>
 
 		<!-- Tickets Section -->

--- a/dashboard/src/components/CancellationRequestDialog.vue
+++ b/dashboard/src/components/CancellationRequestDialog.vue
@@ -12,7 +12,7 @@
 			<!-- Info about excluded tickets -->
 			<div
 				v-if="cancelledTickets.length > 0 || cancellationRequestedTickets.length > 0"
-				class="p-4 bg-surface-blue-1 border border-outline-blue-1 rounded-lg"
+				class="p-4 bg-surface-blue-1 border border-outline-blue-1 rounded-6"
 			>
 				<p class="text-sm text-ink-blue-5">
 					<span v-if="cancelledTickets.length > 0">
@@ -32,7 +32,7 @@
 			<!-- Select All Option -->
 			<div
 				v-if="availableTickets.length > 0"
-				class="border border-outline-gray-2 rounded-lg p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
+				class="border border-outline-gray-2 rounded-6 p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
 				:class="{
 					'border-outline-gray-4 bg-surface-gray-2': isAllSelected,
 				}"
@@ -43,7 +43,7 @@
 						type="checkbox"
 						:checked="isAllSelected"
 						@change="toggleSelectAll"
-						class="h-4 w-4 text-ink-gray-6 border-outline-gray-1 rounded focus:ring-ink-gray-5"
+						class="h-4 w-4 text-ink-gray-6 border-outline-gray-1 rounded-4 focus:ring-ink-gray-5"
 					/>
 					<div>
 						<h3 class="font-semibold text-ink-gray-9">
@@ -75,7 +75,7 @@
 					<div
 						v-for="ticket in availableTickets"
 						:key="ticket.name"
-						class="border border-outline-gray-2 rounded-lg p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
+						class="border border-outline-gray-2 rounded-6 p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
 						:class="{
 							'border-outline-gray-4 bg-surface-gray-2': selectedTickets.includes(ticket.name),
 						}"
@@ -86,7 +86,7 @@
 								type="checkbox"
 								:checked="selectedTickets.includes(ticket.name)"
 								@change="toggleTicketSelection(ticket.name)"
-								class="h-4 w-4 text-ink-gray-6 border-outline-gray-1 rounded focus:ring-ink-gray-5 mt-1"
+								class="h-4 w-4 text-ink-gray-6 border-outline-gray-1 rounded-4 focus:ring-ink-gray-5 mt-1"
 							/>
 							<div class="flex-1">
 								<div class="flex items-center justify-between">
@@ -137,7 +137,7 @@
 			<!-- Summary -->
 			<div
 				v-if="selectedTickets.length > 0"
-				class="p-4 bg-surface-blue-1 border border-outline-blue-1 rounded-lg"
+				class="p-4 bg-surface-blue-1 border border-outline-blue-1 rounded-6"
 			>
 				<div class="flex items-center justify-between">
 					<div>

--- a/dashboard/src/components/CancellationRequestNotice.vue
+++ b/dashboard/src/components/CancellationRequestNotice.vue
@@ -1,6 +1,6 @@
 <template>
 	<div v-if="cancellationRequest" class="mb-6">
-		<div class="bg-surface-blue-1 border border-outline-blue-1 rounded-lg p-4">
+		<div class="bg-surface-blue-1 border border-outline-blue-1 rounded-6 p-4">
 			<div class="flex items-center">
 				<LucideInfo class="w-5 h-5 text-ink-blue-5 mr-3" />
 				<div>

--- a/dashboard/src/components/CustomFieldInput.vue
+++ b/dashboard/src/components/CustomFieldInput.vue
@@ -106,7 +106,7 @@
 			<span v-if="field.mandatory" class="text-ink-red-8">*</span>
 		</label>
 		<div v-if="modelValue" class="relative inline-block">
-			<img :src="modelValue" class="h-16 w-16 rounded object-cover border" />
+			<img :src="modelValue" class="h-16 w-16 rounded-4 object-cover border" />
 			<Button
 				variant="subtle"
 				theme="gray"

--- a/dashboard/src/components/EventDetailsHeader.vue
+++ b/dashboard/src/components/EventDetailsHeader.vue
@@ -2,7 +2,7 @@
 <template>
 	<div v-if="eventDetails" class="mb-8">
 		<!-- Banner Image -->
-		<div v-if="eventDetails.banner_image" class="relative w-full rounded-lg overflow-hidden mb-6">
+		<div v-if="eventDetails.banner_image" class="relative w-full rounded-6 overflow-hidden mb-6">
 			<img
 				:src="eventDetails.banner_image"
 				:alt="eventDetails.title"
@@ -18,7 +18,7 @@
 		</div>
 
 		<!-- Event Details -->
-		<div class="bg-surface-gray-1 rounded-lg p-6">
+		<div class="bg-surface-gray-1 rounded-6 p-6">
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6 text-sm">
 				<!-- Date -->
 				<div v-if="eventDetails.start_date" class="flex flex-col items-start gap-3">

--- a/dashboard/src/components/EventSelector.vue
+++ b/dashboard/src/components/EventSelector.vue
@@ -48,7 +48,8 @@
 </template>
 
 <script setup lang="ts">
-import { ListView, Spinner, createListResource, dayjsLocal } from "frappe-ui"
+import { Spinner, createListResource, dayjsLocal } from "frappe-ui"
+import { ListView } from "frappe-ui/experimental"
 
 import type { BuzzEvent } from "@/types"
 

--- a/dashboard/src/components/LoginDialog.vue
+++ b/dashboard/src/components/LoginDialog.vue
@@ -7,17 +7,17 @@
 		</template>
 		<div
 			v-if="login_context?.login_banner"
-			class="rounded-md bg-surface-gray-2 p-3 prose prose-sm max-w-none mb-6"
+			class="rounded-5 bg-surface-gray-2 p-3 prose prose-sm max-w-none mb-6"
 			v-html="login_context.login_banner"
 		/>
 
-		<div v-if="error_message" class="mb-4 rounded-md bg-surface-red-2 p-3 text-sm text-ink-red-6">
+		<div v-if="error_message" class="mb-4 rounded-5 bg-surface-red-2 p-3 text-sm text-ink-red-6">
 			{{ error_message }}
 		</div>
 
 		<div
 			v-if="success_message"
-			class="mb-4 rounded-md bg-surface-green-2 p-3 text-sm text-ink-green-6"
+			class="mb-4 rounded-5 bg-surface-green-2 p-3 text-sm text-ink-green-6"
 		>
 			{{ success_message }}
 		</div>

--- a/dashboard/src/components/OfflinePaymentDialog.vue
+++ b/dashboard/src/components/OfflinePaymentDialog.vue
@@ -8,7 +8,7 @@
 
 			<div class="space-y-4">
 				<!-- Amount -->
-				<div class="text-center p-3 bg-surface-gray-1 rounded">
+				<div class="text-center p-3 bg-surface-gray-1 rounded-4">
 					<div class="text-2xl-bold text-ink-gray-9">
 						{{ formatCurrency(amount, currency) }}
 					</div>
@@ -17,7 +17,7 @@
 				<!-- Payment Details (HTML Content) -->
 				<div
 					v-if="offlineSettings.payment_details"
-					class="prose-sm [&>:first-child]:mt-0 bg-surface-gray-1 border border-outline-gray-1 rounded p-3 text-ink-gray-9"
+					class="prose-sm [&>:first-child]:mt-0 bg-surface-gray-1 border border-outline-gray-1 rounded-4 p-3 text-ink-gray-9"
 					v-html="offlineSettings.payment_details"
 				></div>
 
@@ -46,7 +46,7 @@
 								<span class="truncate">{{ paymentProof.file_name || paymentProof.name }}</span>
 								<button
 									type="button"
-									class="ml-auto p-1 rounded hover:bg-surface-gray-2 text-ink-gray-5 hover:text-ink-gray-8"
+									class="ml-auto p-1 rounded-4 hover:bg-surface-gray-2 text-ink-gray-5 hover:text-ink-gray-8"
 									:title="__('Replace')"
 									@click="openFileSelector"
 								>

--- a/dashboard/src/components/PaymentGatewayDialog.vue
+++ b/dashboard/src/components/PaymentGatewayDialog.vue
@@ -4,7 +4,7 @@
 			<div
 				v-for="gateway in paymentGateways"
 				:key="gateway"
-				class="border border-outline-gray-2 rounded-lg p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
+				class="border border-outline-gray-2 rounded-6 p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
 				:class="{
 					'border-outline-gray-4 bg-surface-gray-2': selectedGateway === gateway,
 				}"

--- a/dashboard/src/components/PhoneInput.vue
+++ b/dashboard/src/components/PhoneInput.vue
@@ -93,9 +93,9 @@ function emitValue() {
 	emit("update:modelValue", formatPhone(dialCode.value, localNumber.value))
 }
 
-function onDialCodeChange(code: string | null) {
+function onDialCodeChange(code: unknown) {
 	if (code) {
-		dialCode.value = code
+		dialCode.value = String(code)
 		emitValue()
 	}
 }

--- a/dashboard/src/components/ProposalEditDialog.vue
+++ b/dashboard/src/components/ProposalEditDialog.vue
@@ -25,10 +25,10 @@
 				>
 					<EditorFixedMenu
 						:items="editorToolbar"
-						class="rounded-t-md border border-b-0 border-outline-gray-2 px-2 py-1"
+						class="rounded-t-5 border border-b-0 border-outline-gray-2 px-2 py-1"
 					/>
 					<EditorContent
-						class="prose-sm py-2 px-3 min-h-[12rem] border border-outline-gray-2 hover:border-outline-gray-3 rounded-b-md bg-surface-gray-3"
+						class="prose-sm py-2 px-3 min-h-[12rem] border border-outline-gray-2 hover:border-outline-gray-3 rounded-b-5 bg-surface-gray-3"
 					/>
 				</Editor>
 			</div>

--- a/dashboard/src/components/QRScanner.vue
+++ b/dashboard/src/components/QRScanner.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden"
+		class="bg-white dark:bg-gray-800 rounded-6 shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden"
 	>
 		<div class="p-4 border-b border-gray-200 dark:border-gray-700">
 			<h3 class="font-medium text-gray-900 dark:text-white">

--- a/dashboard/src/components/RestrictionNotices.vue
+++ b/dashboard/src/components/RestrictionNotices.vue
@@ -2,7 +2,7 @@
 	<div>
 		<!-- Single consolidated restriction notice -->
 		<div v-if="hasRestrictions" class="mb-4">
-			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-lg p-4">
+			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-6 p-4">
 				<div class="flex items-start">
 					<LucideTriangleAlert class="w-5 h-5 text-ink-amber-5 mr-3 mt-0.5 flex-shrink-0" />
 					<div>

--- a/dashboard/src/components/SponsorshipPaymentDialog.vue
+++ b/dashboard/src/components/SponsorshipPaymentDialog.vue
@@ -28,7 +28,7 @@
 				<div
 					v-for="tier in tiers.data"
 					:key="tier.name"
-					class="border border-outline-gray-2 rounded-lg p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
+					class="border border-outline-gray-2 rounded-6 p-4 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
 					:class="{
 						'border-outline-gray-4 bg-surface-gray-2': selectedTier?.name === tier.name,
 					}"
@@ -66,7 +66,7 @@
 					<div
 						v-for="gateway in paymentGateways"
 						:key="gateway"
-						class="border border-outline-gray-2 rounded-lg px-4 py-3 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
+						class="border border-outline-gray-2 rounded-6 px-4 py-3 cursor-pointer transition-all hover:border-outline-gray-3 hover:bg-surface-gray-1"
 						:class="{
 							'border-outline-gray-4 bg-surface-gray-2': selectedGateway === gateway,
 						}"
@@ -88,7 +88,7 @@
 			<!-- Selected Summary -->
 			<div
 				v-if="selectedTier"
-				class="p-4 bg-surface-green-1 border border-outline-green-1 rounded-lg"
+				class="p-4 bg-surface-green-1 border border-outline-green-1 rounded-6"
 			>
 				<div class="flex items-center justify-between">
 					<div>

--- a/dashboard/src/components/SuccessMessage.vue
+++ b/dashboard/src/components/SuccessMessage.vue
@@ -8,7 +8,7 @@
 		leave-from-class="opacity-100 transform translate-y-0 scale-100"
 		leave-to-class="opacity-0 transform -translate-y-4 scale-95"
 	>
-		<div v-if="show" class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-lg p-4">
+		<div v-if="show" class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-6 p-4">
 			<div class="flex items-center">
 				<LucideCheckCircle class="w-6 h-6 text-ink-green-6 mr-3" />
 				<div>

--- a/dashboard/src/components/TicketCard.vue
+++ b/dashboard/src/components/TicketCard.vue
@@ -1,12 +1,12 @@
 <template>
-	<li class="shadow-md p-4 rounded-lg bg-surface-base border border-outline-gray-2 relative">
+	<li class="shadow-md p-4 rounded-6 bg-surface-base border border-outline-gray-2 relative">
 		<!-- Status Badge -->
 		<div v-if="isCancelled || isCancellationRequested" class="absolute top-2 left-2">
 			<Badge v-if="isCancelled" variant="outline" theme="red" size="sm" :label="__('Cancelled')" />
 			<Badge
 				v-else-if="isCancellationRequested"
 				variant="subtle"
-				theme="orange"
+				theme="amber"
 				size="sm"
 				:label="__('Cancellation Requested')"
 			/>
@@ -38,7 +38,7 @@
 					<div
 						v-for="addon in ticket.add_ons"
 						:key="addon.name"
-						class="bg-surface-gray-1 px-3 py-2 rounded text-xs"
+						class="bg-surface-gray-1 px-3 py-2 rounded-4 text-xs"
 					>
 						<div class="font-medium text-ink-gray-8 mb-1">{{ addon.title }}</div>
 						<div v-if="addon.user_selects_option" class="text-ink-gray-7">

--- a/dashboard/src/components/TicketsSection.vue
+++ b/dashboard/src/components/TicketsSection.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6">
+	<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6">
 		<div class="flex justify-between items-center mb-4">
 			<h3 class="text-lg-semibold text-ink-gray-9">{{ __("Your Tickets") }}</h3>
 

--- a/dashboard/src/composables/useProposalStatuses.ts
+++ b/dashboard/src/composables/useProposalStatuses.ts
@@ -3,13 +3,13 @@ import { createListResource } from "frappe-ui"
 // Frappe color name (Talk Proposal Status.color) -> frappe-ui Badge theme.
 // frappe-ui's Badge only themes these five colors, so the doctype's color
 // options are limited to match.
-type BadgeTheme = "blue" | "red" | "green" | "gray" | "orange"
+type BadgeTheme = "blue" | "red" | "green" | "gray" | "amber"
 
 const COLOR_TO_THEME: Record<string, BadgeTheme> = {
 	Gray: "gray",
 	Green: "green",
 	Blue: "blue",
-	Orange: "orange",
+	Orange: "amber",
 	Red: "red",
 }
 
@@ -18,7 +18,7 @@ const COLOR_TO_THEME: Record<string, BadgeTheme> = {
 const FALLBACK_THEME: Record<string, BadgeTheme> = {
 	Accepted: "green",
 	Shortlisted: "blue",
-	"Review Pending": "orange",
+	"Review Pending": "amber",
 	Rejected: "red",
 	Replied: "blue",
 	Duplicate: "gray",

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -7,7 +7,6 @@ import {
 	FormControl,
 	TextInput,
 	frappeRequest,
-	pageMetaPlugin,
 	resourcesPlugin,
 	setConfig,
 } from "frappe-ui"
@@ -41,7 +40,6 @@ applyLanguageFromQuery(router)
 app.use(router)
 app.use(translationPlugin)
 app.use(resourcesPlugin)
-app.use(pageMetaPlugin)
 
 const socket = initSocket()
 app.config.globalProperties.$socket = socket

--- a/dashboard/src/pages/Account.vue
+++ b/dashboard/src/pages/Account.vue
@@ -11,9 +11,10 @@
 		/>
 	</div>
 
-	<!-- Desktop: Tabs for navigation -->
+	<!-- Desktop: Tabs for navigation. Unbound in route mode, so selection follows
+	     the URL; the key re-mounts the list when the async Sponsorships tab lands. -->
 	<div class="hidden sm:block">
-		<Tabs as="div" v-model="tabIndex" :tabs="tabs">
+		<Tabs as="div" :key="tabs.length" :tabs="tabs">
 			<template #tab-panel>
 				<div></div>
 			</template>
@@ -27,7 +28,7 @@
 
 <script setup lang="ts">
 import { Tabs, createResource } from "frappe-ui"
-import { computed, ref, watch } from "vue"
+import { computed, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import LucideCalendarDays from "~icons/lucide/calendar-days"
 import LucideCircleDollarSign from "~icons/lucide/circle-dollar-sign"
@@ -49,23 +50,31 @@ const sponsorships = createResource({
 const tabs = computed(() => {
 	const accountTabs = [
 		{
+			value: "/account/bookings",
 			label: __("My Bookings"),
 			route: "/account/bookings",
-			icon: LucideCalendarDays,
+			iconLeft: LucideCalendarDays,
 		},
-		{ label: __("My Tickets"), route: "/account/tickets", icon: LucideTicket },
 		{
+			value: "/account/tickets",
+			label: __("My Tickets"),
+			route: "/account/tickets",
+			iconLeft: LucideTicket,
+		},
+		{
+			value: "/account/proposals",
 			label: __("Talk Proposals"),
 			route: "/account/proposals",
-			icon: LucideMegaphone,
+			iconLeft: LucideMegaphone,
 		},
 	]
 
 	if (sponsorships.data?.length) {
 		accountTabs.push({
+			value: "/account/sponsorships",
 			label: __("Sponsorships"),
 			route: "/account/sponsorships",
-			icon: LucideCircleDollarSign,
+			iconLeft: LucideCircleDollarSign,
 		})
 	}
 
@@ -88,25 +97,16 @@ function onSelectChange(value: string) {
 	router.push(value)
 }
 
-// Find the tab index based on current route path
-const getTabIndexFromRoute = () => {
-	const currentPath = route.path
-	const index = tabs.value.findIndex((tab) => currentPath.startsWith(tab.route))
-	return index >= 0 ? index : 0
-}
-
-const tabIndex = ref(getTabIndexFromRoute())
-
+// An unknown /account/* path matches no tab, so send it to the first one — but
+// only once the async Sponsorships tab has settled, or /account/sponsorships
+// would bounce away before its tab exists.
 watch(
 	[() => route.path, () => tabs.value.length, () => sponsorships.loading],
 	() => {
 		const onKnownTab = tabs.value.some((tab) => route.path.startsWith(tab.route))
-		const settled = !sponsorships.loading
-		if (!onKnownTab && settled && route.path.startsWith("/account/")) {
+		if (!onKnownTab && !sponsorships.loading && route.path.startsWith("/account/")) {
 			router.replace(tabs.value[0].route)
-			return
 		}
-		tabIndex.value = getTabIndexFromRoute()
 	},
 	{ immediate: true },
 )

--- a/dashboard/src/pages/BookTickets.vue
+++ b/dashboard/src/pages/BookTickets.vue
@@ -23,7 +23,7 @@
 					v-if="eventBookingData.eventDetails?.banner_image"
 					:src="eventBookingData.eventDetails.banner_image"
 					:alt="eventBookingData.eventDetails?.title"
-					class="w-full rounded-lg mb-6 object-cover max-h-48"
+					class="w-full rounded-6 mb-6 object-cover max-h-48"
 				/>
 				<h2 class="text-2xl-semibold text-ink-gray-8 mb-2">
 					{{ __("Registrations Closed") }}

--- a/dashboard/src/pages/BookingDetails.vue
+++ b/dashboard/src/pages/BookingDetails.vue
@@ -8,7 +8,7 @@
 	<div v-else-if="bookingDetails.data">
 		<!-- Approval Pending Status -->
 		<div v-if="!bookingDetails.data.event.free_event && isOfflinePaymentPending" class="mb-6">
-			<div class="p-4 rounded-lg border bg-yellow-50 border-yellow-200">
+			<div class="p-4 rounded-6 border bg-yellow-50 border-yellow-200">
 				<div class="flex items-center gap-3">
 					<div class="w-8 h-8 rounded-full bg-yellow-100 flex items-center justify-center">
 						<LucideClock class="w-4 h-4 text-yellow-600" />
@@ -31,7 +31,7 @@
 
 		<!-- Rejected Status -->
 		<div v-if="isBookingRejected" class="mb-6">
-			<div class="p-4 rounded-lg border bg-red-50 border-red-200">
+			<div class="p-4 rounded-6 border bg-red-50 border-red-200">
 				<div class="flex items-center gap-3">
 					<div class="w-8 h-8 rounded-full bg-red-100 flex items-center justify-center">
 						<LucideXCircle class="w-4 h-4 text-red-600" />

--- a/dashboard/src/pages/BookingsList.vue
+++ b/dashboard/src/pages/BookingsList.vue
@@ -24,7 +24,7 @@
 						row.status === 'Approved' || row.status === 'Confirmed'
 							? 'green'
 							: row.status === 'Approval Pending'
-								? 'orange'
+								? 'amber'
 								: 'red'
 					"
 					variant="subtle"
@@ -39,8 +39,9 @@
 </template>
 
 <script setup lang="ts">
-import { Badge, ListRowItem, ListView, useList } from "frappe-ui"
+import { Badge, useList } from "frappe-ui"
 import { dayjsLocal } from "frappe-ui"
+import { ListRowItem, ListView } from "frappe-ui/experimental"
 
 import { formatCurrency } from "@/utils/currency"
 import { pluralize } from "@/utils/pluralize"

--- a/dashboard/src/pages/CheckInScanner.vue
+++ b/dashboard/src/pages/CheckInScanner.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="min-h-[75vh] border border-gray-200 dark:border-gray-700 shadow-sm mx-4 rounded-md">
+	<div class="min-h-[75vh] border border-gray-200 dark:border-gray-700 shadow-sm mx-4 rounded-5">
 		<!-- Header -->
 		<div class="shadow-sm border-b">
 			<div class="max-w-md mx-auto px-4 py-4">
@@ -51,13 +51,13 @@
 				<!-- Last Scan Status -->
 				<div
 					v-if="validationResult"
-					class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4"
+					class="bg-white dark:bg-gray-800 rounded-6 shadow-sm border border-gray-200 dark:border-gray-700 p-4"
 				>
 					<h3 class="font-medium text-gray-900 dark:text-white mb-2">
 						{{ __("Last Scan Result") }}
 					</h3>
 					<div
-						class="p-3 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800"
+						class="p-3 rounded-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800"
 					>
 						<p class="text-sm-medium text-green-800 dark:text-green-200">
 							{{ validationResult.message }}

--- a/dashboard/src/pages/EventProposalForm.vue
+++ b/dashboard/src/pages/EventProposalForm.vue
@@ -5,7 +5,7 @@
 		</div>
 
 		<div v-else-if="submitted" class="text-center">
-			<div class="bg-surface-green-1 border border-outline-green-1 rounded-lg p-8">
+			<div class="bg-surface-green-1 border border-outline-green-1 rounded-6 p-8">
 				<LucideCheckCircle class="w-16 h-16 text-ink-green-6 mx-auto mb-4" />
 				<h2 class="text-ink-green-6 text-2xl-semibold mb-2">
 					{{ form_data?.success_title }}
@@ -28,7 +28,7 @@
 
 		<div v-else-if="form_data">
 			<form
-				class="bg-surface-base border border-outline-gray-1 rounded-lg"
+				class="bg-surface-base border border-outline-gray-1 rounded-6"
 				@submit.prevent="handleSubmit"
 			>
 				<div class="px-6 py-5 border-b border-outline-gray-1">
@@ -64,7 +64,7 @@
 		</div>
 
 		<div v-else-if="load_error" class="text-center">
-			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-lg p-8">
+			<div class="bg-surface-amber-1 border border-outline-amber-1 rounded-6 p-8">
 				<LucideAlertCircle class="w-16 h-16 text-ink-amber-6 mx-auto mb-4" />
 				<h2 class="text-ink-amber-6 text-2xl-semibold mb-2">
 					{{ __("Not Found") }}

--- a/dashboard/src/pages/ProposalDetails.vue
+++ b/dashboard/src/pages/ProposalDetails.vue
@@ -20,7 +20,7 @@
 		<!-- Accepted Alert -->
 		<div
 			v-if="proposal.doc.status === 'Accepted'"
-			class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-lg p-6"
+			class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-6 p-6"
 		>
 			<div class="flex items-center">
 				<LucideCheckCircle class="w-6 h-6 text-ink-green-6 mr-3" />
@@ -36,7 +36,7 @@
 		<!-- Shortlisted Alert -->
 		<div
 			v-else-if="proposal.doc.status === 'Shortlisted'"
-			class="mb-6 bg-surface-blue-1 border border-outline-blue-1 rounded-lg p-6"
+			class="mb-6 bg-surface-blue-1 border border-outline-blue-1 rounded-6 p-6"
 		>
 			<div class="flex items-center">
 				<LucideStar class="w-6 h-6 text-ink-blue-5 mr-3" />
@@ -52,7 +52,7 @@
 		<!-- Review Pending Alert -->
 		<div
 			v-else-if="proposal.doc.status === 'Review Pending'"
-			class="mb-6 bg-surface-orange-1 border border-outline-orange-1 rounded-lg p-6"
+			class="mb-6 bg-surface-orange-1 border border-outline-orange-1 rounded-6 p-6"
 		>
 			<div class="flex items-center">
 				<LucideClock class="w-6 h-6 text-ink-gray-8 mr-3" />
@@ -72,7 +72,7 @@
 		<!-- Rejected Alert -->
 		<div
 			v-else-if="proposal.doc.status === 'Rejected'"
-			class="mb-6 bg-surface-red-1 border border-outline-red-1 rounded-lg p-6"
+			class="mb-6 bg-surface-red-1 border border-outline-red-1 rounded-6 p-6"
 		>
 			<div class="flex items-center">
 				<LucideXCircle class="w-6 h-6 text-ink-red-5 mr-3" />
@@ -91,7 +91,7 @@
 
 		<div class="space-y-6">
 			<!-- Proposal Information -->
-			<div class="bg-surface-base border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-base border border-outline-gray-1 rounded-6 p-6">
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 					<div>
 						<label class="block text-sm-medium text-ink-gray-6 mb-1">{{ __("Title") }}</label>
@@ -121,7 +121,7 @@
 			</div>
 
 			<!-- Speakers -->
-			<div class="bg-surface-base border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-base border border-outline-gray-1 rounded-6 p-6">
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">{{ __("Speakers") }}</h3>
 				<ListView
 					v-if="proposal.doc.speakers && proposal.doc.speakers.length > 0"
@@ -134,7 +134,7 @@
 			</div>
 
 			<!-- Description -->
-			<div class="bg-surface-base border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-base border border-outline-gray-1 rounded-6 p-6">
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">{{ __("Description") }}</h3>
 				<div
 					v-if="proposal.doc.description"
@@ -170,12 +170,12 @@
 import {
 	Badge,
 	Button,
-	ListView,
 	Spinner,
 	createDocumentResource,
 	createResource,
 	dayjsLocal,
 } from "frappe-ui"
+import { ListView } from "frappe-ui/experimental"
 import { computed, ref, watch } from "vue"
 import LucideCheckCircle from "~icons/lucide/check-circle"
 import LucideClock from "~icons/lucide/clock"

--- a/dashboard/src/pages/ProposalsList.vue
+++ b/dashboard/src/pages/ProposalsList.vue
@@ -49,7 +49,8 @@
 </template>
 
 <script setup lang="ts">
-import { Badge, ListRowItem, ListView, Spinner, createResource, dayjsLocal } from "frappe-ui"
+import { Badge, Spinner, createResource, dayjsLocal } from "frappe-ui"
+import { ListRowItem, ListView } from "frappe-ui/experimental"
 
 import { useProposalStatuses } from "@/composables/useProposalStatuses"
 import { session } from "@/data/session"

--- a/dashboard/src/pages/RegisterInterest.vue
+++ b/dashboard/src/pages/RegisterInterest.vue
@@ -5,7 +5,7 @@
 		</div>
 
 		<div v-else-if="registered" class="text-center">
-			<div class="bg-surface-green-1 border border-outline-green-1 rounded-lg p-8">
+			<div class="bg-surface-green-1 border border-outline-green-1 rounded-6 p-8">
 				<LucideCheckCircle class="w-16 h-16 text-ink-green-6 mx-auto mb-4" />
 				<h2 class="text-ink-green-6 text-2xl-semibold mb-2">
 					{{ __("Thank you for your interest!") }}
@@ -16,10 +16,7 @@
 			</div>
 		</div>
 
-		<div
-			v-else-if="campaignDoc"
-			class="bg-surface-base border border-outline-gray-1 rounded-lg p-6"
-		>
+		<div v-else-if="campaignDoc" class="bg-surface-base border border-outline-gray-1 rounded-6 p-6">
 			<h1 class="text-ink-gray-9 text-3xl-bold mb-6">
 				{{ campaignDoc.title }}
 			</h1>
@@ -45,7 +42,7 @@
 		</div>
 
 		<div v-else-if="error" class="text-center">
-			<div class="bg-surface-red-1 border border-outline-red-1 rounded-lg p-8">
+			<div class="bg-surface-red-1 border border-outline-red-1 rounded-6 p-8">
 				<LucideXCircle class="w-16 h-16 text-ink-red-5 mx-auto mb-4" />
 				<h2 class="text-ink-red-6 text-2xl-semibold mb-2">
 					{{ __("Campaign Not Found") }}

--- a/dashboard/src/pages/SponsorshipDetails.vue
+++ b/dashboard/src/pages/SponsorshipDetails.vue
@@ -31,7 +31,7 @@
 		>
 			<div
 				v-if="showSuccessMessage"
-				class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-lg p-4"
+				class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-6 p-4"
 			>
 				<div class="flex items-center">
 					<LucideCheckCircle class="w-6 h-6 text-ink-green-6 mr-3" />
@@ -54,7 +54,7 @@
 		<!-- Sponsorship Confirmation (shown at top if sponsored) -->
 		<div
 			v-if="sponsorDetails"
-			class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-lg p-6"
+			class="mb-6 bg-surface-green-1 border border-outline-green-1 rounded-6 p-6"
 		>
 			<div class="flex items-center mb-4">
 				<LucideCheckCircle class="w-6 h-6 text-ink-green-6 mr-3" />
@@ -79,7 +79,7 @@
 		<!-- Withdrawn Alert (shown at top for withdrawn inquiries) -->
 		<div
 			v-if="enquiryDetails.data.enquiry.status === 'Withdrawn'"
-			class="mb-6 bg-surface-red-1 border border-outline-red-1 rounded-lg p-6"
+			class="mb-6 bg-surface-red-1 border border-outline-red-1 rounded-6 p-6"
 		>
 			<div class="flex items-center">
 				<LucideXCircle class="w-6 h-6 text-ink-red-5 mr-3" />
@@ -95,7 +95,7 @@
 		<!-- Approval Pending Alert (shown at top for pending approval) -->
 		<div
 			v-if="enquiryDetails.data.enquiry.status === 'Approval Pending'"
-			class="mb-6 bg-surface-blue-1 border border-outline-blue-1 rounded-lg p-6"
+			class="mb-6 bg-surface-blue-1 border border-outline-blue-1 rounded-6 p-6"
 		>
 			<div class="flex items-center">
 				<LucideClock class="w-6 h-6 text-ink-blue-5 mr-3" />
@@ -112,7 +112,7 @@
 		<!-- Payment Pending Alert (shown at top for pending payments) -->
 		<div
 			v-else-if="enquiryDetails.data.enquiry.status === 'Payment Pending'"
-			class="mb-6 bg-surface-orange-1 border border-outline-orange-1 rounded-lg p-6"
+			class="mb-6 bg-surface-orange-1 border border-outline-orange-1 rounded-6 p-6"
 		>
 			<div class="flex items-center justify-between">
 				<div class="flex items-center">
@@ -133,7 +133,7 @@
 
 		<div class="space-y-6">
 			<!-- Company Information -->
-			<div class="bg-surface-base border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-base border border-outline-gray-1 rounded-6 p-6">
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">Company Information</h3>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 					<div>
@@ -156,7 +156,7 @@
 										<img
 											:src="currentLogo"
 											:alt="companyName"
-											class="h-16 w-auto object-contain border border-outline-gray-1 rounded p-1 contrast-100 brightness-100"
+											class="h-16 w-auto object-contain border border-outline-gray-1 rounded-4 p-1 contrast-100 brightness-100"
 											:class="{
 												'opacity-50': uploading || updateLogoResource.loading,
 											}"
@@ -164,7 +164,7 @@
 									</div>
 									<div v-else class="mb-2">
 										<div
-											class="h-16 w-20 border-2 border-dashed border-outline-gray-2 rounded flex items-center justify-center"
+											class="h-16 w-20 border-2 border-dashed border-outline-gray-2 rounded-4 flex items-center justify-center"
 										>
 											<span class="text-ink-gray-4 text-xs">No Logo</span>
 										</div>
@@ -212,7 +212,7 @@
 			</div>
 
 			<!-- Event & Sponsorship Details -->
-			<div class="bg-surface-base border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-base border border-outline-gray-1 rounded-6 p-6">
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">Sponsorship Details</h3>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 					<div>
@@ -247,7 +247,7 @@
 			<!-- Event Information (if available) -->
 			<div
 				v-if="enquiryDetails.data.event_details"
-				class="bg-surface-base border border-outline-gray-1 rounded-lg p-6"
+				class="bg-surface-base border border-outline-gray-1 rounded-6 p-6"
 			>
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">Event Information</h3>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -299,7 +299,7 @@
 		title="Withdraw Sponsorship Inquiry"
 		message="Are you sure you want to withdraw this sponsorship inquiry? This action cannot be undone."
 		size="lg"
-		:icon="{ name: 'triangle-alert', theme: 'yellow' }"
+		:icon="{ name: 'triangle-alert', theme: 'amber' }"
 		:actions="[
 			{
 				label: 'Withdraw Inquiry',
@@ -452,7 +452,7 @@ const getStatusTheme = (status: string) => {
 		case "Paid":
 			return "green"
 		case "Payment Pending":
-			return "orange"
+			return "amber"
 		case "Approval Pending":
 			return "blue"
 		case "Withdrawn":

--- a/dashboard/src/pages/SponsorshipsList.vue
+++ b/dashboard/src/pages/SponsorshipsList.vue
@@ -54,8 +54,9 @@
 </template>
 
 <script setup lang="ts">
-import { Badge, ListView, Spinner, createResource } from "frappe-ui"
+import { Badge, Spinner, createResource } from "frappe-ui"
 import { dayjsLocal } from "frappe-ui"
+import { ListView } from "frappe-ui/experimental"
 
 const columns = [
 	{ label: __("Company"), key: "company_name" },
@@ -85,7 +86,7 @@ const getStatusTheme = (status: string) => {
 		case "Paid":
 			return "green"
 		case "Payment Pending":
-			return "orange"
+			return "amber"
 		case "Approval Pending":
 			return "blue"
 		case "Withdrawn":

--- a/dashboard/src/pages/TicketDetails.vue
+++ b/dashboard/src/pages/TicketDetails.vue
@@ -45,7 +45,7 @@
 
 		<div
 			v-if="hasCustomizableAddOns && !canChangeAddOns"
-			class="mb-4 bg-surface-amber-1 border border-outline-amber-1 rounded-lg p-4"
+			class="mb-4 bg-surface-amber-1 border border-outline-amber-1 rounded-6 p-4"
 		>
 			<div class="flex items-center">
 				<LucideTriangleAlert class="w-5 h-5 text-ink-amber-5 mr-3" />
@@ -60,7 +60,7 @@
 
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 			<!-- Ticket Information -->
-			<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6">
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">
 					{{ __("Ticket Information") }}
 				</h3>
@@ -104,7 +104,7 @@
 			<!-- QR Code Display -->
 			<div
 				v-if="ticketDetails.data.doc.qr_code"
-				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6"
+				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6"
 			>
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">{{ __("QR Code") }}</h3>
 				<div class="flex justify-center">
@@ -112,7 +112,7 @@
 						:src="ticketDetails.data.doc.qr_code"
 						:alt="__('Ticket QR Code')"
 						:title="__('Click to enlarge')"
-						class="max-w-48 h-auto border border-outline-gray-1 rounded contrast-100 brightness-100 cursor-pointer hover:opacity-80 transition-opacity"
+						class="max-w-48 h-auto border border-outline-gray-1 rounded-4 contrast-100 brightness-100 cursor-pointer hover:opacity-80 transition-opacity"
 						@click="showQRExpanded = true"
 					/>
 				</div>
@@ -121,7 +121,7 @@
 			<!-- Add-ons Information -->
 			<div
 				v-if="ticketDetails.data.add_ons && ticketDetails.data.add_ons.length > 0"
-				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6"
+				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6"
 			>
 				<div class="flex justify-between items-center mb-4">
 					<h3 class="text-ink-gray-8 text-lg-semibold">{{ __("Add-ons") }}</h3>
@@ -142,7 +142,7 @@
 					<div
 						v-for="addon in ticketDetails.data.add_ons"
 						:key="addon.name"
-						class="flex justify-between items-center p-3 bg-surface-gray-1 rounded-lg"
+						class="flex justify-between items-center p-3 bg-surface-gray-1 rounded-6"
 					>
 						<div>
 							<p class="font-medium text-ink-gray-9">
@@ -157,7 +157,7 @@
 			</div>
 
 			<!-- Event Information -->
-			<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6">
+			<div class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6">
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">
 					{{ __("Event Information") }}
 				</h3>
@@ -192,7 +192,7 @@
 			<!-- Zoom Webinar Access (only shown if webinar is linked) -->
 			<div
 				v-if="ticketDetails.data.zoom_join_url"
-				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6"
+				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6"
 			>
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">
 					{{ __("Webinar Access") }}
@@ -206,7 +206,7 @@
 						:href="ticketDetails.data.zoom_join_url"
 						target="_blank"
 						rel="noopener noreferrer"
-						class="inline-flex items-center gap-2 px-4 py-2 bg-ink-blue-6 text-surface-base rounded-lg hover:bg-blue-700 transition-colors"
+						class="inline-flex items-center gap-2 px-4 py-2 bg-ink-blue-6 text-surface-base rounded-6 hover:bg-blue-700 transition-colors"
 					>
 						<span>{{ __("Join Zoom Webinar") }}</span>
 						<LucideExternalLink class="w-4 h-4" />
@@ -217,7 +217,7 @@
 			<!-- Booking Information (only shown if user owns the booking) -->
 			<div
 				v-if="ticketDetails.data.booking"
-				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-lg p-6"
+				class="bg-surface-elevation-1 border border-outline-gray-1 rounded-6 p-6"
 			>
 				<h3 class="text-ink-gray-8 text-lg-semibold mb-4">
 					{{ __("Booking Information") }}

--- a/dashboard/src/pages/TicketsList.vue
+++ b/dashboard/src/pages/TicketsList.vue
@@ -6,7 +6,7 @@
 
 		<div
 			v-else-if="tickets.error"
-			class="bg-surface-red-1 border border-outline-red-1 rounded-lg p-4"
+			class="bg-surface-red-1 border border-outline-red-1 rounded-6 p-4"
 		>
 			<p class="text-ink-red-6">{{ __("Error loading tickets") }}: {{ tickets.error.message }}</p>
 		</div>
@@ -36,8 +36,9 @@
 </template>
 
 <script setup lang="ts">
-import { ListView, useList } from "frappe-ui"
+import { useList } from "frappe-ui"
 import { dayjsLocal } from "frappe-ui"
+import { ListView } from "frappe-ui/experimental"
 
 const columns = [
 	{ label: __("Attendee Name"), key: "attendee_name" },

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -1,12 +1,15 @@
-import frappeUIPreset from "frappe-ui/tailwind"
+import frappeUIPreset, { content as frappeUIContent } from "frappe-ui/tailwind"
 
 export default {
 	presets: [frappeUIPreset],
 	content: [
 		"./index.html",
 		"./src/**/*.{vue,js,ts,jsx,tsx}",
-		"./node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}",
-		"./node_modules/frappe-ui/src/molecules/**/*.{vue,js,ts,jsx,tsx}",
+		...frappeUIContent,
+		// ListView lives in frappe-ui/experimental, which the `content` export
+		// deliberately skips. Without this its classes are never scanned and every
+		// list renders unstyled.
+		"./node_modules/frappe-ui/experimental/ListView/**/*.{vue,js,ts,jsx,tsx}",
 	],
 	theme: {
 		extend: {},

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -280,13 +280,6 @@
   dependencies:
     "@floating-ui/utils" "^0.2.9"
 
-"@floating-ui/core@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz"
-  integrity sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==
-  dependencies:
-    "@floating-ui/utils" "^0.2.10"
-
 "@floating-ui/core@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.8.0.tgz#d01c0bbea02e4a57f6fd7d5de6fc2c5c7dca40e1"
@@ -302,14 +295,6 @@
     "@floating-ui/core" "^1.7.1"
     "@floating-ui/utils" "^0.2.9"
 
-"@floating-ui/dom@^1.7.0":
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz"
-  integrity sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==
-  dependencies:
-    "@floating-ui/core" "^1.7.3"
-    "@floating-ui/utils" "^0.2.10"
-
 "@floating-ui/dom@^1.7.4":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.8.0.tgz#8a20e6facbe2456afdbeb6c8b968a72df689cf63"
@@ -317,11 +302,6 @@
   dependencies:
     "@floating-ui/core" "^1.8.0"
     "@floating-ui/utils" "^0.2.12"
-
-"@floating-ui/utils@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz"
-  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
 "@floating-ui/utils@^0.2.12":
   version "0.2.12"
@@ -342,11 +322,6 @@
     "@floating-ui/utils" "^0.2.9"
     vue-demi ">=0.13.0"
 
-"@headlessui/vue@^1.7.14":
-  version "1.7.16"
-  resolved "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.16.tgz"
-  integrity sha512-nKT+nf/q6x198SsyK54mSszaQl/z+QxtASmgMEJtpxSX2Q0OPJX0upS/9daDyiECpeAsvjkoOrm2O/6PyBQ+Qg==
-
 "@iconify/types@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz"
@@ -365,11 +340,6 @@
     kolorist "^1.8.0"
     local-pkg "^1.0.0"
     mlly "^1.7.4"
-
-"@interactjs/types@1.10.27":
-  version "1.10.27"
-  resolved "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz"
-  integrity sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==
 
 "@internationalized/date@^3.5.0":
   version "3.8.2"
@@ -449,11 +419,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@juggle/resize-observer@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz"
-  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
 "@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
   version "1.5.2"
@@ -786,11 +751,6 @@
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
-
-"@popperjs/core@^2.11.2":
-  version "2.11.2"
-  resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz"
-  integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
 "@popperjs/core@^2.9.0":
   version "2.11.7"
@@ -1231,29 +1191,10 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/web-bluetooth@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz"
-  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
-
 "@types/web-bluetooth@^0.0.21":
   version "0.0.21"
   resolved "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz"
   integrity sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==
-
-"@vexip-ui/hooks@^2.8.0":
-  version "2.9.3"
-  resolved "https://registry.npmjs.org/@vexip-ui/hooks/-/hooks-2.9.3.tgz"
-  integrity sha512-DrGlwSa0P0KQ98RU0MrQ4+KcItZDaejAJISv3iT6T6/E2ly4z7c2dzuNzn5Wk7y4FYnkXDfrf2UFNv7EDw8GJg==
-  dependencies:
-    "@floating-ui/dom" "^1.7.0"
-    "@juggle/resize-observer" "^3.4.0"
-    "@vexip-ui/utils" "2.16.4"
-
-"@vexip-ui/utils@2.16.4", "@vexip-ui/utils@^2.16.1":
-  version "2.16.4"
-  resolved "https://registry.npmjs.org/@vexip-ui/utils/-/utils-2.16.4.tgz"
-  integrity sha512-KX+Q4EsuwDp6ZlRJ7OAkiYxu52D5CVM8zpqQz/FXYV+JUtzl9T3dvxgtA8gQ0wm5Sh/xT6jp8Wo4X7tLAzRh/A==
 
 "@vitejs/plugin-vue@^6.0.8":
   version "6.0.8"
@@ -1405,25 +1346,6 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.27.tgz#33a63143d8fb9ca1b3efbc7ecf9bd0ab05f7e06e"
   integrity sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==
 
-"@vueuse/core@^10.4.1":
-  version "10.11.1"
-  resolved "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz"
-  integrity sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==
-  dependencies:
-    "@types/web-bluetooth" "^0.0.20"
-    "@vueuse/metadata" "10.11.1"
-    "@vueuse/shared" "10.11.1"
-    vue-demi ">=0.14.8"
-
-"@vueuse/core@^13.6.0":
-  version "13.6.0"
-  resolved "https://registry.npmjs.org/@vueuse/core/-/core-13.6.0.tgz"
-  integrity sha512-DJbD5fV86muVmBgS9QQPddVX7d9hWYswzlf4bIyUD2dj8GC46R1uNClZhVAmsdVts4xb2jwp1PbpuiA50Qee1A==
-  dependencies:
-    "@types/web-bluetooth" "^0.0.21"
-    "@vueuse/metadata" "13.6.0"
-    "@vueuse/shared" "13.6.0"
-
 "@vueuse/core@^14.1.0":
   version "14.3.0"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-14.3.0.tgz#66c92f9ad7ee989e4a8fd23ec368e55429ea42b2"
@@ -1433,49 +1355,41 @@
     "@vueuse/metadata" "14.3.0"
     "@vueuse/shared" "14.3.0"
 
-"@vueuse/metadata@10.11.1":
-  version "10.11.1"
-  resolved "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz"
-  integrity sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==
-
-"@vueuse/metadata@13.6.0":
-  version "13.6.0"
-  resolved "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.6.0.tgz"
-  integrity sha512-rnIH7JvU7NjrpexTsl2Iwv0V0yAx9cw7+clymjKuLSXG0QMcLD0LDgdNmXic+qL0SGvgSVPEpM9IDO/wqo1vkQ==
+"@vueuse/core@^14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-14.4.0.tgz#a841da6b3c7d548bdeed5bf611e73f3de62d20fa"
+  integrity sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.21"
+    "@vueuse/metadata" "14.4.0"
+    "@vueuse/shared" "14.4.0"
 
 "@vueuse/metadata@14.3.0":
   version "14.3.0"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-14.3.0.tgz#d782b00732d1568503027965c0be92bc1699d76c"
   integrity sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==
 
-"@vueuse/router@^13.6.0":
-  version "13.9.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/router/-/router-13.9.0.tgz#44235e6732a30b53d1c8e2ef13ce783fdd189ca6"
-  integrity sha512-7AYay8Pv/0fC4D0eygbIyZuLyVs+9D7dsnO5D8aqat9qcOz91v/XFWR667WE1+p+OkU0ib+FjQUdnTVBNoIw8g==
+"@vueuse/metadata@14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-14.4.0.tgz#a2508499b803bac14775a9c9b852b8738fc16f98"
+  integrity sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==
+
+"@vueuse/router@^14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/router/-/router-14.4.0.tgz#4c6718241a62400ca2cd50092cc6874681c438e5"
+  integrity sha512-q+dRUKI6xYGT4vNPq2t3fujrXPw2KBFV5Jxhw38liTFzwzGXBYcf8Qdjk7AiQpjEH2xLSin6WVTvj85EEIpo9w==
   dependencies:
-    "@vueuse/shared" "13.9.0"
-
-"@vueuse/shared@10.11.1":
-  version "10.11.1"
-  resolved "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz"
-  integrity sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==
-  dependencies:
-    vue-demi ">=0.14.8"
-
-"@vueuse/shared@13.6.0":
-  version "13.6.0"
-  resolved "https://registry.npmjs.org/@vueuse/shared/-/shared-13.6.0.tgz"
-  integrity sha512-pDykCSoS2T3fsQrYqf9SyF0QXWHmcGPQ+qiOVjlYSzlWd9dgppB2bFSM1GgKKkt7uzn0BBMV3IbJsUfHG2+BCg==
-
-"@vueuse/shared@13.9.0":
-  version "13.9.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-13.9.0.tgz#7168b4ed647e625b05eb4e7e80fe8aabd00e3923"
-  integrity sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==
+    "@vueuse/shared" "14.4.0"
 
 "@vueuse/shared@14.3.0", "@vueuse/shared@^14.1.0":
   version "14.3.0"
   resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-14.3.0.tgz#a3e7e6391f9ed7f363cbb28c32c4a278efaacbd0"
   integrity sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==
+
+"@vueuse/shared@14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-14.4.0.tgz#4e89813c7859d153d48c03d74bff78739f96723b"
+  integrity sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==
 
 acorn@^8.14.0, acorn@^8.14.1:
   version "8.15.0"
@@ -1826,13 +1740,13 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-echarts@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz"
-  integrity sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==
+echarts@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-6.1.0.tgz#ae0f68590f5ebbd728d900907c27acde7c5456d1"
+  integrity sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.6.1"
+    zrender "6.1.0"
 
 electron-to-chromium@^1.4.17:
   version "1.4.47"
@@ -1890,6 +1804,11 @@ entities@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
   integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1956,14 +1875,6 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-feather-icons@^4.28.0:
-  version "4.28.0"
-  resolved "https://registry.npmjs.org/feather-icons/-/feather-icons-4.28.0.tgz"
-  integrity sha512-gRdqKESXRBUZn6Nl0VBq2wPHKRJgZz7yblrrc2lYsS6odkNFDnA4bqvrlEVRUPjE1tFax+0TdbJKZ31ziJuzjg==
-  dependencies:
-    classnames "^2.2.5"
-    core-js "^3.1.3"
-
 feather-icons@^4.29.2:
   version "4.29.2"
   resolved "https://registry.npmjs.org/feather-icons/-/feather-icons-4.29.2.tgz"
@@ -1999,10 +1910,10 @@ fraction.js@^4.1.2:
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz"
   integrity sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==
 
-frappe-ui@1.0.0-beta.25:
-  version "1.0.0-beta.25"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.25.tgz#99aa2463de799ae98550e9be7e4770e79b431680"
-  integrity sha512-RiHl6Nv3vy8ywtQfWG9pvWYiH9aRdhzteXPiF2+Qjsh0owBVnim0ZP6ZE03jhtmaZ5QgrPovZu+rcBTOORWzuA==
+frappe-ui@1.0.0-beta.55:
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.55.tgz#405b8e569d456d8b6679f4dd3109068c3982dfcc"
+  integrity sha512-+G+5GDVIr31+QJ2ekDpM8FOXUWzTO4oBhh9rMjfDzJnFGzISbAy4U7V/XOF3hYOkQz4R/QqnrHTD55o+JRcOoA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"
@@ -2015,8 +1926,6 @@ frappe-ui@1.0.0-beta.25:
     "@codemirror/lang-xml" "^6.1.0"
     "@codemirror/lang-yaml" "^6.1.3"
     "@floating-ui/dom" "^1.7.4"
-    "@headlessui/vue" "^1.7.14"
-    "@popperjs/core" "^2.11.2"
     "@tailwindcss/forms" "^0.5.3"
     "@tailwindcss/line-clamp" "^0.4.4"
     "@tailwindcss/typography" "^0.5.16"
@@ -2056,18 +1965,18 @@ frappe-ui@1.0.0-beta.25:
     "@tiptap/starter-kit" "^3.26.0"
     "@tiptap/suggestion" "^3.26.0"
     "@tiptap/vue-3" "^3.26.0"
-    "@vueuse/core" "^10.4.1"
+    "@vueuse/core" "^14.1.0"
     codemirror "^6.0.1"
     dayjs "^1.11.13"
     dompurify "^3.4.0"
-    echarts "^5.6.0"
-    feather-icons "^4.28.0"
+    echarts "^6.1.0"
+    es-module-lexer "^1.7.0"
     fuzzysort "^3.1.0"
-    grid-layout-plus "^1.1.0"
     highlight.js "^11.11.1"
     idb-keyval "^6.2.0"
     lowlight "^3.3.0"
-    lucide-static "^1.16.0"
+    lucide-static "^1.31.0"
+    magic-string "^0.30.21"
     marked "^15.0.12"
     ora "5.4.1"
     prettier "^3.3.2"
@@ -2133,15 +2042,6 @@ globals@^15.14.0:
   resolved "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz"
   integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
 
-grid-layout-plus@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/grid-layout-plus/-/grid-layout-plus-1.1.0.tgz"
-  integrity sha512-Q5uj0U5nx6xfHg8G1CDRJAEg+/40RVJl5jjRImcRwC78BxoJrEkTneT1pyxYMlbZ8fpGPT6QdHJQkD4+W6gt5A==
-  dependencies:
-    "@vexip-ui/hooks" "^2.8.0"
-    "@vexip-ui/utils" "^2.16.1"
-    interactjs "^1.10.27"
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
@@ -2180,13 +2080,6 @@ inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-interactjs@^1.10.27:
-  version "1.10.27"
-  resolved "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz"
-  integrity sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==
-  dependencies:
-    "@interactjs/types" "1.10.27"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -2419,10 +2312,10 @@ lru-cache@^10.2.0:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lucide-static@^1.16.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/lucide-static/-/lucide-static-1.25.0.tgz#d44930d6e5815faace63d9fd9c46c0cadabaaae8"
-  integrity sha512-uJTdyP8vxKELd+Kqk45ahUvOA1rv3Ehy6ZUP7JlBt8UJwmzHgFFts0OZNU3C6/4MDKsssgR9Jrut7GnuqGgYmg==
+lucide-static@^1.31.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/lucide-static/-/lucide-static-1.35.0.tgz#c8fe76915566f1c2495f17f8f7ead0c1c9824a43"
+  integrity sha512-Mc0cSZXDF+JkVG5YCrTsiDE3jnUrhNE0HJxL/8JJAI6NBGBDuJQPCni4QBRtK1AXVAmU4SlD1DfQG66VStUNCg==
 
 magic-string@^0.30.17:
   version "0.30.17"
@@ -3524,11 +3417,6 @@ vue-demi@>=0.13.0:
   resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz"
   integrity sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==
 
-vue-demi@>=0.14.8:
-  version "0.14.10"
-  resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz"
-  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
-
 vue-router@^4.5.0:
   version "4.5.1"
   resolved "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz"
@@ -3632,9 +3520,9 @@ yaml@^2.3.4:
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz"
   integrity sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==
 
-zrender@5.6.1:
-  version "5.6.1"
-  resolved "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz"
-  integrity sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==
+zrender@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-6.1.0.tgz#c3ef06e6426d5c28865b7183035680d685e00136"
+  integrity sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==
   dependencies:
     tslib "2.3.0"


### PR DESCRIPTION
Manual backport of #394 to `main`. The bot's cherry-pick failed, so this was
resolved by hand.

## What changed

Same commit as #394 — frappe-ui 1.0.0-beta.55, the API migrations it forces
(ListView to `frappe-ui/experimental`, `useTheme` to `useColorScheme`,
`pageMetaPlugin` removed, Popover's `isOpen` slot prop to `open`, orange/yellow
themes to amber, value-based Tabs), the ADR-0006 radius rename, the Tailwind
`content` glob fix for `experimental/ListView`, and @vueuse 13 to 14.

## The conflict

All 14 conflicts were the same shape — `modify/delete`, zero content conflicts.
`main` has no manager dashboard: `ManagerLayout.vue`, `UserMenu.vue`,
`TeamSwitcher.vue`, `dashboard/events/*`, `dashboard/tickets/*` and everything
under `pages/manage/` simply do not exist there. Resolved by keeping them
deleted rather than reintroducing half a feature onto `main`, which is why this
lands 41 files against #394's 55.

Worth stating, since it is the thing that could have gone wrong quietly:
`main`'s `dashboard/src` is a strict subset of develop's, so there is no file
here that the upgrade commit failed to reach. I checked the resolved tree
directly for leftovers rather than trusting that — no named radius aliases
survive, every `ListView`/`ListRowItem` import points at
`frappe-ui/experimental`, and no Popover still destructures the old `isOpen`.

## Testing

`yarn install`, `vue-tsc` clean (0 errors in `src/`), `yarn build` passes,
oxlint and oxfmt pass. Confirmed `min-w-full` and the numbered radius tokens
reach the built CSS, which is the failure mode typecheck cannot see.

Not verified in a browser — no Chrome available here, same caveat as #394.
`skip-demo` applied because this is a backport of an already-reviewed change,
not because the visual does not matter; #394 is where the UI wants a real look.