### PR TITLE
feat(dashboard): event workspace header and directional sidebar transition

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -52,6 +52,7 @@ declare module 'vue' {
     LanguageSwitcher: typeof import('./src/components/LanguageSwitcher.vue')['default']
     LoginDialog: typeof import('./src/components/LoginDialog.vue')['default']
     LoginRequired: typeof import('./src/components/LoginRequired.vue')['default']
+    ManagerSidebarHeader: typeof import('./src/components/dashboard/ManagerSidebarHeader.vue')['default']
     Navbar: typeof import('./src/components/Navbar.vue')['default']
     OfflinePaymentDialog: typeof import('./src/components/OfflinePaymentDialog.vue')['default']
     PaymentGatewayDialog: typeof import('./src/components/PaymentGatewayDialog.vue')['default']

--- a/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
+++ b/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
@@ -13,8 +13,7 @@ const isCollapsed = inject(
 	computed(() => false),
 )
 
-// Outside an event the sidebar has nothing to go back to, so it keeps the account menu.
-// The id is never shown: it is a hash, and swapping it for the title reads as a glitch.
+// Never falls back to the id: swapping a hash for the title reads as a glitch.
 const name = computed(() => props.eventTitle ?? "")
 
 const goBack = () => router.push("/manage/events")

--- a/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
+++ b/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { Tooltip, sidebarCollapsedKey } from "frappe-ui"
+import { computed, inject } from "vue"
+import { useRouter } from "vue-router"
+
+import UserMenu from "@/components/UserMenu.vue"
+
+const props = defineProps<{ eventId?: string; eventTitle?: string }>()
+
+const router = useRouter()
+const isCollapsed = inject(
+	sidebarCollapsedKey,
+	computed(() => false),
+)
+
+// Outside an event the sidebar has nothing to go back to, so it keeps the account menu.
+// The id is never shown: it is a hash, and swapping it for the title reads as a glitch.
+const name = computed(() => props.eventTitle ?? "")
+
+const goBack = () => router.push("/manage/events")
+</script>
+
+<template>
+	<UserMenu v-if="!eventId" />
+
+	<Tooltip v-else class="w-full" text="Back to events" placement="right" :disabled="!isCollapsed">
+		<button
+			aria-label="Back to events"
+			class="group flex h-12 w-full items-center gap-1.5 rounded-4 px-1 transition duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"
+			@click="goBack"
+		>
+			<span
+				class="lucide-chevron-left size-4 shrink-0 text-ink-gray-5 transition duration-150 ease-out group-hover:-translate-x-0.5 group-hover:text-ink-gray-8"
+			/>
+			<span
+				class="flex size-7 shrink-0 items-center justify-center rounded-3 bg-surface-gray-2 text-ink-gray-7 transition-colors duration-150 ease-out group-hover:bg-surface-gray-3"
+			>
+				<span class="lucide-box size-4" />
+			</span>
+			<span v-if="!isCollapsed" class="flex min-w-0 flex-col text-left leading-tight">
+				<span
+					class="truncate text-base font-medium text-ink-gray-8 transition-opacity duration-150 ease-out"
+					:class="{ 'opacity-0': !name }"
+					:title="name"
+				>
+					{{ name || "\u00a0" }}
+				</span>
+				<span class="truncate text-xs text-ink-gray-5">Event Workspace</span>
+			</span>
+		</button>
+	</Tooltip>
+</template>

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -7,11 +7,12 @@ import {
 	SidebarCollapseToggle,
 	SidebarItem,
 } from "frappe-ui"
-import { computed } from "vue"
+import { computed, ref, watch } from "vue"
 import { useRoute } from "vue-router"
 
-import UserMenu from "@/components/UserMenu.vue"
+import ManagerSidebarHeader from "@/components/dashboard/ManagerSidebarHeader.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
+import { eventDetail } from "@/data/events"
 import { useMySponsorships } from "@/data/sponsorships"
 import NotFound from "@/pages/NotFound.vue"
 
@@ -51,11 +52,25 @@ const mainItems = computed(() => {
 // An event opens into the same shell with its own destinations.
 const eventId = computed(() => route.params.eventId as string | undefined)
 
+const eventTitle = ref("")
+watch(
+	eventId,
+	(id) => {
+		eventTitle.value = ""
+		if (!id) return
+		// The user can hop between events faster than a fetch returns, so a late
+		// response for the event that was left has to be dropped.
+		eventDetail(id).promise?.then((event) => {
+			if (eventId.value === id) eventTitle.value = event?.title ?? ""
+		})
+	},
+	{ immediate: true },
+)
+
 const items = computed(() => {
 	if (!eventId.value) return mainItems.value
 	const event = `/manage/events/${eventId.value}`
 	return [
-		{ label: "Back", icon: "lucide-arrow-left", to: "/" },
 		{ label: "Details", icon: "lucide-receipt-text", to: `${event}/details` },
 		{ label: "Guests", icon: "lucide-users-round", to: `${event}/guests` },
 		{ label: "Talks", icon: "lucide-presentation", to: `${event}/talks` },
@@ -70,9 +85,9 @@ const items = computed(() => {
 	<DesktopShell v-else-if="access === 'granted'" :scroll="false">
 		<template #sidebar>
 			<Sidebar v-model:collapsed="collapsed">
-				<!-- px-1: puts the avatar on the item-icon centerline, in both states. -->
+				<!-- px-1: puts the header mark on the item-icon centerline, in both states. -->
 				<div class="flex shrink-0 items-center px-1 pt-2">
-					<UserMenu />
+					<ManagerSidebarHeader :event-id="eventId" :event-title="eventTitle" />
 				</div>
 
 				<div class="flex flex-col gap-0.5 mx-2 py-2">

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -52,14 +52,19 @@ const mainItems = computed(() => {
 // An event opens into the same shell with its own destinations.
 const eventId = computed(() => route.params.eventId as string | undefined)
 
+// Entering an event pushes the sidebar left, leaving it pulls back right.
+const direction = ref<"forward" | "back">("forward")
+watch(eventId, (id, previous) => {
+	direction.value = id && !previous ? "forward" : "back"
+})
+
 const eventTitle = ref("")
 watch(
 	eventId,
 	(id) => {
 		eventTitle.value = ""
 		if (!id) return
-		// The user can hop between events faster than a fetch returns, so a late
-		// response for the event that was left has to be dropped.
+		// Drops a late response for an event the user has already left.
 		eventDetail(id).promise?.then((event) => {
 			if (eventId.value === id) eventTitle.value = event?.title ?? ""
 		})
@@ -85,20 +90,35 @@ const items = computed(() => {
 	<DesktopShell v-else-if="access === 'granted'" :scroll="false">
 		<template #sidebar>
 			<Sidebar v-model:collapsed="collapsed">
-				<!-- px-1: puts the header mark on the item-icon centerline, in both states. -->
-				<div class="flex shrink-0 items-center px-1 pt-2">
-					<ManagerSidebarHeader :event-id="eventId" :event-title="eventTitle" />
+				<!-- px-1: puts the header mark on the item-icon centerline, in both states.
+				     h-14 holds the height while both states overlap mid-transition. -->
+				<div class="nav-stage relative h-14 shrink-0">
+					<Transition :name="`nav-${direction}`">
+						<div
+							:key="eventId ? 'event' : 'root'"
+							class="absolute inset-x-1 top-2 flex items-center"
+						>
+							<ManagerSidebarHeader :event-id="eventId" :event-title="eventTitle" />
+						</div>
+					</Transition>
 				</div>
 
-				<div class="flex flex-col gap-0.5 mx-2 py-2">
-					<SidebarItem
-						v-for="item in items"
-						:key="item.label"
-						:label="item.label"
-						:icon="item.icon"
-						:to="item.to"
-						:active="isActive(item.to)"
-					/>
+				<!-- One block, not per row: absolute rows would all collapse onto the
+				     container's corner. my-2, not py-2: the leaving list anchors to the
+				     padding box, so padding here would lift it out of line. -->
+				<div class="nav-stage relative mx-2 my-2">
+					<Transition :name="`nav-${direction}`">
+						<div :key="eventId ? 'event' : 'root'" class="nav-list flex flex-col gap-0.5">
+							<SidebarItem
+								v-for="item in items"
+								:key="item.label"
+								:label="item.label"
+								:icon="item.icon"
+								:to="item.to"
+								:active="isActive(item.to)"
+							/>
+						</div>
+					</Transition>
 				</div>
 
 				<div class="mt-auto px-2 py-2">
@@ -119,3 +139,62 @@ const items = computed(() => {
 		</div>
 	</DesktopShell>
 </template>
+
+<style scoped>
+/* One vanishing point per stage, so header and list hinge off the same rail. */
+.nav-stage {
+	perspective: 700px;
+}
+
+.nav-forward-enter-active,
+.nav-back-enter-active,
+.nav-forward-leave-active,
+.nav-back-leave-active {
+	transform-origin: left center;
+}
+
+/* Opacity lands before the movement: a row still visible at the end of its slide
+   reads as a ghost. */
+.nav-forward-enter-active,
+.nav-back-enter-active {
+	transition:
+		opacity 140ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.nav-forward-leave-active,
+.nav-back-leave-active {
+	transition:
+		opacity 100ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* Only the list leaves the flow; re-anchoring the header would shift it 4px. */
+.nav-list.nav-forward-leave-active,
+.nav-list.nav-back-leave-active {
+	position: absolute;
+	inset-inline: 0;
+	top: 0;
+}
+
+.nav-forward-enter-from,
+.nav-back-leave-to {
+	opacity: 0;
+	transform: translateX(10px) rotateY(-8deg);
+}
+
+.nav-forward-leave-to,
+.nav-back-enter-from {
+	opacity: 0;
+	transform: translateX(-10px) rotateY(8deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.nav-forward-enter-from,
+	.nav-forward-leave-to,
+	.nav-back-enter-from,
+	.nav-back-leave-to {
+		transform: none;
+	}
+}
+</style>

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -67,9 +67,10 @@ test.describe("Event workspace", () => {
 	})
 
 	test("swaps the sidebar for the event's own destinations", async ({ page }) => {
-		for (const label of ["Back", "Details", "Guests", "Talks"]) {
+		for (const label of ["Details", "Guests", "Talks"]) {
 			await expect(page.getByRole("link", { name: label })).toBeVisible({ timeout: 15000 })
 		}
+		await expect(page.getByRole("button", { name: "Back to events" })).toBeVisible()
 		await expect(page.getByRole("link", { name: "My Tickets" })).toHaveCount(0)
 	})
 
@@ -80,8 +81,8 @@ test.describe("Event workspace", () => {
 		await expect(page.getByText("Work in progress")).toBeVisible()
 	})
 
-	test("leaves the workspace through the back item", async ({ page }) => {
-		await page.getByRole("link", { name: "Back" }).click()
+	test("leaves the workspace through the back button", async ({ page }) => {
+		await page.getByRole("button", { name: "Back to events" }).click()
 
 		await expect(page).toHaveURL(/\/b\/manage\/events$/, { timeout: 15000 })
 		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()


### PR DESCRIPTION
## What changed

- Inside an event, the sidebar's account menu becomes a full-width back button: chevron, mark, event title, "Event Workspace".
- The separate "Back" nav item is gone — one target instead of two.
- Title comes from the event detail resource. The event id is never shown in its place; a late response for an event you've already left is dropped.
- The swap is directional: opening an event pushes header and nav list left, going back pulls them right. 200ms in, 140ms out, transform and opacity only. Reduced motion keeps the fade, drops the travel.

Gotchas if you touch this:

- Each stage transitions as one block, not per row — an absolutely positioned flex child resolves to its container's corner, so leaving rows would stack on each other.
- The list stage uses `my-2`, not `py-2` — the leaving list anchors to the padding box, and padding there lifts it 8px out of line.

## Demo


https://github.com/user-attachments/assets/0609f1d1-a2f2-4eb9-9a32-e00ee9111dfb



<!-- Screenshots to drag in: sidebar-events.png, sidebar-event-workspace.png -->

## Testing

- Type-checks and pre-commit hooks pass.
- Both directions verified in the running app with frame-by-frame sampling: forward moves both lists left (`x 8 → -2` out, `x 18 → 8` in), back moves both right, baselines stay aligned.
- No automated tests — presentation only.
