### PR TITLE
feat(dashboard): brand header and reordered manager sidebar

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -53,7 +53,6 @@ declare module 'vue' {
     PaymentGatewayDialog: typeof import('./src/components/PaymentGatewayDialog.vue')['default']
     PhoneInput: typeof import('./src/components/PhoneInput.vue')['default']
     PrintedTicket: typeof import('./src/components/dashboard/tickets/PrintedTicket.vue')['default']
-    PrintedTicketLoud: typeof import('./src/components/dashboard/tickets/PrintedTicketLoud.vue')['default']
     ProfileView: typeof import('./src/components/ProfileView.vue')['default']
     ProposalCard: typeof import('./src/components/dashboard/proposals/ProposalCard.vue')['default']
     ProposalEditDialog: typeof import('./src/components/ProposalEditDialog.vue')['default']

--- a/dashboard/src/components/UserMenu.vue
+++ b/dashboard/src/components/UserMenu.vue
@@ -2,6 +2,7 @@
 import { Avatar, Button, Divider, Popover, useColorScheme } from "frappe-ui"
 
 import { session } from "@/data/session"
+import { currentTeam } from "@/data/teams"
 
 const { colorScheme, setColorScheme } = useColorScheme()
 
@@ -16,20 +17,23 @@ const themes = [
 	<Popover match-trigger-width side="bottom" align="start">
 		<template #trigger="{ open: isOpen }">
 			<button
-				aria-label="Account"
-				class="group flex h-10 w-full items-center gap-2 rounded-4 px-1.5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				aria-label="Account menu"
+				class="flex h-12 w-full items-center gap-2 rounded-4 px-1.5 transition-colors duration-150 hover:bg-surface-gray-2 focus-visible:outline-none focus-visible:focus-ring"
 				:class="{ 'bg-surface-gray-2': isOpen }"
 			>
-				<Avatar :image="session.userImage ?? undefined" :label="session.fullName" size="lg" />
-				<span class="flex-1 truncate text-left text-base text-ink-gray-8">
-					{{ session.fullName }}
+				<Avatar
+					image="/assets/buzz/images/buzz-logo-rounded.png"
+					label="Buzz"
+					size="lg"
+					shape="square"
+				/>
+				<span class="flex min-w-0 flex-1 flex-col text-left">
+					<span class="truncate text-base font-medium text-ink-gray-8">
+						{{ currentTeam?.team_name ?? "Buzz" }}
+					</span>
+					<span class="truncate text-sm text-ink-gray-6">{{ session.fullName }}</span>
 				</span>
-				<span
-					class="grid size-6 shrink-0 place-items-center rounded-4 transition-colors duration-150 group-hover:bg-surface-gray-3"
-					:class="{ 'bg-surface-gray-3': isOpen }"
-				>
-					<span class="lucide-ellipsis size-4 text-ink-gray-6" />
-				</span>
+				<span class="lucide-chevron-down size-4 shrink-0 text-ink-gray-5" />
 			</button>
 		</template>
 

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -39,7 +39,7 @@ const personalItems = [
 // Team-scoped destinations read the active team from data/teams rather than the path,
 // so they are fixed and need no team loaded to render.
 const teamItems = [
-	{ label: "Overview", icon: "lucide-layout-dashboard", to: "/manage/team/overview" },
+	{ label: "Home", icon: "lucide-house", to: "/manage/team/overview" },
 	{ label: "Events", icon: "lucide-calendar-days", to: "/manage/team/events" },
 	{ label: "Members", icon: "lucide-users-round", to: "/manage/team/members" },
 ]

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -13,7 +13,6 @@ import { useRoute } from "vue-router"
 
 import UserMenu from "@/components/UserMenu.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
-import { currentTeam } from "@/data/teams"
 import NotFound from "@/pages/NotFound.vue"
 
 const isMobile = useBreakpoints(breakpointsTailwind).smaller("sm")
@@ -76,7 +75,7 @@ const eventItems = computed(() => [
 	<DesktopShell v-else-if="access === 'granted'" :scroll="false">
 		<template #sidebar>
 			<Sidebar v-model:collapsed="collapsed" :disable-collapse="!isMobile">
-				<div class="flex h-12 shrink-0 items-center px-2">
+				<div class="flex shrink-0 items-center px-2 pt-2">
 					<UserMenu />
 				</div>
 
@@ -91,9 +90,9 @@ const eventItems = computed(() => [
 					/>
 				</div>
 
-				<div v-else class="flex flex-col mx-2 py-2">
+				<div v-else class="flex flex-col gap-0.5 mx-2 py-2">
 					<SidebarItem
-						v-for="item in personalItems"
+						v-for="item in teamItems"
 						:key="item.label"
 						:label="item.label"
 						:icon="item.icon"
@@ -101,10 +100,13 @@ const eventItems = computed(() => [
 						:active="isActive(item.to)"
 					/>
 
-					<SidebarSection :label="currentTeam?.team_name" collapsible>
+					<!-- Not <Divider>: outside a flex-item context it computes h-full and
+					     stretches to the sidebar's height. -->
+					<hr class="mt-2 border-t border-outline-gray-2" />
+
+					<SidebarSection label="Personal">
 						<SidebarItem
-							class="ml-2"
-							v-for="item in teamItems"
+							v-for="item in personalItems"
 							:key="item.label"
 							:label="item.label"
 							:icon="item.icon"

--- a/dashboard/src/pages/manage/teams/TeamOverview.vue
+++ b/dashboard/src/pages/manage/teams/TeamOverview.vue
@@ -35,7 +35,7 @@ const hiddenMemberCount = computed(() =>
 </script>
 
 <template>
-	<TeamPageHeader title="Overview" />
+	<TeamPageHeader title="Home" />
 
 	<div class="m-auto max-w-[1000px] w-full py-8 px-4 space-y-8">
 		<LoadingText v-if="teamOverview.loading" text="Loading team…" />


### PR DESCRIPTION
## What changed

The manager sidebar led with a user row and put the four personal destinations
above a collapsible team section. This reworks that ordering.

- The header is now a brand block: Buzz logo, the active team's name, and the
  signed-in user beneath it. Clicking it opens the same account popover as
  before (profile, theme, log out).
- Team destinations move to the top as a flat list — the collapsible section
  and its team-name label are gone, since the header carries the name now.
- A rule separates them from the personal destinations, which sit under a
  "Personal" section heading.
- The team's Overview destination is renamed Home (`lucide-house`). The route
  stays `/manage/team/overview`.

Two things worth knowing for whoever touches this next:

- The separator is a plain `<hr>`, not frappe-ui's `Divider`. `Divider`
  computes `h-full` when it is not a flex item, which stretches it to the
  sidebar's full height inside this flex column.
- The brand avatar stays at `size="lg"` (32px). The sidebar collapses to
  `3rem` on mobile, so a larger avatar clips.

Not changed: there is still no team switcher — team selection has had no UI
since #396, and `data/teams` picks the first team on load. The header shows
which team is active but cannot change it.

## Demo
<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/a8e946fb-4d77-4f69-ba21-6253ea723e00" />

<!-- screenshot pending -->

## Testing

Manual, against buzz.localhost. Typecheck clean (`vue-tsc --noEmit`, app
sources). No automated tests — this is presentation-only markup.