### PR TITLE
feat(dashboard): move the account menu to the sidebar footer

### DIFF
--- a/dashboard/src/components/UserMenu.vue
+++ b/dashboard/src/components/UserMenu.vue
@@ -27,30 +27,27 @@ const themes = [
 </script>
 
 <template>
-	<Popover match-trigger-width side="bottom" align="start">
+	<Popover match-trigger-width side="top" align="start">
 		<template #trigger="{ open: isOpen }">
 			<button
 				aria-label="Account menu"
-				class="flex h-12 w-full items-center gap-2 rounded-4 px-1.5 transition-colors duration-150 hover:bg-surface-gray-2 focus-visible:outline-none focus-visible:focus-ring"
+				class="flex h-12 w-full items-center gap-2 rounded-4 px-1.5 transition-[background-color,transform] duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"
 				:class="{ 'bg-surface-gray-2': isOpen }"
 			>
-				<Tooltip text="Buzz" placement="right" :disabled="!isCollapsed">
-					<Avatar
-						image="/assets/buzz/images/buzz-logo-rounded.png"
-						label="Buzz"
-						size="lg"
-						shape="square"
-					/>
+				<Tooltip :text="session.fullName" side="right" :disabled="!isCollapsed">
+					<Avatar :image="session.userImage ?? undefined" :label="session.fullName" size="lg" />
 				</Tooltip>
 				<span
-					class="flex min-w-0 flex-col text-left transition-all ease-in-out"
+					class="flex min-w-0 flex-col text-left transition-opacity duration-150 ease-out"
 					:class="isCollapsed ? 'w-0 flex-none overflow-hidden opacity-0' : 'flex-1 opacity-100'"
 				>
-					<span class="truncate text-base font-medium text-ink-gray-8">Buzz</span>
-					<span class="truncate text-sm text-ink-gray-6">{{ session.fullName }}</span>
+					<span class="truncate text-base font-medium text-ink-gray-8">
+						{{ session.fullName }}
+					</span>
+					<span class="truncate text-sm text-ink-gray-6">{{ session.user }}</span>
 				</span>
 				<span
-					class="lucide-chevron-down size-4 shrink-0 text-ink-gray-5 transition-all ease-in-out"
+					class="lucide-chevrons-up-down size-4 shrink-0 text-ink-gray-5 transition-opacity duration-150 ease-out"
 					:class="{ 'w-0 overflow-hidden opacity-0': isCollapsed }"
 				/>
 			</button>

--- a/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
+++ b/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { Tooltip, sidebarCollapsedKey } from "frappe-ui"
+import { Avatar, Tooltip, sidebarCollapsedKey } from "frappe-ui"
 import { computed, inject } from "vue"
 import { useRouter } from "vue-router"
-
-import UserMenu from "@/components/UserMenu.vue"
 
 const props = defineProps<{ eventId?: string; eventTitle?: string }>()
 
@@ -20,9 +18,25 @@ const goBack = () => router.push("/manage/events")
 </script>
 
 <template>
-	<UserMenu v-if="!eventId" />
+	<!-- Identity and the way home; the account menu sits in the sidebar footer. -->
+	<Tooltip v-if="!eventId" class="w-full" text="Buzz" side="right" :disabled="!isCollapsed">
+		<router-link
+			to="/manage"
+			class="flex h-12 w-full items-center gap-2 rounded-4 px-1.5 transition-[background-color,transform] duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"
+		>
+			<Avatar
+				image="/assets/buzz/images/buzz-logo-rounded.png"
+				label="Buzz"
+				size="lg"
+				shape="square"
+			/>
+			<span v-if="!isCollapsed" class="flex-1 truncate text-base font-medium text-ink-gray-8">
+				Buzz
+			</span>
+		</router-link>
+	</Tooltip>
 
-	<Tooltip v-else class="w-full" text="Back to events" placement="right" :disabled="!isCollapsed">
+	<Tooltip v-else class="w-full" text="Back to events" side="right" :disabled="!isCollapsed">
 		<button
 			aria-label="Back to events"
 			class="group flex h-12 w-full items-center gap-1.5 rounded-4 px-1 transition duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -1,25 +1,15 @@
 <script setup lang="ts">
-import { StorageSerializers, useStorage } from "@vueuse/core"
-import {
-	DesktopShell,
-	PageHeaderTarget,
-	Sidebar,
-	SidebarCollapseToggle,
-	SidebarItem,
-} from "frappe-ui"
+import { DesktopShell, PageHeaderTarget, Sidebar, SidebarItem } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 import { useRoute } from "vue-router"
 
 import ManagerSidebarHeader from "@/components/dashboard/ManagerSidebarHeader.vue"
+import UserMenu from "@/components/UserMenu.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
 import { eventDetail } from "@/data/events"
 import { useMySponsorships } from "@/data/sponsorships"
 import NotFound from "@/pages/NotFound.vue"
 
-// `null` keeps the sidebar's own rule: collapsed below `sm`, until the toggle overrides it.
-const collapsed = useStorage<boolean | null>("buzz-sidebar-collapsed", null, undefined, {
-	serializer: StorageSerializers.boolean,
-})
 const route = useRoute()
 
 const access = useTeamAccess()
@@ -89,7 +79,7 @@ const items = computed(() => {
 	<!-- scroll=false: the rounded panel below owns its own scroll. -->
 	<DesktopShell v-else-if="access === 'granted'" :scroll="false">
 		<template #sidebar>
-			<Sidebar v-model:collapsed="collapsed">
+			<Sidebar>
 				<!-- px-1: puts the header mark on the item-icon centerline, in both states.
 				     h-14 holds the height while both states overlap mid-transition. -->
 				<div class="nav-stage relative h-14 shrink-0">
@@ -122,12 +112,12 @@ const items = computed(() => {
 				</div>
 
 				<div class="mt-auto px-2 py-2">
-					<SidebarCollapseToggle />
+					<UserMenu />
 				</div>
 			</Sidebar>
 		</template>
 
-		<div class="flex flex-col h-full min-h-0 bg-surface-sidebar py-2 pl-2">
+		<div class="flex flex-col h-full min-h-0 bg-surface-sidebar py-2 pl-1">
 			<div
 				class="flex h-full flex-col overflow-hidden rounded-l-6 bg-surface-elevation-1 shadow-base"
 			>


### PR DESCRIPTION
## What changed

The sidebar header is now identity only — the Buzz mark and name, linking to the dashboard home. The account menu (avatar, name, email) moved to the footer and opens upward.

Collapse loses its manual toggle and its persisted state: the sidebar stays expanded above `sm` and collapses itself below.

## Demo
<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/8059f9ab-c140-4bf4-bbb6-163883c5624f" />
<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/055d1c19-990b-45c3-94e6-6fc87c760ae0" />

<!-- screenshot to follow -->

## Testing

Manual: header link, account popover, theme switch, log out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199LmSmd9tZWMNpCfvsnPRE