### PR TITLE
feat(dashboard): empty states for My Tickets and Talk Proposals

### DIFF
--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -33,7 +33,7 @@ const isActive = (to: string) => route.path === to
 const personalItems = [
 	{ label: "My Calendar", icon: "lucide-calendar-days", to: "/manage/events" },
 	{ label: "My Tickets", icon: "lucide-ticket", to: "/manage/tickets" },
-	{ label: "Talk Proposals", icon: "lucide-file-text", to: "/manage/proposals" },
+	{ label: "Talk Proposals", icon: "lucide-mic", to: "/manage/proposals" },
 	{ label: "Sponsorship", icon: "lucide-handshake", to: "/manage/sponsorship" },
 ]
 

--- a/dashboard/src/pages/manage/MyProposals.vue
+++ b/dashboard/src/pages/manage/MyProposals.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { dayjs } from "frappe-ui"
+import { Icon, dayjs } from "frappe-ui"
 import { computed, ref } from "vue"
 
+import EmptyState from "@/components/common/EmptyState.vue"
 import ProposalCard from "@/components/dashboard/proposals/ProposalCard.vue"
 import TimelineList from "@/components/dashboard/TimelineList.vue"
 import { useMyProposals } from "@/data/proposals"
@@ -24,17 +25,32 @@ const dated = computed(() =>
 const months = computed(() =>
 	groupEventsByMonth(inTab(dated.value, tab.value, dayjs().format("YYYY-MM-DD"))),
 )
+
+const emptyDescription = computed(() =>
+	tab.value === "upcoming"
+		? "Talks you propose will show up here."
+		: "Talks you proposed for past events will show up here.",
+)
 </script>
 
 <template>
 	<TimelineList
 		v-model:tab="tab"
 		heading="Talk Proposals"
+		icon="lucide-mic"
 		noun="proposals"
 		:months="months"
 		:loading="myProposals.loading"
 		:error="myProposals.error"
 	>
+		<template #empty-state>
+			<EmptyState :title="`No ${tab} proposals`" :description="emptyDescription">
+				<template #illustration>
+					<Icon name="lucide-mic-off" class="size-8 text-ink-gray-4" />
+				</template>
+			</EmptyState>
+		</template>
+
 		<template #default="{ item }">
 			<ProposalCard :proposal="item" />
 		</template>

--- a/dashboard/src/pages/manage/MyTickets.vue
+++ b/dashboard/src/pages/manage/MyTickets.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { dayjs } from "frappe-ui"
+import { Icon, dayjs } from "frappe-ui"
 import { computed, ref } from "vue"
 
+import EmptyState from "@/components/common/EmptyState.vue"
 import PrintedTicket from "@/components/dashboard/tickets/PrintedTicket.vue"
 import TicketDrawer from "@/components/dashboard/tickets/TicketDrawer.vue"
 import TimelineList from "@/components/dashboard/TimelineList.vue"
@@ -35,6 +36,12 @@ const dated = computed(() =>
 const months = computed(() =>
 	groupEventsByMonth(inTab(dated.value, tab.value, dayjs().format("YYYY-MM-DD"))),
 )
+
+const emptyDescription = computed(() =>
+	tab.value === "upcoming"
+		? "Tickets you book will show up here."
+		: "Tickets for events you have already attended will show up here.",
+)
 </script>
 
 <template>
@@ -47,6 +54,14 @@ const months = computed(() =>
 		:loading="tickets.loading"
 		:error="tickets.error"
 	>
+		<template #empty-state>
+			<EmptyState :title="`No ${tab} tickets`" :description="emptyDescription">
+				<template #illustration>
+					<Icon name="lucide-ticket-slash" class="size-8 text-ink-gray-4" />
+				</template>
+			</EmptyState>
+		</template>
+
 		<template #default="{ item }">
 			<PrintedTicket :ticket="item" :banner-image="item.banner_image" @open="openTicket(item)" />
 		</template>


### PR DESCRIPTION
## What changed

My Tickets and Talk Proposals fell through to TimelineList's bare "No upcoming tickets." line. Both now fill the `empty-state` slot with the same `EmptyState` component My Calendar uses, with tab-aware copy for upcoming vs past.

Illustrations are subject-specific rather than the generic ghost: `ticket-slash` and `mic-off`. Talk Proposals also moves from `file-text` to `mic` in the sidebar, and passes that icon to TimelineList so its header matches the other two pages.

No filter-aware copy here — only My Calendar has filters.

## Demo

<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/c5e53852-8cca-4cec-9a06-7675bd94a894" />

<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/9c0a1e45-1c3c-42fe-8775-8725e5d34052" />

## Testing

`dashboard/typecheck.sh` passes. Empty states verified visually.
