### PR TITLE
feat(dashboard): hide Sponsorship in the manager sidebar until there is an inquiry

### DIFF
--- a/dashboard/src/data/sponsorships.ts
+++ b/dashboard/src/data/sponsorships.ts
@@ -1,0 +1,10 @@
+import { useCall } from "frappe-ui"
+
+// v2 path: useCall reads the payload from `data`, which /api/method names `message`.
+// Uncached: cacheKey would persist this user's inquiries to IndexedDB past a logout.
+// Rows are only ever counted, so the sidebar and tab bar need no more than the key.
+export function useMySponsorships() {
+	return useCall<{ name: string }[]>({
+		url: "/api/v2/method/buzz.api.sponsorships.get_user_sponsorship_inquiries",
+	})
+}

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -12,6 +12,7 @@ import { useRoute } from "vue-router"
 
 import UserMenu from "@/components/UserMenu.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
+import { useMySponsorships } from "@/data/sponsorships"
 import NotFound from "@/pages/NotFound.vue"
 
 // `null` keeps the sidebar's own rule: collapsed below `sm`, until the toggle overrides it.
@@ -26,17 +27,32 @@ const access = useTeamAccess()
 // type Boolean, so Vue casts the absent prop to false and the inference never runs.
 const isActive = (to: string) => route.path === to
 
-const mainItems = [
-	{ label: "Events", icon: "lucide-calendar-days", to: "/manage/events" },
-	{ label: "Talk Proposals", icon: "lucide-mic", to: "/manage/proposals" },
-	{ label: "Sponsorship", icon: "lucide-handshake", to: "/manage/sponsorship" },
-]
+// Sponsorship is hidden until the user has an inquiry, the same rule the account
+// page applies to its Sponsorships tab.
+const sponsorships = useMySponsorships()
+
+const mainItems = computed(() => {
+	const destinations = [
+		{ label: "Events", icon: "lucide-calendar-days", to: "/manage/events" },
+		{ label: "Talk Proposals", icon: "lucide-mic", to: "/manage/proposals" },
+	]
+
+	if (sponsorships.data?.length) {
+		destinations.push({
+			label: "Sponsorship",
+			icon: "lucide-handshake",
+			to: "/manage/sponsorship",
+		})
+	}
+
+	return destinations
+})
 
 // An event opens into the same shell with its own destinations.
 const eventId = computed(() => route.params.eventId as string | undefined)
 
 const items = computed(() => {
-	if (!eventId.value) return mainItems
+	if (!eventId.value) return mainItems.value
 	const event = `/manage/events/${eventId.value}`
 	return [
 		{ label: "Back", icon: "lucide-arrow-left", to: "/" },

--- a/e2e/tests/manage-access.spec.ts
+++ b/e2e/tests/manage-access.spec.ts
@@ -12,12 +12,18 @@ test.describe("Manage access", () => {
 		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
 	})
 
-	test("routes a sidebar item with no page yet to the placeholder", async ({ page }) => {
+	test("keeps Sponsorship out of the sidebar until there is an inquiry", async ({ page }) => {
 		await page.goto("/b/manage/events")
-		await page.getByRole("link", { name: "Sponsorship" }).click()
 
-		await expect(page).toHaveURL(/\/b\/manage\/sponsorship$/)
-		await expect(page.getByText("Work in progress")).toBeVisible()
+		// The heading first: the sidebar is only worth counting once the shell has rendered.
+		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
+		await expect(page.getByRole("link", { name: "Sponsorship" })).toHaveCount(0)
+	})
+
+	test("routes a section with no page yet to the placeholder", async ({ page }) => {
+		await page.goto("/b/manage/sponsorship")
+
+		await expect(page.getByText("Work in progress")).toBeVisible({ timeout: 15000 })
 	})
 
 	test("shows a 404 for a manage section that does not exist", async ({ page }) => {


### PR DESCRIPTION
## What changed

The account page only shows its Sponsorships tab once `get_user_sponsorship_inquiries` returns rows. The manager sidebar linked Sponsorship unconditionally, so every team member saw a destination that is empty for most of them.

The same rule now drives the sidebar item. The call lives in a new `data/sponsorships.ts` (`useMySponsorships`) so both surfaces can share it — uncached on purpose, since a `cacheKey` would persist one user's inquiries to IndexedDB past a logout.

Not in this PR: Account.vue still uses its own `createResource` with a shared `account-sponsorships-check` cache key. Migrating it to the new composable is a separate change, and it drags the tab-bar redirect watcher along with it.

## Demo

No screenshot — Chrome is not installed for Playwright on this machine, so I could not drive the running dev server. The change is one conditional on a sidebar item; happy to add a capture if you want one before merge.

## Testing

- `vue-tsc --noEmit` clean for app sources (only pre-existing `node_modules/frappe-ui` errors remain).
- `pre-commit run --files` on both changed files: oxlint and oxfmt pass.
- Not manually verified in the browser, see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHcY5jCBavD2nK6FHZUdF6