### PR TITLE
feat(dashboard): event drawer and filters for My Calendar

### DIFF
--- a/buzz/api/booking/__init__.py
+++ b/buzz/api/booking/__init__.py
@@ -6,6 +6,7 @@ from buzz.api.booking.schemas import (
 	BookingConfirmationResponse,
 	BookingDetailsResponse,
 	BookingRequest,
+	BookingSummary,
 	EventBookingDataResponse,
 	FreeBookingResponse,
 	OfflineBookingResponse,
@@ -42,6 +43,12 @@ def get_booking_confirmation(booking_id: str, token: str | None = None) -> Booki
 @frappe.whitelist()
 def get_booking_details(booking_id: str) -> BookingDetailsResponse:
 	return details.build_booking_details(booking_id)
+
+
+@frappe.whitelist()
+def get_my_booking_summaries(event: str) -> list[BookingSummary]:
+	"""Every booking the session user made for one event, each as a receipt."""
+	return details.build_my_booking_summaries(event)
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method

--- a/buzz/api/booking/details.py
+++ b/buzz/api/booking/details.py
@@ -1,15 +1,18 @@
 import frappe
 from frappe import _
+from frappe.utils import flt
 
 from buzz.api.booking.schemas import (
 	BookingConfirmationResponse,
 	BookingDetailsResponse,
+	BookingLine,
+	BookingSummary,
 	ConfirmationBooking,
 	ConfirmationEvent,
 	ConfirmationTicket,
 	ConfirmationVenue,
 )
-from buzz.api.booking.services import verify_booking_access_token
+from buzz.api.booking.services import OFFLINE_PAYMENT_METHOD, verify_booking_access_token
 from buzz.api.tickets import windows
 
 TICKET_FIELDS = [
@@ -162,3 +165,110 @@ def get_cancellation_requested_tickets(cancellation_request, tickets) -> list[st
 		"Ticket Cancellation Item", filters={"parent": cancellation_request.name}, fields=["ticket"]
 	)
 	return [item.ticket for item in requested]
+
+
+def build_my_booking_summaries(event: str) -> list[BookingSummary]:
+	"""The session user's own bookings for one event, newest first.
+
+	The `user` filter is the scope, and the permission query still applies on top of it —
+	nothing here runs with ignore_permissions. A draft stays in so an offline booking
+	awaiting verification is visible; a cancelled one drops out.
+	"""
+	names = frappe.get_all(
+		"Event Booking",
+		filters={"event": event, "user": frappe.session.user, "docstatus": ("!=", 2)},
+		order_by="creation desc",
+		pluck="name",
+	)
+	bookings = [frappe.get_cached_doc("Event Booking", name) for name in names]
+	titles = ticket_type_titles(bookings)
+	add_ons = add_on_values(bookings)
+	return [summarize_booking(booking, titles, add_ons) for booking in bookings]
+
+
+def ticket_type_titles(bookings: list) -> dict[str, str]:
+	"""Titles for every ticket type across the bookings, in one query.
+
+	Ticket types autoname to integers and arrive off an attendee row as strings, so both
+	sides of the lookup are cast.
+	"""
+	ids = {attendee.ticket_type for booking in bookings for attendee in booking.attendees}
+	if not ids:
+		return {}
+
+	# db.get_all: the bookings themselves are already permission-checked, and a title is
+	# all that is read.
+	rows = frappe.db.get_all(
+		"Event Ticket Type", filters={"name": ("in", list(ids))}, fields=["name", "title"]
+	)
+	return {str(row.name): row.title for row in rows}
+
+
+def add_on_values(bookings: list) -> dict[str, list]:
+	"""Add-on rows bought across the bookings, grouped by the attendee row that holds them."""
+	parents = {attendee.add_ons for booking in bookings for attendee in booking.attendees if attendee.add_ons}
+	if not parents:
+		return {}
+
+	rows = frappe.db.get_all(
+		"Ticket Add-on Value",
+		filters={"parent": ("in", list(parents))},
+		fields=["parent", "add_on", "add_on.title as title", "price"],
+	)
+
+	grouped = {}
+	for row in rows:
+		grouped.setdefault(row.parent, []).append(row)
+	return grouped
+
+
+def summarize_booking(booking, titles: dict[str, str], add_ons: dict[str, list]) -> BookingSummary:
+	return BookingSummary(
+		name=booking.name,
+		status=booking.status,
+		payment_status=booking.payment_status,
+		payment_method=booking.offline_payment_method or booking.payment_method,
+		is_offline=booking.payment_method == OFFLINE_PAYMENT_METHOD,
+		currency=booking.currency,
+		booked_on=booking.creation,
+		lines=build_lines(booking, titles, add_ons),
+		net_amount=flt(booking.net_amount),
+		discount_amount=flt(booking.discount_amount),
+		coupon_code=booking.coupon_code,
+		tax_amount=flt(booking.tax_amount),
+		tax_label=booking.tax_label,
+		tax_percentage=flt(booking.tax_percentage),
+		total_amount=flt(booking.total_amount),
+	)
+
+
+def build_lines(booking, titles: dict[str, str], add_ons: dict[str, list]) -> list[BookingLine]:
+	"""One line per ticket type, with the add-ons bought against it beneath.
+
+	ponytail: line amounts are the stored attendee amounts. A Free Tickets coupon zeroes
+	those after the subtotal has already counted them, so under that coupon the lines sum
+	to less than `net_amount` and the discount line makes up the difference.
+	"""
+	lines: dict[str, BookingLine] = {}
+	# Two add-ons of one event may carry the same title, so the sub-lines are keyed by
+	# add-on id and the title is only ever displayed.
+	sub_lines: dict[tuple[str, str], BookingLine] = {}
+	for attendee in booking.attendees:
+		key = str(attendee.ticket_type)
+		line = lines.setdefault(key, BookingLine(label=titles.get(key, key), quantity=0, amount=0))
+		line.quantity += 1
+		line.amount += flt(attendee.amount)
+		fold_add_ons(line, sub_lines, key, add_ons.get(attendee.add_ons, []))
+	return list(lines.values())
+
+
+def fold_add_ons(line: BookingLine, sub_lines: dict, ticket_type: str, rows: list) -> None:
+	"""Fold one attendee's add-ons into their ticket type's line, one entry per add-on."""
+	for row in rows:
+		add_on = sub_lines.get((ticket_type, str(row.add_on)))
+		if not add_on:
+			add_on = BookingLine(label=row.title, quantity=0, amount=0)
+			line.add_ons.append(add_on)
+			sub_lines[(ticket_type, str(row.add_on))] = add_on
+		add_on.quantity += 1
+		add_on.amount += flt(row.price)

--- a/buzz/api/booking/schemas.py
+++ b/buzz/api/booking/schemas.py
@@ -1,5 +1,7 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
+
+from pydantic import Field
 
 from buzz.api.schemas import APIRequest, APIResponse
 
@@ -140,3 +142,37 @@ class FreeTicketsCouponResponse(APIResponse):
 	ticket_type: Any
 	remaining_tickets: int
 	free_add_ons: list
+
+
+class BookingLine(APIResponse):
+	"""One ticket type on a booking. Its add-ons hang off it and never nest further."""
+
+	label: str
+	quantity: int
+	# Attendee amounts only — every add-on carries its own.
+	amount: float
+	add_ons: list["BookingLine"] = Field(default_factory=list)
+
+
+class BookingSummary(APIResponse):
+	"""A booking as a receipt: what was bought and what it cost, and nothing else.
+
+	No ticket, attendee or QR field travels — the card draws none of them, and the reader
+	is always the person who booked.
+	"""
+
+	name: str
+	status: str
+	payment_status: str
+	payment_method: str | None
+	is_offline: bool
+	currency: str
+	booked_on: datetime
+	lines: list[BookingLine]
+	net_amount: float
+	discount_amount: float
+	coupon_code: str | None
+	tax_amount: float
+	tax_label: str | None
+	tax_percentage: float
+	total_amount: float

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -6,6 +6,7 @@ from frappe.tests import IntegrationTestCase
 from buzz.api.booking import (
 	get_booking_details,
 	get_event_booking_data,
+	get_my_booking_summaries,
 	process_booking,
 	send_guest_booking_otp,
 	validate_coupon,
@@ -52,6 +53,26 @@ GUEST_EVENT_DETAIL_FIELDS = {
 	"guest_verification_method",
 	"default_ticket_type",
 }
+
+SUMMARY_FIELDS = {
+	"name",
+	"status",
+	"payment_status",
+	"payment_method",
+	"is_offline",
+	"currency",
+	"booked_on",
+	"lines",
+	"net_amount",
+	"discount_amount",
+	"coupon_code",
+	"tax_amount",
+	"tax_label",
+	"tax_percentage",
+	"total_amount",
+}
+
+LINE_FIELDS = {"label", "quantity", "amount", "add_ons"}
 
 DETAILS_FIELDS = {
 	"doc",
@@ -593,3 +614,87 @@ class TestValidateCoupon(BookingTestCase):
 		)
 		self.assertTrue(payload["valid"])
 		self.assertEqual(payload["max_discount_amount"], 0)
+
+
+class TestGetMyBookingSummaries(BookingTestCase):
+	def setUp(self):
+		super().setUp()
+		for email, first_name in ((BOOKER, "Booking"), (OUTSIDER, "Outsider")):
+			if not frappe.db.exists("User", email):
+				frappe.get_doc(
+					{"doctype": "User", "email": email, "first_name": first_name, "send_welcome_email": 0}
+				).insert(ignore_permissions=True)
+
+	def attendee(self, email="booker@example.com", **overrides):
+		return {
+			"first_name": "Booker",
+			"email": email,
+			"ticket_type": str(self.free_ticket_type.name),
+			**overrides,
+		}
+
+	def book_as(self, user, attendees=None):
+		frappe.set_user(user)
+		try:
+			# The add-on path builds a payment link from a gateway tests do not configure.
+			with patch("buzz.api.booking.services.get_payment_link_for_booking", return_value="/pay"):
+				request = self.booking_request(attendees=attendees or [self.attendee()])
+				return process_booking(request).__json__().get("booking_name")
+		finally:
+			frappe.set_user("Administrator")
+
+	def summaries_of(self, user):
+		frappe.set_user(user)
+		try:
+			return [summary.__json__() for summary in get_my_booking_summaries(str(self.event.name))]
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_the_payload_names_no_ticket_and_no_attendee(self):
+		self.book_as(BOOKER)
+
+		summary = self.summaries_of(BOOKER)[0]
+
+		self.assertEqual(set(summary), SUMMARY_FIELDS)
+		self.assertEqual(set(summary["lines"][0]), LINE_FIELDS)
+
+	def test_another_users_booking_is_absent(self):
+		self.book_as(BOOKER)
+
+		self.assertEqual(self.summaries_of(OUTSIDER), [])
+
+	def test_two_attendees_on_one_ticket_type_are_one_line(self):
+		self.book_as(BOOKER, [self.attendee(), self.attendee("second@example.com")])
+
+		lines = self.summaries_of(BOOKER)[0]["lines"]
+
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(lines[0]["quantity"], 2)
+		self.assertEqual(lines[0]["label"], self.free_ticket_type.title)
+
+	def test_an_add_on_hangs_off_its_ticket_line(self):
+		add_on = frappe.get_doc(
+			{
+				"doctype": "Ticket Add-on",
+				"event": self.event.name,
+				"title": f"Meal {frappe.generate_hash(length=6)}",
+				"price": 500,
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+		self.book_as(BOOKER, [self.attendee(add_ons=[{"add_on": add_on.name, "value": "Veg"}])])
+
+		add_ons = self.summaries_of(BOOKER)[0]["lines"][0]["add_ons"]
+
+		self.assertEqual(len(add_ons), 1)
+		self.assertEqual(add_ons[0]["label"], add_on.title)
+		self.assertEqual(add_ons[0]["quantity"], 1)
+		self.assertEqual(add_ons[0]["amount"], 500)
+
+	def test_a_cancelled_booking_is_excluded(self):
+		booking_name = self.book_as(BOOKER)
+		# Cancelling a ticket mails its holder, and a test site configures no email account.
+		with patch("frappe.sendmail"):
+			frappe.get_doc("Event Booking", booking_name).cancel()
+
+		self.assertEqual(self.summaries_of(BOOKER), [])

--- a/buzz/api/events/__init__.py
+++ b/buzz/api/events/__init__.py
@@ -5,6 +5,7 @@ from buzz.api.events.schemas import (
 	CreatedEvent,
 	EventDetail,
 	EventGuestsResponse,
+	MyEventFilters,
 	MyEventsResponse,
 	NewEvent,
 	RouteAvailability,
@@ -12,9 +13,14 @@ from buzz.api.events.schemas import (
 
 
 @frappe.whitelist()
-def get_my_events() -> MyEventsResponse:
-	"""Events hosted by the session user's teams, plus events they hold a ticket to."""
-	return services.my_events()
+def get_my_events(filters: dict | str | None = None) -> MyEventsResponse:
+	"""Events hosted by the session user's teams, plus events they hold a ticket to.
+
+	`filters` arrives as JSON rather than a model: a nested object cannot ride on a GET
+	query string, and frappe validates a model-annotated argument with validate_python,
+	which does not parse JSON. Same shape as submit_custom_form's `data`.
+	"""
+	return services.my_events(MyEventFilters.model_validate(frappe.parse_json(filters or {})))
 
 
 @frappe.whitelist()

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -1,8 +1,21 @@
 from datetime import date, timedelta
+from typing import Literal
 
 from pydantic import Field
 
 from buzz.api.schemas import APIRequest, APIResponse
+
+
+class MyEventFilters(APIRequest):
+	"""Every field narrows the feed; None is no constraint.
+
+	Literals rather than plain strings so an unknown value is refused at the boundary
+	instead of quietly matching nothing.
+	"""
+
+	role: Literal["hosting", "attending"] | None = None
+	team: str | None = None
+	medium: Literal["In Person", "Online"] | None = None
 
 
 class MyEvent(APIResponse):
@@ -14,8 +27,10 @@ class MyEvent(APIResponse):
 	start_time: timedelta | None = None
 	end_time: timedelta | None = None
 	venue: str | None = None
+	medium: str | None = None
 	banner_image: str | None = None
 	is_host: bool
+	is_attendee: bool
 	team: str | None = None
 	team_name: str | None = None
 	team_logo: str | None = None

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -12,6 +12,7 @@ class MyEvent(APIResponse):
 	start_date: date
 	end_date: date | None = None
 	start_time: timedelta | None = None
+	end_time: timedelta | None = None
 	venue: str | None = None
 	banner_image: str | None = None
 	is_host: bool

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -19,6 +19,7 @@ from buzz.api.events.schemas import (
 	EventVenue,
 	GuestAddOn,
 	MyEvent,
+	MyEventFilters,
 	MyEventsResponse,
 	NewEvent,
 	RouteAvailability,
@@ -28,17 +29,21 @@ from buzz.permissions import has_team_access, my_teams
 from buzz.utils import is_app_installed
 
 
-def my_events() -> MyEventsResponse:
-	upcoming, past = split_by_date(events_for(frappe.session.user))
+def my_events(filters: MyEventFilters | None = None) -> MyEventsResponse:
+	upcoming, past = split_by_date(events_for(frappe.session.user, filters))
 	return MyEventsResponse(upcoming=upcoming, past=past)
 
 
-def events_for(user: str) -> list[MyEvent]:
+def events_for(user: str, filters: MyEventFilters | None = None) -> list[MyEvent]:
 	"""Team membership and ticket ownership are the authorization here.
 
 	Buzz Event's own query condition shows published events to everyone and drafts to the
 	team, which is neither list: a Viewer needs their team's drafts, and an attendee needs
 	the unpublished event they hold a ticket to.
+
+	Filters only ever narrow. The hosted-or-ticketed predicate still bounds the result, so
+	a team filter cannot reach an event the user could not already see, and needs no guard
+	of its own.
 	"""
 	event = frappe.qb.DocType("Buzz Event")
 	ticket = frappe.qb.DocType("Event Ticket")
@@ -51,7 +56,7 @@ def events_for(user: str) -> list[MyEvent]:
 		.where((ticket.attendee_email == user) & (ticket.docstatus == 1))
 	)
 
-	rows = (
+	query = (
 		frappe.qb.from_(event)
 		# Left join: an event predating the team backfill still belongs in the feed.
 		.left_join(team)
@@ -65,19 +70,37 @@ def events_for(user: str) -> list[MyEvent]:
 			event.start_time,
 			event.end_time,
 			event.venue,
+			event.medium,
 			event.banner_image,
 			event.team,
 			team.team_name,
 			team.logo.as_("team_logo"),
 			Case().when(hosted, 1).else_(0).as_("is_host"),
+			Case().when(ticketed, 1).else_(0).as_("is_attendee"),
 		)
 		.where(hosted | ticketed)
 		.orderby(event.start_date)
 		.orderby(event.start_time)
-	).run(as_dict=True)
+	)
+
+	query = narrow(query, event, hosted, ticketed, filters)
+	rows = query.run(as_dict=True)
 
 	# Buzz Event autonames to integers, while every link to it travels as a string.
 	return [MyEvent(**row | {"name": str(row.name)}) for row in rows]
+
+
+def narrow(query, event, hosted, ticketed, filters: MyEventFilters | None):
+	"""Each set field adds one clause; the role reuses the criterions built above."""
+	if not filters:
+		return query
+	if filters.role:
+		query = query.where(hosted if filters.role == "hosting" else ticketed)
+	if filters.team:
+		query = query.where(event.team == filters.team)
+	if filters.medium:
+		query = query.where(event.medium == filters.medium)
+	return query
 
 
 def split_by_date(events: list[MyEvent]) -> tuple[list[MyEvent], list[MyEvent]]:

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -63,6 +63,7 @@ def events_for(user: str) -> list[MyEvent]:
 			event.start_date,
 			event.end_date,
 			event.start_time,
+			event.end_time,
 			event.venue,
 			event.banner_image,
 			event.team,

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -175,6 +175,7 @@ class TestGetMyEvents(IntegrationTestCase):
 				"start_date",
 				"end_date",
 				"start_time",
+				"end_time",
 				"venue",
 				"banner_image",
 				"is_host",

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, today
+from pydantic import ValidationError
 
 from buzz.api.events import check_event_route, get_event, get_event_guests, get_my_events
 from buzz.api.events import create_event as create_event_endpoint
@@ -54,9 +55,9 @@ class TestGetMyEvents(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		self.addCleanup(frappe.set_user, "Administrator")
 
-	def events_of(self, user: str) -> dict[str, list[dict]]:
+	def events_of(self, user: str, **filters) -> dict[str, list[dict]]:
 		frappe.set_user(user)
-		return get_my_events().__json__()
+		return get_my_events(filters or None).__json__()
 
 	def names_in(self, events: list[dict]) -> list[str]:
 		return [event["name"] for event in events]
@@ -161,6 +162,49 @@ class TestGetMyEvents(IntegrationTestCase):
 		self.assertIsNone(row["team_name"])
 		self.assertIsNone(row["team_logo"])
 
+	def test_a_role_filter_keeps_only_hosted_events(self):
+		hosted = create_event("Role Filter Hosted", self.host_team)
+		ticketed = create_event("Role Filter Ticketed", self.other_team)
+		issue_ticket(ticketed, self.host_user)
+
+		names = self.names_in(self.events_of(self.host_user, role="hosting")["upcoming"])
+
+		self.assertIn(hosted, names)
+		self.assertNotIn(ticketed, names)
+
+	def test_a_role_filter_keeps_only_ticketed_events(self):
+		hosted = create_event("Role Filter Own", self.host_team)
+		ticketed = create_event("Role Filter Guest", self.other_team)
+		issue_ticket(ticketed, self.host_user)
+
+		names = self.names_in(self.events_of(self.host_user, role="attending")["upcoming"])
+
+		self.assertIn(ticketed, names)
+		self.assertNotIn(hosted, names)
+
+	def test_a_team_filter_keeps_only_that_teams_events(self):
+		mine = create_event("Team Filter Mine", self.host_team)
+		theirs = create_event("Team Filter Theirs", self.other_team)
+		issue_ticket(theirs, self.host_user)
+
+		names = self.names_in(self.events_of(self.host_user, team=self.host_team)["upcoming"])
+
+		self.assertIn(mine, names)
+		self.assertNotIn(theirs, names)
+
+	def test_a_medium_filter_keeps_only_that_medium(self):
+		online = create_event("Medium Online", self.host_team, medium="Online")
+		in_person = create_event("Medium In Person", self.host_team, medium="In Person")
+
+		names = self.names_in(self.events_of(self.host_user, medium="Online")["upcoming"])
+
+		self.assertIn(online, names)
+		self.assertNotIn(in_person, names)
+
+	def test_an_unknown_filter_value_is_refused(self):
+		with self.assertRaises(ValidationError):
+			self.events_of(self.host_user, role="lurking")
+
 	def test_serializes_every_declared_field(self):
 		create_event("Payload Shape", self.host_team)
 
@@ -177,8 +221,10 @@ class TestGetMyEvents(IntegrationTestCase):
 				"start_time",
 				"end_time",
 				"venue",
+				"medium",
 				"banner_image",
 				"is_host",
+				"is_attendee",
 				"team",
 				"team_name",
 				"team_logo",

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -32,6 +32,7 @@ declare module 'vue' {
     DrawerContent: typeof import('./src/components/common/drawer/DrawerContent.vue')['default']
     EmptyState: typeof import('./src/components/common/EmptyState.vue')['default']
     EventBanner: typeof import('./src/components/dashboard/events/EventBanner.vue')['default']
+    EventBookings: typeof import('./src/components/dashboard/events/EventBookings.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
     EventDrawer: typeof import('./src/components/dashboard/events/EventDrawer.vue')['default']

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -28,6 +28,8 @@ declare module 'vue' {
     CancellationRequestNotice: typeof import('./src/components/CancellationRequestNotice.vue')['default']
     CustomFieldInput: typeof import('./src/components/CustomFieldInput.vue')['default']
     CustomFieldsSection: typeof import('./src/components/CustomFieldsSection.vue')['default']
+    Drawer: typeof import('./src/components/common/drawer/Drawer.vue')['default']
+    DrawerContent: typeof import('./src/components/common/drawer/DrawerContent.vue')['default']
     EmptyState: typeof import('./src/components/common/EmptyState.vue')['default']
     EventBanner: typeof import('./src/components/dashboard/events/EventBanner.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -42,6 +42,7 @@ declare module 'vue' {
     EventRoute: typeof import('./src/components/dashboard/events/EventRoute.vue')['default']
     EventSchedule: typeof import('./src/components/dashboard/events/EventSchedule.vue')['default']
     EventSelector: typeof import('./src/components/EventSelector.vue')['default']
+    FilterBar: typeof import('./src/components/common/filters/FilterBar.vue')['default']
     FormFieldSections: typeof import('./src/components/FormFieldSections.vue')['default']
     LanguageSwitcher: typeof import('./src/components/LanguageSwitcher.vue')['default']
     LoginDialog: typeof import('./src/components/LoginDialog.vue')['default']

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -34,6 +34,7 @@ declare module 'vue' {
     EventBanner: typeof import('./src/components/dashboard/events/EventBanner.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
+    EventDrawer: typeof import('./src/components/dashboard/events/EventDrawer.vue')['default']
     EventGuestItem: typeof import('./src/components/dashboard/events/EventGuestItem.vue')['default']
     EventLocation: typeof import('./src/components/dashboard/events/EventLocation.vue')['default']
     EventMedium: typeof import('./src/components/dashboard/events/EventMedium.vue')['default']

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -28,6 +28,7 @@ declare module 'vue' {
     CancellationRequestNotice: typeof import('./src/components/CancellationRequestNotice.vue')['default']
     CustomFieldInput: typeof import('./src/components/CustomFieldInput.vue')['default']
     CustomFieldsSection: typeof import('./src/components/CustomFieldsSection.vue')['default']
+    EmptyState: typeof import('./src/components/common/EmptyState.vue')['default']
     EventBanner: typeof import('./src/components/dashboard/events/EventBanner.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -20,11 +20,13 @@
 		"canvas-confetti": "^1.9.3",
 		"feather-icons": "^4.29.2",
 		"frappe-ui": "1.0.0-beta.55",
+		"reka-ui": "^2.10.1",
 		"socket.io-client": "^4.7.2",
 		"vue": "^3.5.13",
 		"vue-router": "^4.5.0"
 	},
 	"resolutions": {
+		"reka-ui": "2.10.4",
 		"prosemirror-keymap": "^1.2.3",
 		"prosemirror-model": "^1.25.11",
 		"prosemirror-state": "^1.4.4",

--- a/dashboard/src/components/common/EmptyState.vue
+++ b/dashboard/src/components/common/EmptyState.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+defineProps<{
+	title: string
+	description?: string
+}>()
+</script>
+
+<template>
+	<div class="flex flex-col items-center gap-2 py-12 text-center">
+		<slot name="illustration" />
+
+		<h2 class="text-lg-medium text-ink-gray-8">{{ title }}</h2>
+		<p v-if="description" class="text-base text-ink-gray-5">{{ description }}</p>
+	</div>
+</template>

--- a/dashboard/src/components/common/drawer/Drawer.vue
+++ b/dashboard/src/components/common/drawer/Drawer.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { DrawerRoot } from "reka-ui"
+
+// The edge the drawer is anchored to is the edge you swipe towards to dismiss it,
+// so reka's swipeDirection is the only positioning input DrawerContent needs.
+withDefaults(
+	defineProps<{
+		swipeDirection?: "up" | "right" | "down" | "left"
+		// false lets the page stay interactive; "trap-focus" keeps focus in without
+		// locking scroll.
+		modal?: boolean | "trap-focus"
+		snapPoints?: (number | string)[]
+	}>(),
+	{ swipeDirection: "down", modal: true, snapPoints: undefined },
+)
+
+const open = defineModel<boolean>("open", { default: false })
+const snapPoint = defineModel<number | string | null>("snapPoint", { default: null })
+</script>
+
+<template>
+	<DrawerRoot
+		v-model:open="open"
+		v-model:snap-point="snapPoint"
+		:swipe-direction="swipeDirection"
+		:modal="modal"
+		:snap-points="snapPoints"
+	>
+		<slot />
+	</DrawerRoot>
+</template>

--- a/dashboard/src/components/common/drawer/DrawerContent.vue
+++ b/dashboard/src/components/common/drawer/DrawerContent.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { DrawerContent, DrawerHandle, DrawerOverlay, DrawerPortal } from "reka-ui"
+
+withDefaults(
+	defineProps<{
+		showSwipeHandle?: boolean
+		// Governs the cross axis: width for a side drawer, height for a bottom or top one.
+		size?: "md" | "lg" | "xl"
+	}>(),
+	{ showSwipeHandle: true, size: "md" },
+)
+</script>
+
+<template>
+	<DrawerPortal>
+		<DrawerOverlay class="drawer-overlay fixed inset-0 z-40 bg-black/20 backdrop-blur-sm" />
+
+		<DrawerContent :data-size="size" class="drawer bg-surface-elevation-2 shadow-2xl">
+			<DrawerHandle
+				v-if="showSwipeHandle"
+				class="drawer-handle mx-auto my-3 h-1.5 w-12 shrink-0 rounded-full bg-surface-gray-4"
+			/>
+			<slot />
+		</DrawerContent>
+	</DrawerPortal>
+</template>
+
+<style scoped>
+/* reka positions nothing: it sets data-swipe-direction plus the swipe offset vars and
+   leaves the transform to us, the same contract Base UI gives shadcn.
+
+   Keyframes rather than transitions, against the usual preference: reka's Presence
+   decides when to unmount by waiting for animationend and reading animation-name, so a
+   plain transition unmounts instantly with no exit. Keyframes also give an entrance,
+   which a transition cannot — the element mounts already at data-state="open", with no
+   from-state to travel from. */
+.drawer {
+	position: fixed;
+	z-index: 50;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	--drawer-inset: 0.5rem;
+	--drawer-width: 28rem;
+	--drawer-height: calc(100dvh - 12rem);
+	--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.drawer[data-state="open"] {
+	animation: drawer-in 320ms var(--ease-out);
+}
+/* Fast where the system responds, slower where the user was deciding. */
+.drawer[data-state="closed"] {
+	animation: drawer-out 200ms var(--ease-out) forwards;
+}
+
+/* Following the finger has to be instant, or the drawer lags behind the drag. */
+.drawer[data-swiping] {
+	animation: none;
+}
+
+@keyframes drawer-in {
+	from {
+		transform: var(--drawer-hidden);
+	}
+}
+@keyframes drawer-out {
+	to {
+		transform: var(--drawer-hidden);
+	}
+}
+
+/* The largest takes half the viewport once there is room for it; below that the 75%
+   cross-axis rule already keeps it from swallowing a small screen. */
+.drawer[data-size="lg"] {
+	--drawer-width: 36rem;
+	--drawer-height: calc(100dvh - 6rem);
+}
+.drawer[data-size="xl"] {
+	--drawer-width: max(28rem, 50vw);
+	--drawer-height: max(28rem, 50dvh);
+}
+
+.drawer[data-swipe-direction="down"],
+.drawer[data-swipe-direction="up"] {
+	left: 0;
+	right: 0;
+	max-height: var(--drawer-height);
+	transform: translateY(var(--drawer-swipe-movement-y, 0px));
+}
+
+/* Inset from every edge rather than pinned to one: a side drawer reads as a panel over
+   the page, so it keeps its rounding on all four corners. */
+.drawer[data-swipe-direction="left"],
+.drawer[data-swipe-direction="right"] {
+	top: var(--drawer-inset);
+	bottom: var(--drawer-inset);
+	width: 75%;
+	max-width: var(--drawer-width);
+	border-radius: var(--radius-6);
+	transform: translateX(var(--drawer-swipe-movement-x, 0px));
+}
+
+/* The inset has to be travelled too, or the drawer parks a gap short of the edge. */
+.drawer[data-swipe-direction="down"] {
+	bottom: 0;
+	border-top-left-radius: var(--radius-6);
+	border-top-right-radius: var(--radius-6);
+	--drawer-hidden: translateY(100%);
+}
+.drawer[data-swipe-direction="up"] {
+	top: 0;
+	border-bottom-left-radius: var(--radius-6);
+	border-bottom-right-radius: var(--radius-6);
+	--drawer-hidden: translateY(-100%);
+}
+.drawer[data-swipe-direction="left"] {
+	left: var(--drawer-inset);
+	--drawer-hidden: translateX(calc(-100% - var(--drawer-inset)));
+}
+.drawer[data-swipe-direction="right"] {
+	right: var(--drawer-inset);
+	--drawer-hidden: translateX(calc(100% + var(--drawer-inset)));
+}
+
+/* A side drawer has no edge to swipe down from, so its handle would be a lie. */
+.drawer[data-swipe-direction="left"] .drawer-handle,
+.drawer[data-swipe-direction="right"] .drawer-handle {
+	display: none;
+}
+
+/* Settled before the panel lands rather than racing it. */
+.drawer-overlay {
+	--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+}
+.drawer-overlay[data-state="open"] {
+	animation: drawer-overlay-in 240ms var(--ease-out);
+}
+.drawer-overlay[data-state="closed"] {
+	animation: drawer-overlay-out 200ms var(--ease-out) forwards;
+}
+
+@keyframes drawer-overlay-in {
+	from {
+		opacity: 0;
+	}
+}
+@keyframes drawer-overlay-out {
+	to {
+		opacity: 0;
+	}
+}
+
+/* Gentler, not none: the fade still explains what happened, nothing travels. */
+@media (prefers-reduced-motion: reduce) {
+	.drawer[data-state="open"] {
+		animation: drawer-overlay-in 200ms var(--ease-out);
+	}
+	.drawer[data-state="closed"] {
+		animation: drawer-overlay-out 200ms var(--ease-out) forwards;
+	}
+}
+</style>

--- a/dashboard/src/components/common/drawer/index.ts
+++ b/dashboard/src/components/common/drawer/index.ts
@@ -1,0 +1,8 @@
+// Trigger, Close, Title and Description carry no styling of their own — pass `as-child`
+// or a class and let the caller decide — so they come straight from reka. Title and
+// Description also wire the content's aria-labelledby and aria-describedby, so a drawer
+// should always render them even when its layout puts them somewhere unusual.
+export { DrawerClose, DrawerDescription, DrawerTitle, DrawerTrigger } from "reka-ui"
+
+export { default as Drawer } from "./Drawer.vue"
+export { default as DrawerContent } from "./DrawerContent.vue"

--- a/dashboard/src/components/common/filters/FilterBar.vue
+++ b/dashboard/src/components/common/filters/FilterBar.vue
@@ -96,7 +96,7 @@ const clear = () => (model.value = Object.fromEntries(props.groups.map((group) =
 					>
 						Filters
 						<template v-if="hiddenCount" #suffix>
-							<Badge theme="blue" size="sm" :label="String(hiddenCount)" />
+							<Badge variant="solid" size="sm" :label="String(hiddenCount)" />
 						</template>
 					</Button>
 				</template>

--- a/dashboard/src/components/common/filters/FilterBar.vue
+++ b/dashboard/src/components/common/filters/FilterBar.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { Badge, Button, Checkbox, Popover, Select } from "frappe-ui"
+import { computed } from "vue"
+
+export interface FilterOption {
+	value: string
+	label: string
+}
+
+export interface FilterGroup {
+	/** Doubles as the query-param name. */
+	key: string
+	label: string
+	options: FilterOption[]
+	/** Rendered beside the Filters button rather than inside it. */
+	quick?: boolean
+	/** One choice at a time, shown as a select. Give it an option with an empty value
+	 *  for the "no filter" case — that choice drops the param. */
+	single?: boolean
+}
+
+/** Group key to selected values. Within a group the values are OR-ed. */
+export type FilterValues = Record<string, string[]>
+
+const props = defineProps<{ groups: FilterGroup[] }>()
+const model = defineModel<FilterValues>({ required: true })
+
+const quickGroups = computed(() => props.groups.filter((group) => group.quick))
+const panelGroups = computed(() => props.groups.filter((group) => !group.quick))
+
+// Chips already show their own state, so only what the panel hides gets counted.
+const hiddenCount = computed(() =>
+	panelGroups.value.reduce((total, group) => total + (model.value[group.key]?.length || 0), 0),
+)
+
+const anyActive = computed(() => props.groups.some((group) => model.value[group.key]?.length))
+
+const isOn = (key: string, value: string) => !!model.value[key]?.includes(value)
+
+const chosen = (key: string) => model.value[key]?.[0] || ""
+
+/** An empty value means "no filter", so it clears the group rather than selecting nothing. */
+function choose(key: string, value: string) {
+	model.value = { ...model.value, [key]: value ? [value] : [] }
+}
+
+function toggle(key: string, value: string) {
+	const current = model.value[key] || []
+	// Assignment, not mutation: a route-backed getter hands back a fresh array each read.
+	model.value = {
+		...model.value,
+		[key]: isOn(key, value) ? current.filter((held) => held !== value) : [...current, value],
+	}
+}
+
+const clear = () => (model.value = Object.fromEntries(props.groups.map((group) => [group.key, []])))
+</script>
+
+<template>
+	<div class="flex flex-wrap items-center gap-2">
+		<template v-for="group in quickGroups" :key="group.key">
+			<Select
+				v-if="group.single"
+				size="sm"
+				:aria-label="group.label"
+				:class="chosen(group.key) && 'bg-surface-gray-2 ring-1 ring-outline-gray-4'"
+				:options="group.options"
+				:model-value="chosen(group.key)"
+				@update:model-value="choose(group.key, String($event ?? ''))"
+			/>
+
+			<div v-else role="group" :aria-label="group.label" class="flex gap-2">
+				<Button
+					v-for="option in group.options"
+					:key="option.value"
+					size="sm"
+					:label="option.label"
+					:variant="isOn(group.key, option.value) ? 'solid' : 'subtle'"
+					:aria-pressed="isOn(group.key, option.value)"
+					@click="toggle(group.key, option.value)"
+				/>
+			</div>
+		</template>
+
+		<div v-if="panelGroups.length" class="flex items-center">
+			<!-- Popover, not Dropdown: a Dropdown's switch rows sit outside the focus
+			     collection, so arrow keys and Tab skip them and the panel is mouse-only. -->
+			<Popover align="start">
+				<template #trigger>
+					<!-- No `label` prop: Button forces aria-label from it, silencing the count. -->
+					<Button
+						size="sm"
+						icon-left="lucide-list-filter"
+						:class="anyActive && 'rounded-r-none'"
+						:aria-label="hiddenCount ? `Filters, ${hiddenCount} active` : 'Filters'"
+					>
+						Filters
+						<template v-if="hiddenCount" #suffix>
+							<Badge theme="blue" size="sm" :label="String(hiddenCount)" />
+						</template>
+					</Button>
+				</template>
+
+				<div class="w-56 space-y-4 p-2">
+					<fieldset v-for="group in panelGroups" :key="group.key" class="space-y-0.5">
+						<legend class="px-2 pb-1 text-sm text-ink-gray-5">{{ group.label }}</legend>
+						<Checkbox
+							v-for="option in group.options"
+							:key="option.value"
+							padded
+							:label="option.label"
+							:model-value="isOn(group.key, option.value)"
+							@update:model-value="toggle(group.key, option.value)"
+						/>
+					</fieldset>
+				</div>
+			</Popover>
+
+			<!-- Hairline rather than a gap: the two read as one control, as in Frappe's own
+			     filter chip. -->
+			<template v-if="anyActive">
+				<span class="h-4 w-px bg-outline-gray-2" aria-hidden="true" />
+				<Button
+					size="sm"
+					icon="lucide-x"
+					class="rounded-l-none"
+					aria-label="Clear filters"
+					@click="clear"
+				/>
+			</template>
+		</div>
+	</div>
+</template>

--- a/dashboard/src/components/common/filters/index.ts
+++ b/dashboard/src/components/common/filters/index.ts
@@ -1,0 +1,2 @@
+export { default as FilterBar } from "./FilterBar.vue"
+export type { FilterGroup, FilterOption, FilterValues } from "./FilterBar.vue"

--- a/dashboard/src/components/dashboard/TimelineList.vue
+++ b/dashboard/src/components/dashboard/TimelineList.vue
@@ -38,6 +38,10 @@ const tabOptions = [
 			<TabButtons v-model="tab" :options="tabOptions" size="md" />
 		</header>
 
+		<div v-if="$slots.controls" class="flex items-center justify-between gap-4">
+			<slot name="controls" />
+		</div>
+
 		<ErrorMessage v-if="error" :message="error.message" />
 
 		<LoadingText v-else-if="loading" :text="`Loading ${noun}...`" />

--- a/dashboard/src/components/dashboard/TimelineList.vue
+++ b/dashboard/src/components/dashboard/TimelineList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends { name: string }">
-import { ErrorMessage, LoadingText, TabButtons } from "frappe-ui"
+import { ErrorMessage, Icon, LoadingText, TabButtons } from "frappe-ui"
 
 import { dayLabel, monthLabel, weekday } from "@/utils/dateLabels"
 import type { MonthGroup } from "@/utils/eventGroups"
@@ -7,7 +7,8 @@ import type { TimelineTab } from "@/utils/timelineTabs"
 
 defineProps<{
 	heading: string
-	// Names the rows in "Loading tickets..." and "No upcoming tickets.".
+	icon?: string
+	description?: string
 	noun: string
 	months: MonthGroup<T>[]
 	loading?: boolean
@@ -24,8 +25,16 @@ const tabOptions = [
 
 <template>
 	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
-		<header class="flex items-center justify-between">
-			<h1 class="font-semibold text-4xl">{{ heading }}</h1>
+		<header class="flex items-start justify-between">
+			<div class="flex flex-col gap-3 items-start">
+				<div class="flex gap-3 items-center">
+					<div v-if="icon" class="p-2 bg-surface-gray-3 rounded-4">
+						<Icon :name="icon" class="size-6" />
+					</div>
+					<h1 class="font-semibold text-4xl">{{ heading }}</h1>
+				</div>
+				<p class="text-p-base" v-if="description">{{ description }}</p>
+			</div>
 			<TabButtons v-model="tab" :options="tabOptions" size="md" />
 		</header>
 

--- a/dashboard/src/components/dashboard/TimelineList.vue
+++ b/dashboard/src/components/dashboard/TimelineList.vue
@@ -72,8 +72,11 @@ const tabOptions = [
 			</section>
 		</div>
 
-		<p v-if="!months.length && !loading && !error" class="text-base text-ink-gray-5">
-			No {{ tab }} {{ noun }}.
-		</p>
+		<!-- A div, not a p: the slot takes a block component. -->
+		<div v-if="!months.length && !loading && !error">
+			<slot name="empty-state">
+				<p class="text-base text-ink-gray-5">No {{ tab }} {{ noun }}.</p>
+			</slot>
+		</div>
 	</div>
 </template>

--- a/dashboard/src/components/dashboard/events/EventBookings.vue
+++ b/dashboard/src/components/dashboard/events/EventBookings.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import { Badge, Button, Spinner, dayjs } from "frappe-ui"
+import { Accordion } from "frappe-ui/experimental"
+import { computed, ref, toRef, watch } from "vue"
+
+import { useMyBookingSummaries } from "@/data/bookings"
+import { session } from "@/data/session"
+import { formatCurrency } from "@/utils/currency"
+
+const props = defineProps<{ event: string }>()
+
+const event = toRef(props, "event")
+const summaries = useMyBookingSummaries(() => event.value)
+
+const bookings = computed(() => summaries.data ?? [])
+
+const selected = ref<string | null>(null)
+
+// The first booking is shown by default, and a booking that disappears cannot stay selected.
+watch(
+	bookings,
+	(list) => {
+		const names = list.map((booking) => booking.name)
+		if (!selected.value || !names.includes(selected.value)) selected.value = names[0] ?? null
+	},
+	{ immediate: true },
+)
+
+const booking = computed(() => bookings.value.find((row) => row.name === selected.value) ?? null)
+
+const money = (amount: number) => formatCurrency(amount, booking.value?.currency)
+
+const isPaid = computed(() => booking.value?.payment_status === "Paid")
+
+const statusTheme = computed(() => {
+	if (isPaid.value) return "green"
+	return booking.value?.status === "Rejected" ? "red" : "amber"
+})
+
+/** Only the lines this booking has — a free booking states no tax or discount. */
+const totalLines = computed(() => {
+	const row = booking.value
+	if (!row) return []
+	const lines = [{ label: "Subtotal", value: money(row.net_amount), strong: false }]
+	if (row.discount_amount)
+		lines.push({
+			label: row.coupon_code ? `Discount · ${row.coupon_code}` : "Discount",
+			value: `− ${money(row.discount_amount)}`,
+			strong: false,
+		})
+	if (row.tax_amount)
+		lines.push({
+			label: row.tax_percentage
+				? `${row.tax_label || "Tax"} (${row.tax_percentage}%)`
+				: row.tax_label || "Tax",
+			value: money(row.tax_amount),
+			strong: false,
+		})
+	lines.push({
+		label: "Total",
+		value: row.total_amount ? money(row.total_amount) : "Free",
+		strong: true,
+	})
+	return lines
+})
+
+const bookedOn = computed(() =>
+	booking.value ? dayjs(booking.value.booked_on).format("D MMM, HH:mm") : "",
+)
+
+const accordionItems = [{ value: "booking", title: "Booking Details" }]
+</script>
+
+<template>
+	<div class="px-4 pb-4">
+		<Accordion :items="accordionItems">
+			<template #item-content>
+				<Spinner v-if="summaries.loading" class="size-4" />
+
+				<p v-else-if="!booking" class="text-p-base text-ink-gray-5">
+					No booking of yours for this event.
+				</p>
+
+				<div v-else class="flex flex-col gap-5">
+					<!-- One chip per booking; a person can book the same event more than once. -->
+					<div v-if="bookings.length > 1" class="flex flex-wrap gap-2">
+						<Button
+							v-for="row in bookings"
+							:key="row.name"
+							size="sm"
+							:variant="row.name === selected ? 'solid' : 'subtle'"
+							@click="selected = row.name"
+						>
+							<span class="font-mono">#{{ row.name }}</span>
+						</Button>
+					</div>
+
+					<div class="flex flex-col gap-5 rounded-lg bg-surface-gray-1 p-4">
+						<div>
+							<p class="text-p-xs uppercase tracking-wide text-ink-gray-5">
+								{{ isPaid ? "Amount paid" : "Amount due" }}
+							</p>
+							<div class="mt-1 flex items-center justify-between gap-3">
+								<span class="font-mono text-3xl font-semibold tabular-nums text-ink-gray-9">
+									{{ booking.total_amount ? money(booking.total_amount) : "Free" }}
+								</span>
+								<Badge :theme="statusTheme" variant="subtle" size="lg">
+									<template v-if="isPaid" #prefix>
+										<span class="lucide-check size-3" aria-hidden="true" />
+									</template>
+									{{ isPaid ? "Paid" : booking.payment_status }}
+								</Badge>
+							</div>
+						</div>
+
+						<div
+							v-if="booking.payment_method"
+							class="flex items-center gap-3 rounded-lg border border-dashed border-outline-gray-2 px-3 py-2 text-p-base text-ink-gray-7"
+						>
+							<span class="lucide-circle-dollar-sign size-5 shrink-0" aria-hidden="true" />
+							<span>
+								{{ booking.payment_method }}
+								<template v-if="booking.is_offline"> · collected offline</template>
+							</span>
+						</div>
+
+						<div>
+							<p class="text-p-xs uppercase tracking-wide text-ink-gray-5">Breakdown</p>
+							<ul
+								class="mt-2 flex flex-col divide-y divide-outline-gray-1 border-t border-outline-gray-1"
+							>
+								<li v-for="(line, index) in booking.lines" :key="index" class="py-2">
+									<div class="flex items-baseline justify-between gap-3">
+										<p class="min-w-0 truncate text-p-base text-ink-gray-8">
+											{{ line.label }}
+											<span class="text-ink-gray-5">× {{ line.quantity }}</span>
+										</p>
+										<span class="shrink-0 font-mono text-p-base tabular-nums text-ink-gray-8">
+											{{ money(line.amount) }}
+										</span>
+									</div>
+									<div
+										v-for="(addOn, addOnIndex) in line.add_ons"
+										:key="addOnIndex"
+										class="flex items-baseline justify-between gap-3 pl-4 text-ink-gray-6"
+									>
+										<p class="min-w-0 truncate text-p-sm">
+											↳ {{ addOn.label }}
+											<span class="text-ink-gray-5">× {{ addOn.quantity }}</span>
+										</p>
+										<span class="shrink-0 font-mono text-p-sm tabular-nums">{{
+											money(addOn.amount)
+										}}</span>
+									</div>
+								</li>
+							</ul>
+						</div>
+
+						<dl class="flex flex-col gap-1 border-t border-outline-gray-1 pt-3">
+							<div v-for="line in totalLines" :key="line.label" class="flex justify-between gap-3">
+								<dt
+									:class="
+										line.strong ? 'text-p-base text-ink-gray-8' : 'text-p-base text-ink-gray-5'
+									"
+								>
+									{{ line.label }}
+								</dt>
+								<dd
+									class="font-mono tabular-nums"
+									:class="
+										line.strong
+											? 'text-p-base font-medium text-ink-gray-9'
+											: 'text-p-base text-ink-gray-7'
+									"
+								>
+									{{ line.value }}
+								</dd>
+							</div>
+						</dl>
+					</div>
+
+					<div class="flex items-center gap-2">
+						<span
+							class="flex size-7 shrink-0 items-center justify-center rounded-full bg-surface-gray-2 text-p-sm uppercase text-ink-gray-7"
+						>
+							{{ session.user?.slice(0, 1) }}
+						</span>
+						<div class="min-w-0">
+							<p class="truncate text-p-base text-ink-gray-8">{{ session.user }}</p>
+							<p class="text-p-sm text-ink-gray-5">Booked this on {{ bookedOn }}</p>
+						</div>
+					</div>
+				</div>
+			</template>
+		</Accordion>
+	</div>
+</template>

--- a/dashboard/src/components/dashboard/events/EventCard.vue
+++ b/dashboard/src/components/dashboard/events/EventCard.vue
@@ -4,7 +4,7 @@ import { computed } from "vue"
 import { RouterLink } from "vue-router"
 
 import type { MyEvent } from "@/types"
-import { dayLabel } from "@/utils/dateLabels"
+import { dayLabel, timeLabel } from "@/utils/dateLabels"
 import { bannerPattern } from "@/utils/eventBanner"
 
 // The Events page files cards under a date heading; a standalone list has to
@@ -27,12 +27,7 @@ const linksToManage = computed(() => props.routeToManage && props.event.is_host)
 // The button would be a second link inside the first, so the card link wins.
 const canManage = computed(() => props.showManage && !linksToManage.value && props.event.is_host)
 
-// Times arrive as a serialized timedelta ("9:00:00"), so the hour needs padding.
-const startTime = computed((): string => {
-	if (!props.event.start_time) return ""
-	const [hour, minute] = props.event.start_time.split(":")
-	return `${hour.padStart(2, "0")}:${minute}`
-})
+const startTime = computed(() => (props.event.start_time ? timeLabel(props.event.start_time) : ""))
 
 const banner = computed(() => ({ backgroundImage: bannerPattern(props.event.name) }))
 
@@ -91,6 +86,7 @@ const venue = computed(() => {
 				</p>
 				<Button
 					v-if="canManage"
+					class="relative z-10"
 					label="Manage"
 					icon-right="arrow-right"
 					size="sm"

--- a/dashboard/src/components/dashboard/events/EventDrawer.vue
+++ b/dashboard/src/components/dashboard/events/EventDrawer.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { Alert, Avatar, Button, Icon, toast } from "frappe-ui"
+import { dayjs } from "frappe-ui"
+import { computed } from "vue"
+
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerTitle,
+} from "@/components/common/drawer"
+import type { MyEvent } from "@/types"
+import { timeLabel12Hour } from "@/utils/dateLabels"
+import { bannerPattern } from "@/utils/eventBanner"
+import { copyEventUrl, eventUrl } from "@/utils/eventUrl"
+
+const props = defineProps<{ event: MyEvent | null }>()
+
+const open = defineModel<boolean>("open", { required: true })
+
+// The banner also backs a missing image, so the slot is never blank while it loads.
+const banner = computed(() => ({
+	backgroundImage: props.event ? bannerPattern(props.event.name) : "",
+}))
+
+// The calendar chip wants the parts, not a formatted string.
+const day = computed(() => ({
+	month: props.event ? dayjs(props.event.start_date).format("MMM").toUpperCase() : "",
+	date: props.event ? dayjs(props.event.start_date).format("D") : "",
+}))
+
+// A run that ends on a later day cannot state its times as one range — "09:00 – 17:00"
+// would read as a single afternoon — so each end gets its own line with its own date.
+const spansDays = computed(
+	() => !!props.event?.end_date && props.event.end_date !== props.event.start_date,
+)
+
+const startsAt = computed(() => {
+	if (!props.event) return ""
+	const date = dayjs(props.event.start_date)
+	if (!spansDays.value) return date.format("dddd, D MMMM")
+	const time = props.event.start_time ? `, ${timeLabel12Hour(props.event.start_time)}` : ""
+	return `${date.format("ddd, D MMM")}${time}`
+})
+
+async function copyLink() {
+	if (!props.event?.route) return
+	try {
+		await copyEventUrl(props.event.route)
+		toast.success("Event link copied")
+	} catch {
+		// Clipboard access is refused outside a secure context, and on an http:// host
+		// in development that is every time.
+		toast.error("Could not copy the link")
+	}
+}
+
+const endsAt = computed(() => {
+	if (!props.event) return ""
+	if (spansDays.value) {
+		const date = dayjs(props.event.end_date as string).format("ddd, D MMM")
+		const time = props.event.end_time ? `, ${timeLabel12Hour(props.event.end_time)}` : ""
+		return `to ${date}${time}`
+	}
+	if (!props.event.start_time) return "Time to be announced"
+	const start = timeLabel12Hour(props.event.start_time)
+	return props.event.end_time ? `${start} – ${timeLabel12Hour(props.event.end_time)}` : start
+})
+</script>
+
+<template>
+	<Drawer v-model:open="open" swipe-direction="right">
+		<DrawerContent size="lg">
+			<template v-if="event">
+				<div class="flex gap-2 p-2">
+					<DrawerClose as-child>
+						<Button size="sm" icon="lucide-chevrons-right" aria-label="Close" />
+					</DrawerClose>
+
+					<!-- Both need a route: an unpublished event has no public page to point at. -->
+					<template v-if="event.route">
+						<Button size="sm" label="Copy Link" icon-left="lucide-copy" @click="copyLink" />
+						<Button
+							size="sm"
+							label="Event Page"
+							icon-right="lucide-arrow-up-right"
+							:link="eventUrl(event.route)"
+						/>
+					</template>
+				</div>
+				<Alert
+					v-if="event.is_host"
+					class="shrink-0 rounded-none"
+					theme="blue"
+					title="You have manage access for this event."
+					:primary-action="{
+						label: 'Manage',
+						route: `/manage/events/${event.name}`,
+						variant: 'outline',
+						theme: 'blue',
+						size: 'sm',
+					}"
+				/>
+
+				<div class="flex-1 overflow-y-auto">
+					<div class="p-4">
+						<img
+							v-if="event.banner_image"
+							class="aspect-video w-full rounded-6 object-cover"
+							:src="event.banner_image"
+							:style="banner"
+							alt=""
+						/>
+						<div v-else class="aspect-video w-full rounded-6" :style="banner" />
+					</div>
+
+					<div class="flex flex-col gap-2 px-4">
+						<DrawerTitle class="text-2xl font-semibold text-ink-gray-9">
+							{{ event.title }}
+						</DrawerTitle>
+
+						<div v-if="event.team_name" class="flex items-center gap-2">
+							<Avatar :image="event.team_logo || undefined" :label="event.team_name" size="sm" />
+							<span class="text-base text-ink-gray-6">By {{ event.team_name }}</span>
+						</div>
+					</div>
+
+					<div class="flex flex-col gap-4 p-4">
+						<div class="flex items-center gap-3">
+							<div
+								class="flex size-11 shrink-0 flex-col items-center justify-center rounded-5 border border-outline-gray-2 leading-none"
+							>
+								<span class="text-xs text-ink-gray-5">{{ day.month }}</span>
+								<span class="text-base font-semibold text-ink-gray-8">{{ day.date }}</span>
+							</div>
+							<div class="space-y-0.5">
+								<!-- Doubles as the drawer's accessible description. -->
+								<DrawerDescription class="text-base font-medium text-ink-gray-8">
+									{{ startsAt }}
+								</DrawerDescription>
+								<p class="text-base text-ink-gray-5">{{ endsAt }}</p>
+							</div>
+						</div>
+
+						<div class="flex items-center gap-3">
+							<div
+								class="flex size-11 shrink-0 items-center justify-center rounded-5 border border-outline-gray-2"
+							>
+								<Icon
+									:name="event.venue ? 'lucide-map-pin' : 'lucide-map-pin-off'"
+									class="size-5 text-ink-gray-6"
+								/>
+							</div>
+							<p class="text-base text-ink-gray-8">
+								{{ event.venue || "Venue to be announced" }}
+							</p>
+						</div>
+					</div>
+				</div>
+			</template>
+		</DrawerContent>
+	</Drawer>
+</template>

--- a/dashboard/src/components/dashboard/events/EventDrawer.vue
+++ b/dashboard/src/components/dashboard/events/EventDrawer.vue
@@ -10,6 +10,7 @@ import {
 	DrawerDescription,
 	DrawerTitle,
 } from "@/components/common/drawer"
+import EventBookings from "@/components/dashboard/events/EventBookings.vue"
 import type { MyEvent } from "@/types"
 import { timeLabel12Hour } from "@/utils/dateLabels"
 import { bannerPattern } from "@/utils/eventBanner"
@@ -159,6 +160,8 @@ const endsAt = computed(() => {
 							</p>
 						</div>
 					</div>
+
+					<EventBookings v-if="event.is_attendee" :event="event.name" />
 				</div>
 			</template>
 		</DrawerContent>

--- a/dashboard/src/components/dashboard/events/EventDrawer.vue
+++ b/dashboard/src/components/dashboard/events/EventDrawer.vue
@@ -32,14 +32,16 @@ const day = computed(() => ({
 
 // A run that ends on a later day cannot state its times as one range — "09:00 – 17:00"
 // would read as a single afternoon — so each end gets its own line with its own date.
-const spansDays = computed(
-	() => !!props.event?.end_date && props.event.end_date !== props.event.start_date,
-)
+const laterEndDate = computed(() => {
+	const event = props.event
+	if (!event?.end_date || event.end_date === event.start_date) return null
+	return event.end_date
+})
 
 const startsAt = computed(() => {
 	if (!props.event) return ""
 	const date = dayjs(props.event.start_date)
-	if (!spansDays.value) return date.format("dddd, D MMMM")
+	if (!laterEndDate.value) return date.format("dddd, D MMMM")
 	const time = props.event.start_time ? `, ${timeLabel12Hour(props.event.start_time)}` : ""
 	return `${date.format("ddd, D MMM")}${time}`
 })
@@ -58,8 +60,8 @@ async function copyLink() {
 
 const endsAt = computed(() => {
 	if (!props.event) return ""
-	if (spansDays.value) {
-		const date = dayjs(props.event.end_date as string).format("ddd, D MMM")
+	if (laterEndDate.value) {
+		const date = dayjs(laterEndDate.value).format("ddd, D MMM")
 		const time = props.event.end_time ? `, ${timeLabel12Hour(props.event.end_time)}` : ""
 		return `to ${date}${time}`
 	}

--- a/dashboard/src/composables/useUrlFilters.ts
+++ b/dashboard/src/composables/useUrlFilters.ts
@@ -1,0 +1,26 @@
+import { useRouteQuery } from "@vueuse/router"
+import { computed } from "vue"
+
+import type { FilterValues } from "@/components/common/filters"
+import { formatQueryList, parseQueryList } from "@/utils/queryList"
+
+/**
+ * Filter selections held in the query string, so a filtered list survives a reload and can
+ * be pasted to someone else.
+ *
+ * One comma-joined param per group. Clearing a group drops its param rather than leaving
+ * `?team=`, so the unfiltered view keeps a clean URL.
+ *
+ * `useRouteQuery` writes with `router.replace`, so toggling filters does not pile up history
+ * entries — the Back button leaves the page rather than rewinding chips one at a time.
+ */
+export function useUrlFilters(keys: readonly string[]) {
+	const params = keys.map((key) => [key, useRouteQuery<string | null>(key, null)] as const)
+
+	return computed<FilterValues>({
+		get: () => Object.fromEntries(params.map(([key, param]) => [key, parseQueryList(param.value)])),
+		set: (next) => {
+			for (const [key, param] of params) param.value = formatQueryList(next[key] || [])
+		},
+	})
+}

--- a/dashboard/src/data/bookings.ts
+++ b/dashboard/src/data/bookings.ts
@@ -1,0 +1,14 @@
+import { useCall } from "frappe-ui"
+
+import type { BookingSummary } from "@/types"
+
+// v2 path: useCall reads the payload from `data`, which /api/method names `message`.
+// Uncached: cacheKey would persist this user's bookings to IndexedDB past a logout.
+export function useMyBookingSummaries(event: () => string) {
+	return useCall<BookingSummary[], { event: string }>({
+		url: "/api/v2/method/buzz.api.booking.get_my_booking_summaries",
+		params: () => ({ event: event() }),
+		// Off by default, so without this the drawer keeps the first event's bookings.
+		refetch: true,
+	})
+}

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -4,9 +4,13 @@ import type { EventDetail, EventGuests, MyEvents } from "@/types"
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
 // Uncached: cacheKey would persist this user's feed to IndexedDB past a logout.
-export function useMyEvents() {
-	return useCall<MyEvents>({
+export function useMyEvents(filters?: () => Record<string, string>) {
+	return useCall<MyEvents, { filters: string }>({
 		url: "/api/v2/method/buzz.api.events.get_my_events",
+		// JSON in one param: a nested object on a GET serialises to "[object Object]".
+		params: () => ({ filters: JSON.stringify(filters?.() || {}) }),
+		// Off by default, so without this a filter change rewrites the URL and never refetches.
+		refetch: true,
 	})
 }
 

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -6,13 +6,14 @@ import {
 	Sidebar,
 	SidebarCollapseToggle,
 	SidebarItem,
-	SidebarLabel,
+	SidebarSection,
 } from "frappe-ui"
 import { computed, ref } from "vue"
 import { useRoute } from "vue-router"
 
 import UserMenu from "@/components/UserMenu.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
+import { currentTeam } from "@/data/teams"
 import NotFound from "@/pages/NotFound.vue"
 
 const isMobile = useBreakpoints(breakpointsTailwind).smaller("sm")
@@ -30,7 +31,7 @@ const access = useTeamAccess()
 const isActive = (to: string) => route.path === to
 
 const personalItems = [
-	{ label: "My Events", icon: "lucide-calendar-days", to: "/manage/events" },
+	{ label: "My Calendar", icon: "lucide-calendar-days", to: "/manage/events" },
 	{ label: "My Tickets", icon: "lucide-ticket", to: "/manage/tickets" },
 	{ label: "Talk Proposals", icon: "lucide-file-text", to: "/manage/proposals" },
 	{ label: "Sponsorship", icon: "lucide-handshake", to: "/manage/sponsorship" },
@@ -100,15 +101,17 @@ const eventItems = computed(() => [
 						:active="isActive(item.to)"
 					/>
 
-					<SidebarLabel divider class="mt-3 px-2">Team</SidebarLabel>
-					<SidebarItem
-						v-for="item in teamItems"
-						:key="item.label"
-						:label="item.label"
-						:icon="item.icon"
-						:to="item.to"
-						:active="isActive(item.to)"
-					/>
+					<SidebarSection :label="currentTeam?.team_name" collapsible>
+						<SidebarItem
+							class="ml-2"
+							v-for="item in teamItems"
+							:key="item.label"
+							:label="item.label"
+							:icon="item.icon"
+							:to="item.to"
+							:active="isActive(item.to)"
+						/>
+					</SidebarSection>
 				</div>
 
 				<div class="mt-auto px-2 py-2 sm:hidden">

--- a/dashboard/src/pages/manage/MyEvents.vue
+++ b/dashboard/src/pages/manage/MyEvents.vue
@@ -4,8 +4,10 @@ import { computed, ref } from "vue"
 
 import EmptyState from "@/components/common/EmptyState.vue"
 import EventCard from "@/components/dashboard/events/EventCard.vue"
+import EventDrawer from "@/components/dashboard/events/EventDrawer.vue"
 import TimelineList from "@/components/dashboard/TimelineList.vue"
 import { useMyEvents } from "@/data/events"
+import type { MyEvent } from "@/types"
 import { groupEventsByMonth } from "@/utils/eventGroups"
 import type { TimelineTab } from "@/utils/timelineTabs"
 
@@ -15,6 +17,15 @@ const tab = ref<TimelineTab>("upcoming")
 
 // The feed arrives already split, so the tab only picks a side.
 const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || []))
+
+// Held past the close so the drawer keeps its contents while it animates out.
+const selected = ref<MyEvent | null>(null)
+const drawerOpen = ref(false)
+
+function openEvent(event: MyEvent) {
+	selected.value = event
+	drawerOpen.value = true
+}
 </script>
 
 <template>
@@ -42,8 +53,41 @@ const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || [
 			</EmptyState>
 		</template>
 
+		<!-- The overlay button covers the card rather than wrapping it: EventCard's Manage
+		     link is interactive content, which cannot legally nest inside a button. Manage
+		     is raised above the overlay, so both targets work and both are focusable. -->
 		<template #default="{ item }">
-			<EventCard :event="item" />
+			<div class="event-row relative rounded-8">
+				<button
+					type="button"
+					class="absolute inset-0 rounded-8 focus-visible:outline focus-visible:outline-2 focus-visible:outline-outline-gray-3"
+					:aria-label="`Open ${item.title}`"
+					@click="openEvent(item)"
+				/>
+				<EventCard :event="item" />
+			</div>
 		</template>
 	</TimelineList>
+
+	<EventDrawer v-model:open="drawerOpen" :event="selected" />
 </template>
+
+<style scoped>
+/* A row that is a button has to answer the press. The scale stays near-imperceptible
+   because these are seen dozens of times a session. */
+.event-row {
+	transition: transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.event-row:active {
+	transform: scale(0.995);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.event-row {
+		transition: none;
+	}
+	.event-row:active {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/pages/manage/MyEvents.vue
+++ b/dashboard/src/pages/manage/MyEvents.vue
@@ -1,26 +1,87 @@
 <script setup lang="ts">
+import { useRouteQuery } from "@vueuse/router"
 import { Icon } from "frappe-ui"
 import { computed, ref } from "vue"
 
 import EmptyState from "@/components/common/EmptyState.vue"
+import { FilterBar } from "@/components/common/filters"
+import type { FilterGroup, FilterOption } from "@/components/common/filters"
 import EventCard from "@/components/dashboard/events/EventCard.vue"
 import EventDrawer from "@/components/dashboard/events/EventDrawer.vue"
 import TimelineList from "@/components/dashboard/TimelineList.vue"
+import { useUrlFilters } from "@/composables/useUrlFilters"
 import { useMyEvents } from "@/data/events"
+import { teams } from "@/data/teams"
 import type { MyEvent } from "@/types"
 import { groupEventsByMonth } from "@/utils/eventGroups"
 import type { TimelineTab } from "@/utils/timelineTabs"
 
-const myEvents = useMyEvents()
+// In the URL alongside the filters, so one link carries the whole view.
+const tab = useRouteQuery<TimelineTab>("tab", "upcoming")
 
-const tab = ref<TimelineTab>("upcoming")
+const filterValues = useUrlFilters(["role", "team", "medium"])
 
-// The feed arrives already split, so the tab only picks a side.
+// Declared before the fetch: useCall reads its params getter immediately, so anything the
+// getter touches has to exist by then.
+// The API takes one value per filter, so only the first selection travels.
+const apiFilters = () => {
+	const { role = [], team = [], medium = [] } = filterValues.value
+	return Object.fromEntries(
+		Object.entries({ role: role[0], team: team[0], medium: medium[0] }).filter(
+			([, value]) => value,
+		),
+	) as Record<string, string>
+}
+
+const myEvents = useMyEvents(apiFilters)
+
+// Guest and host rather than attending and hosting: the same list is read on the Past tab,
+// where an activity reads as a claim about an event that is over. Guest is also what the
+// API calls a ticket holder. The empty value is the unfiltered case, which keeps the
+// default view on a clean URL.
+const ROLE_OPTIONS: FilterOption[] = [
+	{ value: "", label: "All Events" },
+	{ value: "attending", label: "As a Guest" },
+	{ value: "hosting", label: "As a Host" },
+]
+
+// The Select's own values, so no mapping table.
+const FORMAT_OPTIONS: FilterOption[] = [
+	{ value: "In Person", label: "In person" },
+	{ value: "Online", label: "Online" },
+]
+
+// From data/teams, not the feed: the server now returns only what matches, so the feed can
+// no longer supply the full option list. This narrows Team to teams you belong to; an event
+// you merely hold a ticket to is still reachable through the role filter.
+const teamOptions = computed((): FilterOption[] =>
+	teams.value.map((team) => ({ value: team.name, label: team.team_name })),
+)
+
+const groups = computed((): FilterGroup[] => [
+	{ key: "role", label: "Role", quick: true, single: true, options: ROLE_OPTIONS },
+	{ key: "team", label: "Team", options: teamOptions.value },
+	{ key: "medium", label: "Format", options: FORMAT_OPTIONS },
+])
+
+// The feed arrives filtered and already split, so the tab only picks a side.
 const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || []))
 
 // Held past the close so the drawer keeps its contents while it animates out.
 const selected = ref<MyEvent | null>(null)
 const drawerOpen = ref(false)
+
+const anyFilterActive = computed(() =>
+	Object.values(filterValues.value).some((values) => values.length),
+)
+
+// A filtered-out list is not an empty feed, and the copy has to say which it is.
+const emptyDescription = computed(() => {
+	if (anyFilterActive.value) return "No events match these filters. Try clearing a few."
+	return tab.value === "upcoming"
+		? "Events you host or hold a ticket to will show up here."
+		: "Events you have already attended or hosted will show up here."
+})
 
 function openEvent(event: MyEvent) {
 	selected.value = event
@@ -38,14 +99,14 @@ function openEvent(event: MyEvent) {
 		:loading="myEvents.loading"
 		:error="myEvents.error"
 	>
+		<template #controls>
+			<FilterBar v-model="filterValues" :groups="groups" />
+		</template>
+
 		<template #empty-state>
 			<EmptyState
-				:title="`No ${tab} events`"
-				:description="
-					tab === 'upcoming'
-						? 'Events you host or hold a ticket to will show up here.'
-						: 'Events you have already attended or hosted will show up here.'
-				"
+				:title="anyFilterActive ? 'No matching events' : `No ${tab} events`"
+				:description="emptyDescription"
 			>
 				<template #illustration>
 					<Icon name="lucide-ghost" class="size-8 text-ink-gray-4" />

--- a/dashboard/src/pages/manage/MyEvents.vue
+++ b/dashboard/src/pages/manage/MyEvents.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { Icon } from "frappe-ui"
 import { computed, ref } from "vue"
 
+import EmptyState from "@/components/common/EmptyState.vue"
 import EventCard from "@/components/dashboard/events/EventCard.vue"
 import TimelineList from "@/components/dashboard/TimelineList.vue"
 import { useMyEvents } from "@/data/events"
@@ -25,6 +27,21 @@ const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || [
 		:loading="myEvents.loading"
 		:error="myEvents.error"
 	>
+		<template #empty-state>
+			<EmptyState
+				:title="`No ${tab} events`"
+				:description="
+					tab === 'upcoming'
+						? 'Events you host or hold a ticket to will show up here.'
+						: 'Events you have already attended or hosted will show up here.'
+				"
+			>
+				<template #illustration>
+					<Icon name="lucide-ghost" class="size-8 text-ink-gray-4" />
+				</template>
+			</EmptyState>
+		</template>
+
 		<template #default="{ item }">
 			<EventCard :event="item" />
 		</template>

--- a/dashboard/src/pages/manage/MyEvents.vue
+++ b/dashboard/src/pages/manage/MyEvents.vue
@@ -18,7 +18,8 @@ const months = computed(() => groupEventsByMonth(myEvents.data?.[tab.value] || [
 <template>
 	<TimelineList
 		v-model:tab="tab"
-		heading="My Events"
+		heading="My Calendar"
+		icon="lucide-calendar-days"
 		noun="events"
 		:months="months"
 		:loading="myEvents.loading"

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -123,6 +123,32 @@ export interface MyEvent {
 	team_logo: string | null
 }
 
+/** buzz.api.booking.get_my_booking_summaries: one ticket type per line, add-ons beneath. */
+export interface BookingLine {
+	label: string
+	quantity: number
+	amount: number
+	add_ons: BookingLine[]
+}
+
+export interface BookingSummary {
+	name: string
+	status: string
+	payment_status: string
+	payment_method: string | null
+	is_offline: boolean
+	currency: string
+	booked_on: string
+	lines: BookingLine[]
+	net_amount: number
+	discount_amount: number
+	coupon_code: string | null
+	tax_amount: number
+	tax_label: string | null
+	tax_percentage: number
+	total_amount: number
+}
+
 export interface MyEvents {
 	upcoming: MyEvent[]
 	past: MyEvent[]

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -114,8 +114,10 @@ export interface MyEvent {
 	start_time: string | null
 	end_time: string | null
 	venue: string | null
+	medium: string | null
 	banner_image: string | null
 	is_host: boolean
+	is_attendee: boolean
 	team: string | null
 	team_name: string | null
 	team_logo: string | null

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -112,6 +112,7 @@ export interface MyEvent {
 	start_date: string
 	end_date: string | null
 	start_time: string | null
+	end_time: string | null
 	venue: string | null
 	banner_image: string | null
 	is_host: boolean

--- a/dashboard/src/utils/dateLabels.ts
+++ b/dashboard/src/utils/dateLabels.ts
@@ -17,3 +17,15 @@ export function dayLabel(date: string): string {
 export function weekday(date: string): string {
 	return dayjs(date).format("dddd")
 }
+
+// Times arrive as a serialized timedelta ("9:00:00"), so the hour needs padding and the
+// seconds dropping — slicing the raw string cuts a single-digit hour mid-segment.
+export function timeLabel(time: string): string {
+	const [hour, minute] = time.split(":")
+	return `${hour.padStart(2, "0")}:${minute}`
+}
+
+/** Same serialized timedelta, rendered on a 12-hour clock: "9:30 AM". */
+export function timeLabel12Hour(time: string): string {
+	return dayjs(`2000-01-01 ${time}`).format("h:mm A")
+}

--- a/dashboard/src/utils/eventUrl.test.ts
+++ b/dashboard/src/utils/eventUrl.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { eventUrl } from "./eventUrl.ts"
+
+const withOrigin = (origin: string, run: () => void) => {
+	// The helper reads the live location; there is no browser under node --test.
+	;(globalThis as { window?: unknown }).window = { location: { origin } }
+	try {
+		run()
+	} finally {
+		;(globalThis as { window?: unknown }).window = undefined
+	}
+}
+
+test("hangs the route off the current origin", () => {
+	withOrigin("https://buzz.example.com", () => {
+		assert.equal(eventUrl("frappeverse-2026"), "https://buzz.example.com/frappeverse-2026")
+	})
+})
+
+test("keeps the port, which differs between the dashboard and the bench", () => {
+	withOrigin("http://buzz.localhost:8080", () => {
+		assert.equal(eventUrl("summit"), "http://buzz.localhost:8080/summit")
+	})
+})

--- a/dashboard/src/utils/eventUrl.ts
+++ b/dashboard/src/utils/eventUrl.ts
@@ -1,0 +1,15 @@
+/**
+ * The public page for an event lives at the site root under the event's own route.
+ *
+ * Built from the current origin rather than a configured base URL: the dashboard and the
+ * bench answer on different ports in development, so anything hardcoded is wrong in one
+ * of the two places.
+ */
+export function eventUrl(route: string): string {
+	return `${window.location.origin}/${route}`
+}
+
+/** Puts an event's public link on the clipboard. Rejects if the browser refuses access. */
+export async function copyEventUrl(route: string): Promise<void> {
+	await navigator.clipboard.writeText(eventUrl(route))
+}

--- a/dashboard/src/utils/queryList.test.ts
+++ b/dashboard/src/utils/queryList.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { formatQueryList, parseQueryList } from "./queryList.ts"
+
+test("a missing or blank param is no selection", () => {
+	assert.deepEqual(parseQueryList(null), [])
+	assert.deepEqual(parseQueryList(undefined), [])
+	assert.deepEqual(parseQueryList(""), [])
+	assert.deepEqual(parseQueryList(",,"), [])
+})
+
+test("values round-trip through the comma form", () => {
+	assert.deepEqual(parseQueryList("hosting,attending"), ["hosting", "attending"])
+	assert.equal(formatQueryList(["hosting", "attending"]), "hosting,attending")
+})
+
+test("padding a hand-edited URL picked up is dropped", () => {
+	assert.deepEqual(parseQueryList("hosting, attending"), ["hosting", "attending"])
+})
+
+test("an empty selection formats to null, so the param can be removed", () => {
+	assert.equal(formatQueryList([]), null)
+	assert.equal(formatQueryList(["", "  "]), null)
+})

--- a/dashboard/src/utils/queryList.ts
+++ b/dashboard/src/utils/queryList.ts
@@ -1,0 +1,21 @@
+/**
+ * Comma-joined lists in a query string.
+ *
+ * Kept apart from the composable so the serialisation is testable on its own: anything
+ * importing vue-router drags in the app, and node --test cannot load that.
+ */
+
+/** An absent, blank or all-blank param reads as no selection rather than one empty value. */
+export function parseQueryList(raw: string | null | undefined): string[] {
+	if (!raw) return []
+	return raw
+		.split(",")
+		.map((value) => value.trim())
+		.filter(Boolean)
+}
+
+/** Empty selections serialise to null so the caller can drop the param entirely. */
+export function formatQueryList(values: string[]): string | null {
+	const kept = values.map((value) => value.trim()).filter(Boolean)
+	return kept.length ? kept.join(",") : null
+}

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -6,10 +6,10 @@ export default {
 		"./index.html",
 		"./src/**/*.{vue,js,ts,jsx,tsx}",
 		...frappeUIContent,
-		// ListView lives in frappe-ui/experimental, which the `content` export
-		// deliberately skips. Without this its classes are never scanned and every
-		// list renders unstyled.
-		"./node_modules/frappe-ui/experimental/ListView/**/*.{vue,js,ts,jsx,tsx}",
+		// frappe-ui/experimental is deliberately absent from the `content` export, so
+		// nothing under it is scanned: ListView renders unstyled, and Accordion loses
+		// its chevron rotation, which lives in a group-data variant.
+		"./node_modules/frappe-ui/experimental/**/*.{vue,js,ts,jsx,tsx}",
 	],
 	theme: {
 		extend: {},

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2912,10 +2912,10 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-reka-ui@^2.9.9:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/reka-ui/-/reka-ui-2.10.1.tgz#af51db13cf753668385639900f0e01e99c386f44"
-  integrity sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ+H3B+zDaMJU0h8KPEPMa7g9BHu3zcOi4OB39XJSWizceFoNO0Z9tctSGLOXqg==
+reka-ui@2.10.4, reka-ui@^2.10.1, reka-ui@^2.9.9:
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/reka-ui/-/reka-ui-2.10.4.tgz#2a0ee3ecec1464c74645c53ec4ab33b1cc638e2b"
+  integrity sha512-kbS5GAbkHkYj0EVKAg5ZPEPndhBjeUFSa1Aq5m5ftQwyHnB1v5tw8X6fcwfKH/ry3StPXblMWM1DW82MVS71cw==
   dependencies:
     "@floating-ui/dom" "^1.6.13"
     "@floating-ui/vue" "^1.1.6"

--- a/e2e/tests/manage-access.spec.ts
+++ b/e2e/tests/manage-access.spec.ts
@@ -9,7 +9,7 @@ test.describe("Manage access", () => {
 		await page.goto("/b/")
 
 		await expect(page).toHaveURL(/\/b\/manage\/events$/, { timeout: 15000 })
-		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
+		await expect(page.getByRole("heading", { name: "My Calendar", level: 1 })).toBeVisible()
 	})
 
 	test("routes a sidebar item with no page yet to the placeholder", async ({ page }) => {

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -84,7 +84,7 @@ test.describe("Event workspace", () => {
 		await page.getByRole("link", { name: "Back" }).click()
 
 		await expect(page).toHaveURL(/\/b\/manage\/events$/, { timeout: 15000 })
-		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
+		await expect(page.getByRole("heading", { name: "My Calendar", level: 1 })).toBeVisible()
 	})
 })
 


### PR DESCRIPTION
## What changed

My Calendar was a dead-end list showing every event any of my teams runs. Now:

- **Clicking a row opens a drawer** — banner, title, team, dates, venue, Copy Link, Event Page. Works for someone who only holds a ticket, not just managers.
- **An attendee also sees their booking** in that drawer: amount, payment method, breakdown by ticket type with add-ons, totals. New `get_my_booking_summaries` endpoint, so no ticket ids or attendee emails reach the browser.
- **The list filters** by role, team and format, filtered by the API rather than the client. Filter state lives in the query string, so a filtered calendar survives a reload and can be pasted to someone else.
- "My Events" becomes "My Calendar", team destinations move into a collapsible sidebar section, and the empty state stops being a grey line.

`components/common/drawer/` and `FilterBar` are new and generic — both are styling layers over reka primitives, holding no state and knowing no field names.

Two things worth a look: the Team filter now lists only teams you belong to (server-side filtering means the feed no longer carries the rows to enumerate the rest — guest teams are under **As a Guest**), and `frappe-ui/tailwind`'s content export skips `experimental/`, so Accordion's classes were never emitted until this widened the glob.

**Not in this PR**: pagination (feed still unbounded), migrating `TeamEvents` / `TeamOverview` off the personal feed, and the Download Invoice button (#398).

## Demo
https://cap.so/s/bncbb7mrqj1rgxf

## Testing

- `test_events` 44 pass, `test_booking` 40 pass — new cases cover the filters and the booking summary's shape, scope and grouping.
- `yarn test:unit` 107 pass (3 pre-existing `timeZones.test.ts` failures reproduce with the branch stashed). Playwright green after fixing two specs that asserted the old heading.
- `oxlint`, `oxfmt`, `vue-tsc`, `ruff` clean. Driven end to end in a browser: filters confirmed travelling on the network request, URL round-trip, keyboard operation of the filter panel, drawer at 1600px and 700px.