### PR TITLE
chore: refactor event details page

### DIFF
--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Literal
 
 from pydantic import Field
@@ -53,6 +53,7 @@ class EventDetail(APIResponse):
 	title: str
 	route: str | None = None
 	team: str | None = None
+	modified: datetime
 	start_date: date
 	end_date: date | None = None
 	start_time: timedelta | None = None

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -116,6 +116,7 @@ DETAIL_FIELDS = (
 	"title",
 	"route",
 	"team",
+	"modified",
 	"start_date",
 	"end_date",
 	"start_time",

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -371,6 +371,7 @@ class TestGetEvent(IntegrationTestCase):
 		self.assertEqual(detail["medium"], "Online")
 		self.assertEqual(detail["meeting_link"], "https://example.com/join")
 		self.assertIsNone(detail["venue"])
+		self.assertTrue(detail["modified"])
 
 	def test_resolves_the_venue_with_its_address(self):
 		venue = frappe.get_doc(

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -37,6 +37,7 @@ declare module 'vue' {
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventCountdownPill: typeof import('./src/components/dashboard/events/EventCountdownPill.vue')['default']
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
+    EventDetailsSkeleton: typeof import('./src/components/dashboard/events/EventDetailsSkeleton.vue')['default']
     EventDrawer: typeof import('./src/components/dashboard/events/EventDrawer.vue')['default']
     EventGuestItem: typeof import('./src/components/dashboard/events/EventGuestItem.vue')['default']
     EventHoverCard: typeof import('./src/components/dashboard/events/EventHoverCard.vue')['default']

--- a/dashboard/src/components/dashboard/events/EventBanner.vue
+++ b/dashboard/src/components/dashboard/events/EventBanner.vue
@@ -54,7 +54,7 @@ watch(image, () => {
 		:validate-file="validateImage"
 		@success="(file: { file_url: string }) => (image = file.file_url)"
 	>
-		<template #default="{ openFileSelector, error: uploadError }">
+		<template #default="{ openFileSelector, uploading, error: uploadError }">
 			<!-- The whole banner is the hit area; the button inside stays the -->
 			<!-- keyboard-reachable control, so its press must not fire twice. -->
 			<div
@@ -95,9 +95,10 @@ watch(image, () => {
 						@click.stop="openFileSelector"
 					/>
 					<!-- Clearing the field is the whole removal: the event carries the file
-						 by URL, and the seeded pattern is already painted underneath. -->
+						 by URL, and the seeded pattern is already painted underneath. Gone
+						 mid-upload, because the upload that lands would put a banner back. -->
 					<Button
-						v-if="image"
+						v-if="image && !uploading"
 						variant="subtle"
 						icon="lucide-trash-2"
 						label="Remove banner"

--- a/dashboard/src/components/dashboard/events/EventBanner.vue
+++ b/dashboard/src/components/dashboard/events/EventBanner.vue
@@ -86,13 +86,23 @@ watch(image, () => {
 					@load="loaded = true"
 				/>
 
-				<div class="absolute inset-0 grid place-items-center">
+				<div class="absolute inset-0 flex items-center justify-center gap-2">
 					<Button
 						variant="subtle"
 						icon-left="lucide-image-up"
 						:label="image ? 'Change banner' : 'Add a banner'"
 						:disabled="disabled"
 						@click.stop="openFileSelector"
+					/>
+					<!-- Clearing the field is the whole removal: the event carries the file
+						 by URL, and the seeded pattern is already painted underneath. -->
+					<Button
+						v-if="image"
+						variant="subtle"
+						icon="lucide-trash-2"
+						label="Remove banner"
+						:disabled="disabled"
+						@click.stop="image = ''"
 					/>
 				</div>
 			</div>

--- a/dashboard/src/components/dashboard/events/EventDetailsSkeleton.vue
+++ b/dashboard/src/components/dashboard/events/EventDetailsSkeleton.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { Skeleton } from "frappe-ui"
+</script>
+
+<template>
+	<!-- Shaped like the loaded page rather than a generic block, so the content settles
+		 into the boxes instead of replacing them. -->
+	<div class="m-auto w-full max-w-[800px] space-y-8 px-4 py-8">
+		<Skeleton class="aspect-[3/1] w-full rounded-7" />
+
+		<div class="grid gap-8 md:grid-cols-5">
+			<div class="space-y-8 md:col-span-3">
+				<div class="space-y-3">
+					<Skeleton class="h-10 w-2/3 rounded-4" />
+					<Skeleton class="h-4 w-full rounded-4" />
+					<Skeleton class="h-4 w-4/5 rounded-4" />
+				</div>
+
+				<div class="space-y-3">
+					<Skeleton class="h-3 w-16 rounded-4" />
+					<Skeleton class="h-48 w-full rounded-6" />
+				</div>
+			</div>
+
+			<div class="space-y-8 md:col-span-2">
+				<div class="space-y-1.5">
+					<Skeleton class="h-3 w-20 rounded-4" />
+					<Skeleton class="h-14 w-full rounded-6" />
+				</div>
+
+				<Skeleton class="h-40 w-full rounded-6" />
+
+				<div class="space-y-3">
+					<Skeleton class="h-3 w-16 rounded-4" />
+					<Skeleton class="h-9 w-full rounded-4" />
+					<Skeleton class="h-9 w-full rounded-4" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/dashboard/src/components/dashboard/events/EventMedium.vue
+++ b/dashboard/src/components/dashboard/events/EventMedium.vue
@@ -59,8 +59,16 @@ async function copyLink() {
 			/>
 		</div>
 
-		<template v-if="isOnline">
-			<div class="flex items-end gap-2">
+		<!-- The two answers are different heights, so the swap moves the column. Opacity
+			 only, and out before in: a height animation here would cost more than it hides. -->
+		<Transition
+			mode="out-in"
+			enter-active-class="transition-opacity duration-100 ease-out motion-reduce:transition-none"
+			enter-from-class="opacity-0"
+			leave-active-class="transition-opacity duration-75 ease-out motion-reduce:transition-none"
+			leave-to-class="opacity-0"
+		>
+			<div v-if="isOnline" class="flex items-end gap-2">
 				<FormControl
 					v-model="meetingLink"
 					class="flex-1"
@@ -75,11 +83,11 @@ async function copyLink() {
 					@click="copyLink"
 				/>
 			</div>
-		</template>
 
-		<template v-else>
-			<EventLocation v-model:venue="venue" :team="team" :show-virtual="false" />
-			<p v-if="address" class="text-base text-ink-gray-5">{{ address }}</p>
-		</template>
+			<div v-else class="flex flex-col gap-3">
+				<EventLocation v-model:venue="venue" :team="team" :show-virtual="false" />
+				<p v-if="address" class="text-base text-ink-gray-5">{{ address }}</p>
+			</div>
+		</Transition>
 	</div>
 </template>

--- a/dashboard/src/components/dashboard/events/EventMedium.vue
+++ b/dashboard/src/components/dashboard/events/EventMedium.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { Button, FormControl, toast } from "frappe-ui"
+import { Button, FormControl } from "frappe-ui"
 import { computed } from "vue"
 
 import EventLocation from "@/components/dashboard/events/EventLocation.vue"
+import { useCopyToClipboard } from "@/composables/useCopyToClipboard"
 import { venues } from "@/data/venues"
 
 // The two values Buzz Event's `medium` select takes.
@@ -38,10 +39,9 @@ function pick(value: string) {
 	else meetingLink.value = ""
 }
 
-async function copyLink() {
-	await navigator.clipboard.writeText(meetingLink.value)
-	toast.success("Link copied")
-}
+const copyToClipboard = useCopyToClipboard()
+
+const copyLink = () => copyToClipboard(meetingLink.value, "Meeting link copied")
 </script>
 
 <template>

--- a/dashboard/src/components/dashboard/events/EventPageHeader.vue
+++ b/dashboard/src/components/dashboard/events/EventPageHeader.vue
@@ -1,17 +1,35 @@
 <script setup lang="ts">
-import { Breadcrumbs, PageHeader } from "frappe-ui"
+import { Breadcrumbs, PageHeader, Tooltip, dayjsLocal } from "frappe-ui"
 import { computed } from "vue"
 
 // The event, then the section of it being looked at. Neither crumb is a link: the
-// event on its own resolves to whichever section is open.
-const props = defineProps<{ title: string | null | undefined; section: string }>()
+// event on its own resolves to whichever section is open. Modified arrives as the
+// raw timestamp and renders relative, with the exact date on hover — the same
+// shape as ProposalCard's "last updated" readout.
+const props = defineProps<{
+	title: string | null | undefined
+	section: string
+	modified?: string | null
+}>()
 
 const items = computed(() => [{ label: props.title || "Event" }, { label: props.section }])
+
+const modifiedAt = computed(() => (props.modified ? dayjsLocal(props.modified) : null))
+const modifiedRelative = computed(() => modifiedAt.value?.fromNow() ?? "")
+const modifiedExact = computed(() => modifiedAt.value?.format("D MMM YYYY, h:mm A") ?? "")
 </script>
 
 <template>
 	<PageHeader class="border-none pt-2 bg-surface-elevation-1">
 		<Breadcrumbs :items="items" />
-		<slot />
+		<div class="flex items-center gap-2">
+			<Tooltip v-if="modifiedAt" :text="`Last updated on ${modifiedExact}`">
+				<span class="flex items-center gap-1 text-p-sm text-ink-gray-4">
+					<span class="lucide-clock-fading size-3.5 shrink-0" aria-hidden="true" />
+					Modified {{ modifiedRelative }}
+				</span>
+			</Tooltip>
+			<slot />
+		</div>
 	</PageHeader>
 </template>

--- a/dashboard/src/components/dashboard/events/EventRoute.vue
+++ b/dashboard/src/components/dashboard/events/EventRoute.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { watchDebounced } from "@vueuse/core"
-import { computed, ref, watch } from "vue"
+import { computed, onBeforeUnmount, ref, watch } from "vue"
 
 import { checkEventRoute } from "@/data/events"
 
@@ -50,6 +50,8 @@ async function copy() {
 	clearTimeout(clearCopied)
 	clearCopied = setTimeout(() => (justCopied.value = false), 1500)
 }
+
+onBeforeUnmount(() => clearTimeout(clearCopied))
 </script>
 
 <template>
@@ -98,17 +100,26 @@ async function copy() {
 			/>
 		</div>
 
-		<p
-			v-if="availability"
-			class="flex items-center gap-1 pt-0.5 text-sm"
-			:class="availability.available ? 'text-ink-green-6' : 'text-ink-red-6'"
+		<!-- The answer lands 400ms after the last keystroke; without this it snaps in and
+			 shoves the column. -->
+		<Transition
+			enter-active-class="transition duration-150 ease-out motion-reduce:transition-none"
+			enter-from-class="opacity-0 -translate-y-0.5"
+			leave-active-class="transition duration-100 ease-out motion-reduce:transition-none"
+			leave-to-class="opacity-0"
 		>
-			<span
-				class="size-3.5 shrink-0"
-				:class="availability.available ? 'lucide-check' : 'lucide-triangle-alert'"
-				aria-hidden="true"
-			/>
-			{{ availability.message }}
-		</p>
+			<p
+				v-if="availability"
+				class="flex items-center gap-1 pt-0.5 text-sm"
+				:class="availability.available ? 'text-ink-green-6' : 'text-ink-red-6'"
+			>
+				<span
+					class="size-3.5 shrink-0"
+					:class="availability.available ? 'lucide-check' : 'lucide-triangle-alert'"
+					aria-hidden="true"
+				/>
+				{{ availability.message }}
+			</p>
+		</Transition>
 	</div>
 </template>

--- a/dashboard/src/components/dashboard/events/EventRoute.vue
+++ b/dashboard/src/components/dashboard/events/EventRoute.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { watchDebounced } from "@vueuse/core"
-import { computed, ref } from "vue"
+import { computed, ref, watch } from "vue"
 
 import { checkEventRoute } from "@/data/events"
 
@@ -9,8 +9,10 @@ import { checkEventRoute } from "@/data/events"
 const props = defineProps<{ event: string; saved: string | null }>()
 
 const route = defineModel<string>({ default: "" })
+// Lifted so the page can refuse to save a slug the server has already claimed.
+const taken = defineModel<boolean>("taken", { default: false })
 
-// The host the dashboard is being used on, so the chip reads as the address it will be.
+// The host the dashboard is being used on, so the field reads as the address it will be.
 const hostname = window.location.hostname
 // Events are served under the dashboard's own base, not off the bare host.
 const publicPath = computed(() => `/b/register/${props.saved}`)
@@ -35,6 +37,8 @@ watchDebounced(
 	{ debounce: 400 },
 )
 
+watch(availability, (answer) => (taken.value = Boolean(answer) && !answer?.available))
+
 // The icon carries the confirmation, so this needs no toast on top of it.
 const justCopied = ref(false)
 let clearCopied: ReturnType<typeof setTimeout>
@@ -49,24 +53,17 @@ async function copy() {
 </script>
 
 <template>
-	<div class="w-80">
-		<div class="flex items-center gap-1 rounded-4 bg-surface-gray-1 py-1 pl-2.5 pr-1 text-base">
-			<span class="shrink-0 text-ink-gray-5">{{ hostname }}/</span>
+	<div class="w-full space-y-1.5">
+		<div class="flex items-center justify-between gap-2">
+			<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Event URL</h2>
 
-			<input
-				v-model="route"
-				aria-label="Event route"
-				placeholder="your-event"
-				class="min-w-0 flex-1 bg-transparent text-ink-gray-8 placeholder:text-ink-gray-4 focus:outline-none"
-			/>
-
-			<template v-if="saved">
+			<div v-if="saved" class="flex items-center gap-1">
 				<a
 					:href="publicPath"
 					target="_blank"
 					rel="noopener"
 					aria-label="Open event page"
-					class="shrink-0 rounded-4 p-1 text-ink-gray-5 transition-[color,transform] duration-150 ease-out hover:text-ink-gray-8 active:scale-95 motion-reduce:transition-none"
+					class="rounded-4 p-1 text-ink-gray-5 transition-[color,transform] duration-150 ease-out hover:text-ink-gray-8 active:scale-95 motion-reduce:transition-none"
 				>
 					<span class="lucide-arrow-up-right block size-4" aria-hidden="true" />
 				</a>
@@ -74,7 +71,7 @@ async function copy() {
 				<button
 					type="button"
 					aria-label="Copy"
-					class="shrink-0 rounded-4 p-1 text-ink-gray-5 transition-[color,transform] duration-150 ease-out hover:text-ink-gray-8 active:scale-95 motion-reduce:transition-none"
+					class="rounded-4 p-1 text-ink-gray-5 transition-[color,transform] duration-150 ease-out hover:text-ink-gray-8 active:scale-95 motion-reduce:transition-none"
 					@click="copy"
 				>
 					<!-- Swapped, not crossfaded: at this size a fade reads as a flicker. -->
@@ -84,12 +81,26 @@ async function copy() {
 						aria-hidden="true"
 					/>
 				</button>
-			</template>
+			</div>
+		</div>
+
+		<!-- Host on its own line so a long slug keeps the full width to itself. The border
+			 lights up on focus-within: the whole box is the field, not just the input. -->
+		<div
+			class="rounded-6 border border-outline-gray-2 px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:border-outline-gray-4 motion-reduce:transition-none"
+		>
+			<p class="text-xs leading-4 text-ink-gray-5">{{ hostname }}/</p>
+			<input
+				v-model="route"
+				aria-label="Event route"
+				placeholder="your-event"
+				class="w-full bg-transparent text-base text-ink-gray-8 placeholder:text-ink-gray-4 focus:outline-none"
+			/>
 		</div>
 
 		<p
 			v-if="availability"
-			class="mt-1.5 flex items-center gap-1 text-sm"
+			class="flex items-center gap-1 pt-0.5 text-sm"
 			:class="availability.available ? 'text-ink-green-6' : 'text-ink-red-6'"
 		>
 			<span

--- a/dashboard/src/components/dashboard/events/EventRoute.vue
+++ b/dashboard/src/components/dashboard/events/EventRoute.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { watchDebounced } from "@vueuse/core"
-import { computed, onBeforeUnmount, ref, watch } from "vue"
+import { computed, ref, watch } from "vue"
 
+import { useCopyToClipboard } from "@/composables/useCopyToClipboard"
 import { checkEventRoute } from "@/data/events"
 
 // The route the event already answers to, which is the one that opens and copies —
@@ -39,19 +40,11 @@ watchDebounced(
 
 watch(availability, (answer) => (taken.value = Boolean(answer) && !answer?.available))
 
-// The icon carries the confirmation, so this needs no toast on top of it.
-const justCopied = ref(false)
-let clearCopied: ReturnType<typeof setTimeout>
+const copyToClipboard = useCopyToClipboard()
 
-async function copy() {
-	// The path the link opens, not the shorthand the chip reads.
-	await navigator.clipboard.writeText(`${window.location.origin}${publicPath.value}`)
-	justCopied.value = true
-	clearTimeout(clearCopied)
-	clearCopied = setTimeout(() => (justCopied.value = false), 1500)
-}
-
-onBeforeUnmount(() => clearTimeout(clearCopied))
+// The path the link opens, not the shorthand the field reads.
+const copy = () =>
+	copyToClipboard(`${window.location.origin}${publicPath.value}`, "Event link copied")
 </script>
 
 <template>
@@ -76,12 +69,7 @@ onBeforeUnmount(() => clearTimeout(clearCopied))
 					class="rounded-4 p-1 text-ink-gray-5 transition-[color,transform] duration-150 ease-out hover:text-ink-gray-8 active:scale-95 motion-reduce:transition-none"
 					@click="copy"
 				>
-					<!-- Swapped, not crossfaded: at this size a fade reads as a flicker. -->
-					<span
-						class="block size-4"
-						:class="justCopied ? 'lucide-check text-ink-gray-6' : 'lucide-copy'"
-						aria-hidden="true"
-					/>
+					<span class="lucide-copy block size-4" aria-hidden="true" />
 				</button>
 			</div>
 		</div>

--- a/dashboard/src/components/dashboard/events/EventSchedule.vue
+++ b/dashboard/src/components/dashboard/events/EventSchedule.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { Combobox, DatePicker, ErrorMessage, TimePicker, dayjsLocal } from "frappe-ui"
+import { Combobox, DateTimePicker, ErrorMessage, dayjsLocal } from "frappe-ui"
 import type { ComboboxCustomOption, ComboboxSelectableOption } from "frappe-ui"
+import type { Ref } from "vue"
 import { computed, ref, watch } from "vue"
 
-import { alignedEndDate, isEndBeforeStart } from "@/utils/eventDates"
+import { alignedEndDate, isEndBeforeStart, normalizedTime } from "@/utils/eventDates"
 import {
 	allTimeZones,
 	zoneCity,
@@ -20,20 +21,12 @@ const endDate = defineModel<string>("endDate", { default: "" })
 const endTime = defineModel<string>("endTime", { default: "" })
 const timeZone = defineModel<string>("timeZone", { default: "" })
 
-// An event cannot start in the past, and cannot end before it starts.
+// An event cannot start in the past.
 const today = dayjsLocal().format("YYYY-MM-DD")
-const earliestEnd = computed(() => startDate.value || today)
 
 watch(startDate, (start) => {
 	endDate.value = alignedEndDate(start, endDate.value)
 })
-
-// Only a single-day event is bounded: a span that runs into another day may well end
-// earlier in the day than it began. The picker rejects a typed value below `min` too,
-// not just the ones it lists.
-const earliestEndTime = computed(() =>
-	!endDate.value || endDate.value === startDate.value ? startTime.value : undefined,
-)
 
 // `min` is inclusive, so it still lets the end land exactly on the start, which the
 // server refuses. It also cannot undo a time that was already valid as a multi-day
@@ -41,6 +34,38 @@ const earliestEndTime = computed(() =>
 const endsBeforeItStarts = computed(() =>
 	isEndBeforeStart(startDate.value, endDate.value, startTime.value, endTime.value),
 )
+
+// DateTimePicker works in `YYYY-MM-DD HH:mm:ss`; the form keeps the halves apart.
+function joined(date: string, time: string) {
+	return date ? `${date} ${normalizedTime(time) || "00:00:00"}` : ""
+}
+
+function splitInto(value: string, date: Ref<string>, time: Ref<string>) {
+	const [datePart = "", timePart = ""] = value.split(" ")
+	date.value = datePart
+	time.value = timePart
+}
+
+const startAt = computed({
+	get: () => joined(startDate.value, startTime.value),
+	set: (value: string) => splitInto(value, startDate, startTime),
+})
+
+const endAt = computed({
+	get: () => joined(endDate.value, endTime.value),
+	set: (value: string) => splitInto(value, endDate, endTime),
+})
+
+// The cell draws its own value, so the picker's own format never shows.
+const momentLabel = (date: string, time: string) =>
+	date ? `${dayjsLocal(date).format("D MMM")}, ${normalizedTime(time).slice(0, 5)}` : "Add date"
+
+// A full moment as the end's `min` also strikes the earlier times off its clock on the
+// start's own day; `endsBeforeItStarts` still catches an end landing exactly on it.
+const earliestEnd = computed(() => startAt.value || today)
+
+const cellClass =
+	"flex w-full flex-col gap-0.5 px-3 py-2 text-left leading-tight transition-colors hover:bg-surface-gray-1"
 
 // The row slot is typed for custom rows too, which carry no value; ours never are.
 const zoneOf = (item: ComboboxSelectableOption | ComboboxCustomOption) => String(item.value ?? "")
@@ -62,44 +87,50 @@ const zoneOptions = computed(() =>
 </script>
 
 <template>
-	<div class="space-y-4">
-		<div class="space-y-1">
-			<label class="text-base text-ink-gray-7">Start</label>
-			<div class="grid grid-cols-2 gap-2">
-				<DatePicker
-					v-model="startDate"
-					format="ddd D MMM"
-					placeholder="Date"
-					:min="today"
-					:disabled="disabled"
-				/>
-				<TimePicker v-model="startTime" placeholder="Time" :disabled="disabled" />
+	<!-- The heading and card travel with the fields: both pages present them this way. -->
+	<section class="space-y-3 rounded-6 bg-surface-gray-1/90 p-4">
+		<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">When</h2>
+
+		<div class="space-y-6">
+			<div class="space-y-2">
+				<div
+					class="grid grid-cols-2 divide-x divide-outline-gray-2 overflow-hidden rounded-4 border border-outline-gray-2 bg-surface-base"
+				>
+					<DateTimePicker v-model="startAt" :min="today" :disabled="disabled">
+						<template #trigger="{ toggle, open }">
+							<button
+								type="button"
+								:class="[cellClass, open && 'bg-surface-gray-1']"
+								:disabled="disabled"
+								@click="toggle"
+							>
+								<span class="text-xs text-ink-gray-5">Start</span>
+								<span class="truncate text-base text-ink-gray-9">
+									{{ momentLabel(startDate, startTime) }}
+								</span>
+							</button>
+						</template>
+					</DateTimePicker>
+
+					<DateTimePicker v-model="endAt" :min="earliestEnd" :disabled="disabled">
+						<template #trigger="{ toggle, open }">
+							<button
+								type="button"
+								:class="[cellClass, open && 'bg-surface-gray-1']"
+								:disabled="disabled"
+								@click="toggle"
+							>
+								<span class="text-xs text-ink-gray-5">End</span>
+								<span class="truncate text-base text-ink-gray-9">
+									{{ momentLabel(endDate, endTime) }}
+								</span>
+							</button>
+						</template>
+					</DateTimePicker>
+				</div>
+
+				<ErrorMessage v-if="endsBeforeItStarts" message="End time must be after start time" />
 			</div>
-		</div>
-
-		<div class="space-y-1">
-			<label class="text-base text-ink-gray-7">End</label>
-			<div class="grid grid-cols-2 gap-2">
-				<DatePicker
-					v-model="endDate"
-					format="ddd D MMM"
-					placeholder="Date"
-					:min="earliestEnd"
-					:disabled="disabled"
-				/>
-				<TimePicker
-					v-model="endTime"
-					placeholder="Time"
-					:min="earliestEndTime"
-					:disabled="disabled"
-				/>
-			</div>
-
-			<ErrorMessage v-if="endsBeforeItStarts" message="End time must be after start time" />
-		</div>
-
-		<div class="space-y-1">
-			<label class="text-base text-ink-gray-7">Timezone</label>
 
 			<Combobox
 				v-model="timeZone"
@@ -110,7 +141,7 @@ const zoneOptions = computed(() =>
 			>
 				<!-- Mounted inside the popover trigger, so the press opens it on its own. -->
 				<template #trigger>
-					<Button class="w-full mt-2" :disabled="disabled">
+					<Button variant="outline" class="w-full mt-2" :disabled="disabled">
 						<div class="flex gap-2">
 							<span class="lucide-globe size-4 shrink-0 text-ink-gray-5" aria-hidden="true" />
 							<span class="shrink-0 text-base text-ink-gray-8">
@@ -135,5 +166,5 @@ const zoneOptions = computed(() =>
 				</template>
 			</Combobox>
 		</div>
-	</div>
+	</section>
 </template>

--- a/dashboard/src/components/dashboard/events/EventSchedule.vue
+++ b/dashboard/src/components/dashboard/events/EventSchedule.vue
@@ -65,7 +65,7 @@ const momentLabel = (date: string, time: string) =>
 const earliestEnd = computed(() => startAt.value || today)
 
 const cellClass =
-	"flex w-full flex-col gap-0.5 px-3 py-2 text-left leading-tight transition-colors hover:bg-surface-gray-1"
+	"flex w-full flex-col gap-0.5 px-3 py-2 text-left leading-tight transition-colors duration-150 ease-out hover:bg-surface-gray-1 active:bg-surface-gray-2 motion-reduce:transition-none"
 
 // The row slot is typed for custom rows too, which carry no value; ours never are.
 const zoneOf = (item: ComboboxSelectableOption | ComboboxCustomOption) => String(item.value ?? "")

--- a/dashboard/src/components/dashboard/proposals/ProposalDrawer.vue
+++ b/dashboard/src/components/dashboard/proposals/ProposalDrawer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useClipboard } from "@vueuse/core"
 import {
 	Alert,
 	Avatar,
@@ -26,6 +25,7 @@ import {
 import EventHoverCard from "@/components/dashboard/events/EventHoverCard.vue"
 import AddSpeakerDialog from "@/components/dashboard/proposals/AddSpeakerDialog.vue"
 import PhoneInput from "@/components/PhoneInput.vue"
+import { useCopyToClipboard } from "@/composables/useCopyToClipboard"
 import { useProposalStatuses } from "@/composables/useProposalStatuses"
 import { useProposal } from "@/data/proposals"
 import { session } from "@/data/session"
@@ -148,18 +148,7 @@ async function removeSpeaker() {
 
 const reader = computed(() => userResource.data?.email || session.user)
 
-// legacy: the async clipboard API is refused outside a secure context, and on an
-// http:// host in development that is every time.
-const { copy } = useClipboard({ legacy: true })
-
-async function copyId(id: string) {
-	try {
-		await copy(id)
-		toast.success("Copied to clipboard")
-	} catch {
-		toast.error("Could not copy to clipboard")
-	}
-}
+const copyId = useCopyToClipboard()
 
 // One theme per speaker, stable across renders so a face keeps its colour.
 const AVATAR_THEMES = ["blue", "green", "amber", "red", "violet"] as const

--- a/dashboard/src/composables/useCopyToClipboard.ts
+++ b/dashboard/src/composables/useCopyToClipboard.ts
@@ -1,0 +1,23 @@
+import { useClipboard } from "@vueuse/core"
+import { toast } from "frappe-ui"
+
+/**
+ * Copies text and says so, or says why it could not.
+ *
+ * legacy: the async clipboard API is refused outside a secure context, and on an
+ * http:// host in development that is every time.
+ */
+export function useCopyToClipboard() {
+	const { copy } = useClipboard({ legacy: true })
+
+	return async function copyToClipboard(text: string, message = "Copied to clipboard") {
+		try {
+			await copy(text)
+			toast.success(message)
+			return true
+		} catch {
+			toast.error("Could not copy to clipboard")
+			return false
+		}
+	}
+}

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -170,17 +170,14 @@ async function save() {
 				</section>
 
 				<div class="space-y-8 md:col-span-2">
-					<section class="space-y-3">
-						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">When</h2>
-						<EventSchedule
-							:disabled="!canCreate"
-							v-model:start-date="startDate"
-							v-model:start-time="startTime"
-							v-model:end-date="endDate"
-							v-model:end-time="endTime"
-							v-model:time-zone="timeZone"
-						/>
-					</section>
+					<EventSchedule
+						:disabled="!canCreate"
+						v-model:start-date="startDate"
+						v-model:start-time="startTime"
+						v-model:end-date="endDate"
+						v-model:end-time="endTime"
+						v-model:time-zone="timeZone"
+					/>
 
 					<section class="space-y-8">
 						<label class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -65,9 +65,11 @@ function fill(detail: EventDetail) {
 	nextTick().then(() => (saved.value = JSON.stringify(form)))
 }
 
+// A dirty form outranks the fetched document: the refetch after a save would otherwise
+// drop anything typed while it was in flight.
 watch(
 	() => event.data,
-	(detail) => detail && fill(detail),
+	(detail) => detail && !isDirty.value && fill(detail),
 )
 
 const isDirty = computed(() => JSON.stringify(form) !== saved.value)
@@ -115,11 +117,14 @@ async function save() {
 	const fieldname = Object.fromEntries(
 		Object.entries(form).map(([field, value]) => [field, value === "" ? null : value]),
 	)
+	const submitted = JSON.stringify(form)
 
 	await updateEvent.submit({ doctype: "Buzz Event", name: eventId, fieldname })
 	if (updateEvent.error) return
 
-	saved.value = JSON.stringify(form)
+	// What the server now holds, not what the form holds — an edit made while the save
+	// was in flight is still unsaved, and the baseline has to say so.
+	saved.value = submitted
 	// The header's modified badge and the route's open/copy links all read the fetched
 	// document, so they stay wrong until it is refetched.
 	await event.reload()

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useEventListener } from "@vueuse/core"
 import { Button, ErrorMessage, Textarea, toast } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue"
@@ -92,6 +93,14 @@ onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
 onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
 onBeforeRouteLeave(() => !isDirty.value || window.confirm(LEAVE_WARNING))
 
+// The page's own save takes the shortcut the browser would otherwise spend on saving the
+// document — swallowed even with nothing to commit, so it never surprises mid-edit.
+useEventListener(document, "keydown", (stroke: KeyboardEvent) => {
+	if (stroke.key !== "s" || !(stroke.metaKey || stroke.ctrlKey) || stroke.altKey) return
+	stroke.preventDefault()
+	if (!stroke.repeat) save()
+})
+
 function discard() {
 	if (event.data) fill(event.data)
 }
@@ -100,7 +109,7 @@ function discard() {
 const errorMessage = computed(() => (updateEvent.error as FrappeError | null)?.messages?.join("\n"))
 
 async function save() {
-	if (!canSave.value) return
+	if (!canSave.value || updateEvent.loading) return
 
 	// A blank date or venue has to reach the server as null, not "".
 	const fieldname = Object.fromEntries(

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -5,6 +5,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } 
 import { onBeforeRouteLeave, useRoute } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
+import EventDetailsSkeleton from "@/components/dashboard/events/EventDetailsSkeleton.vue"
 import EventMedium from "@/components/dashboard/events/EventMedium.vue"
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
 import EventRoute from "@/components/dashboard/events/EventRoute.vue"
@@ -119,90 +120,108 @@ async function save() {
 
 <template>
 	<EventPageHeader :title="event.data?.title" section="Details" :modified="event.data?.modified">
-		<template v-if="isDirty">
-			<Button label="Discard" @click="discard" />
-			<Button
-				variant="solid"
-				label="Save"
-				:disabled="!canSave"
-				:loading="updateEvent.loading"
-				@click="save"
-			/>
-		</template>
+		<!-- These appear mid-edit, so they arrive rather than pop. Exit is quicker than
+			 entry: the save has already happened by then. -->
+		<Transition
+			enter-active-class="transition duration-150 ease-out motion-reduce:transition-none"
+			enter-from-class="opacity-0 translate-y-1"
+			leave-active-class="transition duration-100 ease-out motion-reduce:transition-none"
+			leave-to-class="opacity-0"
+		>
+			<div v-if="isDirty" class="flex items-center gap-2">
+				<Button label="Discard" @click="discard" />
+				<Button
+					variant="solid"
+					label="Save"
+					:disabled="!canSave"
+					:loading="updateEvent.loading"
+					@click="save"
+				/>
+			</div>
+		</Transition>
 	</EventPageHeader>
 
-	<div v-if="event.data" class="m-auto w-full max-w-[800px] space-y-8 px-4 py-8">
-		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
+	<EventDetailsSkeleton v-if="!event.data" />
 
-		<EventBanner v-model="form.banner_image" :seed="form.title" />
+	<Transition
+		enter-active-class="transition-opacity duration-200 ease-out motion-reduce:transition-none"
+		enter-from-class="opacity-0"
+	>
+		<div v-if="event.data" class="m-auto w-full max-w-[800px] space-y-8 px-4 py-8">
+			<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
-		<div class="grid gap-8 md:grid-cols-5">
-			<div class="space-y-8 md:col-span-3">
-				<div class="space-y-2">
-					<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
-					<input
-						v-model="form.title"
-						aria-label="Event title"
-						placeholder="Name your event"
-						class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none"
-					/>
-					<!-- Ghost variant: no border, so it reads as a subtitle under the name. -->
-					<Textarea
-						v-model="form.short_description"
-						variant="ghost"
-						:rows="2"
-						aria-label="Short description"
-						placeholder="Add a small description"
-						class="!border-0 resize-none !px-0 text-ink-gray-6 bg-transparent"
-					/>
-				</div>
+			<EventBanner v-model="form.banner_image" :seed="form.title" />
 
-				<section class="space-y-3">
-					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
-					<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
+			<div class="grid gap-8 md:grid-cols-5">
+				<div class="space-y-8 md:col-span-3">
+					<div class="space-y-2">
+						<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
+						<input
+							v-model="form.title"
+							aria-label="Event title"
+							placeholder="Name your event"
+							class="-mx-1 w-full rounded-4 bg-transparent px-1 text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+						/>
+						<!-- Ghost variant: no border, so it reads as a subtitle under the name. -->
+						<Textarea
+							v-model="form.short_description"
+							variant="ghost"
+							:rows="2"
+							aria-label="Short description"
+							placeholder="Add a small description"
+							class="!border-0 resize-none !px-0 text-ink-gray-6 bg-transparent"
+						/>
+					</div>
+
+					<section class="space-y-3">
+						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
+						<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
 						 itself: the height and scrolling land on the editable area rather than on a
 						 wrapper, and the whole box takes a click. -->
-					<div class="rounded-6 border border-outline-gray-2 p-3">
-						<Editor
-							v-model="form.about"
-							:extensions="[RichTextKit]"
-							placeholder="What is this event about?"
+						<div
+							class="rounded-6 border border-outline-gray-2 p-3 transition-colors duration-150 ease-out focus-within:border-outline-gray-4 motion-reduce:transition-none"
 						>
-							<EditorContent
-								class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
-							/>
-						</Editor>
-					</div>
-				</section>
-			</div>
+							<Editor
+								v-model="form.about"
+								:extensions="[RichTextKit]"
+								placeholder="What is this event about?"
+							>
+								<EditorContent
+									class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
+								/>
+							</Editor>
+						</div>
+					</section>
+				</div>
 
-			<div class="space-y-8 md:col-span-2">
-				<EventRoute
-					v-model="form.route"
-					v-model:taken="routeTaken"
-					:event="eventId"
-					:saved="event.data.route"
-				/>
-
-				<EventSchedule
-					v-model:start-date="form.start_date"
-					v-model:start-time="form.start_time"
-					v-model:end-date="form.end_date"
-					v-model:end-time="form.end_time"
-					v-model:time-zone="form.time_zone"
-				/>
-
-				<section class="space-y-3">
-					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
-					<EventMedium
-						v-model:medium="form.medium"
-						v-model:venue="form.venue"
-						v-model:meeting-link="form.meeting_link"
-						:team="event.data.team || ''"
-						:venue-address="event.data.venue?.address"
+				<div class="space-y-8 md:col-span-2">
+					<EventRoute
+						v-model="form.route"
+						v-model:taken="routeTaken"
+						:event="eventId"
+						:saved="event.data.route"
 					/>
-				</section>
+
+					<EventSchedule
+						v-model:start-date="form.start_date"
+						v-model:start-time="form.start_time"
+						v-model:end-date="form.end_date"
+						v-model:end-time="form.end_time"
+						v-model:time-zone="form.time_zone"
+					/>
+
+					<section class="space-y-3">
+						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
+						<EventMedium
+							v-model:medium="form.medium"
+							v-model:venue="form.venue"
+							v-model:meeting-link="form.meeting_link"
+							:team="event.data.team || ''"
+							:venue-address="event.data.venue?.address"
+						/>
+					</section>
+				</div>
 			</div>
 		</div>
-	</div>
+	</Transition>
 </template>

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { Button, ErrorMessage, Textarea, toast } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
-import { computed, reactive, ref, watch } from "vue"
-import { useRoute } from "vue-router"
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue"
+import { onBeforeRouteLeave, useRoute } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
 import EventMedium from "@/components/dashboard/events/EventMedium.vue"
@@ -11,6 +11,7 @@ import EventRoute from "@/components/dashboard/events/EventRoute.vue"
 import EventSchedule from "@/components/dashboard/events/EventSchedule.vue"
 import { eventDetail, updateEvent } from "@/data/events"
 import type { EventDetail, FrappeError } from "@/types"
+import { isEndBeforeStart } from "@/utils/eventDates"
 
 const route = useRoute()
 const eventId = route.params.eventId as string
@@ -57,7 +58,9 @@ function fill(detail: EventDetail) {
 		venue: detail.venue?.name ?? "",
 		meeting_link: detail.meeting_link ?? "",
 	})
-	saved.value = JSON.stringify(form)
+	// The editor rewrites its own HTML once it mounts, so the baseline is taken after
+	// that settles — otherwise the page loads already dirty.
+	nextTick().then(() => (saved.value = JSON.stringify(form)))
 }
 
 watch(
@@ -67,10 +70,37 @@ watch(
 
 const isDirty = computed(() => JSON.stringify(form) !== saved.value)
 
+// The server refuses both of these, so the page should not spend a round trip finding out.
+const routeTaken = ref(false)
+const canSave = computed(
+	() =>
+		isDirty.value &&
+		!routeTaken.value &&
+		!isEndBeforeStart(form.start_date, form.end_date, form.start_time, form.end_time),
+)
+
+// Nothing here autosaves, so leaving with edits in hand has to be deliberate.
+const LEAVE_WARNING = "You have unsaved changes. Leave without saving?"
+
+function warnOnUnload(unload: BeforeUnloadEvent) {
+	if (!isDirty.value) return
+	unload.preventDefault()
+}
+
+onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
+onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
+onBeforeRouteLeave(() => !isDirty.value || window.confirm(LEAVE_WARNING))
+
+function discard() {
+	if (event.data) fill(event.data)
+}
+
 // createResource types its error as {}, so the message needs narrowing.
 const errorMessage = computed(() => (updateEvent.error as FrappeError | null)?.messages?.join("\n"))
 
 async function save() {
+	if (!canSave.value) return
+
 	// A blank date or venue has to reach the server as null, not "".
 	const fieldname = Object.fromEntries(
 		Object.entries(form).map(([field, value]) => [field, value === "" ? null : value]),
@@ -80,83 +110,87 @@ async function save() {
 	if (updateEvent.error) return
 
 	saved.value = JSON.stringify(form)
+	// The header's modified badge and the route's open/copy links all read the fetched
+	// document, so they stay wrong until it is refetched.
+	await event.reload()
 	toast.success("Event saved")
 }
 </script>
 
 <template>
-	<EventPageHeader :title="event.data?.title" section="Details">
-		<Button
-			v-if="isDirty"
-			variant="solid"
-			label="Save"
-			:loading="updateEvent.loading"
-			@click="save"
-		/>
+	<EventPageHeader :title="event.data?.title" section="Details" :modified="event.data?.modified">
+		<template v-if="isDirty">
+			<Button label="Discard" @click="discard" />
+			<Button
+				variant="solid"
+				label="Save"
+				:disabled="!canSave"
+				:loading="updateEvent.loading"
+				@click="save"
+			/>
+		</template>
 	</EventPageHeader>
 
-	<div v-if="event.data" class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
+	<div v-if="event.data" class="m-auto w-full max-w-[800px] space-y-8 px-4 py-8">
 		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
 		<EventBanner v-model="form.banner_image" :seed="form.title" />
 
-		<div class="space-y-2">
-			<div class="flex items-start justify-between gap-4">
-				<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
-				<input
-					v-model="form.title"
-					aria-label="Event title"
-					placeholder="Name your event"
-					class="min-w-0 flex-1 bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none"
-				/>
-				<EventRoute
-					v-model="form.route"
-					:event="eventId"
-					:saved="event.data.route"
-					class="shrink-0"
-				/>
-			</div>
-			<!-- Ghost variant: no border, so it reads as a subtitle under the name. -->
-			<Textarea
-				v-model="form.short_description"
-				variant="ghost"
-				:rows="2"
-				aria-label="Short description"
-				placeholder="Add a small description"
-				class="!border-0 resize-none px-0 text-ink-gray-6 bg-transparent"
-			/>
-		</div>
-
 		<div class="grid gap-8 md:grid-cols-5">
-			<section class="space-y-3 md:col-span-3">
-				<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
-				<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
-					 itself: the height and scrolling land on the editable area rather than on a
-					 wrapper, and the whole box takes a click. -->
-				<div class="rounded-6 border border-outline-gray-2 p-3">
-					<Editor
-						v-model="form.about"
-						:extensions="[RichTextKit]"
-						placeholder="What is this event about?"
-					>
-						<EditorContent
-							class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
-						/>
-					</Editor>
+			<div class="space-y-8 md:col-span-3">
+				<div class="space-y-2">
+					<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
+					<input
+						v-model="form.title"
+						aria-label="Event title"
+						placeholder="Name your event"
+						class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none"
+					/>
+					<!-- Ghost variant: no border, so it reads as a subtitle under the name. -->
+					<Textarea
+						v-model="form.short_description"
+						variant="ghost"
+						:rows="2"
+						aria-label="Short description"
+						placeholder="Add a small description"
+						class="!border-0 resize-none !px-0 text-ink-gray-6 bg-transparent"
+					/>
 				</div>
-			</section>
+
+				<section class="space-y-3">
+					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
+					<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
+						 itself: the height and scrolling land on the editable area rather than on a
+						 wrapper, and the whole box takes a click. -->
+					<div class="rounded-6 border border-outline-gray-2 p-3">
+						<Editor
+							v-model="form.about"
+							:extensions="[RichTextKit]"
+							placeholder="What is this event about?"
+						>
+							<EditorContent
+								class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
+							/>
+						</Editor>
+					</div>
+				</section>
+			</div>
 
 			<div class="space-y-8 md:col-span-2">
-				<section class="space-y-3">
-					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">When</h2>
-					<EventSchedule
-						v-model:start-date="form.start_date"
-						v-model:start-time="form.start_time"
-						v-model:end-date="form.end_date"
-						v-model:end-time="form.end_time"
-						v-model:time-zone="form.time_zone"
-					/>
-				</section>
+				<EventRoute
+					v-model="form.route"
+					v-model:taken="routeTaken"
+					:event="eventId"
+					:saved="event.data.route"
+				/>
+
+				<EventSchedule
+					v-model:start-date="form.start_date"
+					v-model:start-time="form.start_time"
+					v-model:end-date="form.end_date"
+					v-model:end-time="form.end_time"
+					v-model:time-zone="form.time_zone"
+				/>
 
 				<section class="space-y-3">
 					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -160,6 +160,7 @@ export interface EventDetail {
 	title: string
 	route: string | null
 	team: string | null
+	modified: string
 	start_date: string
 	end_date: string | null
 	start_time: string | null

--- a/dashboard/src/utils/eventDates.test.ts
+++ b/dashboard/src/utils/eventDates.test.ts
@@ -52,3 +52,11 @@ test("a half-filled schedule is not reported as invalid", () => {
 	assert.equal(isEndBeforeStart("2026-08-21", "", "", "09:00:00"), false)
 	assert.equal(isEndBeforeStart("2026-08-21", "", "09:00:00", ""), false)
 })
+
+test("an hour without its leading zero compares by value, not as text", () => {
+	// The API renders a Time field through frappe's `format_timedelta`, which pads the
+	// minutes and seconds but not the hour: 9am arrives as `9:00:00`.
+	assert.equal(isEndBeforeStart("2026-08-21", "", "9:00:00", "18:00:00"), false)
+	assert.equal(isEndBeforeStart("2026-08-21", "", "18:00:00", "9:00:00"), true)
+	assert.equal(isEndBeforeStart("2026-08-21", "", "9:00", "18:00"), false)
+})

--- a/dashboard/src/utils/eventDates.ts
+++ b/dashboard/src/utils/eventDates.ts
@@ -13,9 +13,18 @@ export function alignedEndDate(startDate: string, endDate: string): string {
 	return !endDate || endDate < startDate ? startDate : endDate
 }
 
-/** `HH:mm` and `HH:mm:ss` both reach here; padded, they compare correctly as text. */
-function normalizedTime(time: string): string {
-	return time.length === 5 ? `${time}:00` : time
+/**
+ * A time widened to `HH:mm:ss`, so times compare correctly as text.
+ *
+ * Two sources feed this. The pickers emit `HH:mm`, which only wants its seconds. The API
+ * renders a Time field through frappe's `format_timedelta`, which pads the minutes and
+ * seconds but not the hour — 9am arrives as `9:00:00`, and unpadded it sorts after every
+ * afternoon time.
+ */
+export function normalizedTime(time: string): string {
+	if (!time) return time
+	const [hour = "", minute = "00", second = "00"] = time.split(":")
+	return `${hour.padStart(2, "0")}:${minute}:${second}`
 }
 
 /**

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -2,6 +2,9 @@ import frappeUIPreset, { content as frappeUIContent } from "frappe-ui/tailwind"
 
 export default {
 	presets: [frappeUIPreset],
+	// Tailwind 4 does this by default; on 3 a `hover:` style sticks after a tap, so every
+	// hover state on the dashboard stays lit until something else is touched.
+	future: { hoverOnlyWhenSupported: true },
 	content: [
 		"./index.html",
 		"./src/**/*.{vue,js,ts,jsx,tsx}",


### PR DESCRIPTION
## What changed

The details page is one grid: title, short description and About on the left; the
event URL, When and Where on the right. The route moved out of the headline row —
its host now sits above the slug, so a long one has the column width to itself.

Start and end are two cells in one box, each opening a `DateTimePicker` that carries
the whole moment instead of a separate date and time control. Passing the start
moment as the end's `min` strikes the earlier times off its clock on the same day.
The heading and its card moved into `EventSchedule`, since both pages were
hand-writing the same wrapper and styling one never reached the other — CreateEvent
picks the card up for free.

Three fixes came out of reviewing it:

- **Times compared wrong.** frappe's `format_timedelta` pads minutes and seconds but
  not the hour, so 9am arrives as `9:00:00`, which sorts after every afternoon time.
  Any same-day morning event claimed its end came first. Fixed in `normalizedTime`,
  which every `isEndBeforeStart` caller routes through.
- **Saving left the page stale.** Nothing refetched, so the modified badge, the
  breadcrumb and the route's open/copy links kept their load-time values — copy
  handed you a dead URL right after renaming the slug.
- **Nothing guarded unsaved work.** No route guard, no `beforeunload`, no Discard.
  The About field is a rich-text editor; a sidebar click threw it away silently.

Save is now refused for the two things the page already computes and shows in red:
an end before its start, and a slug the server said was taken.

`modified` is new on the event detail payload — the header had no timestamp to read.

## Demo

<!-- Screenshots to be added. -->


https://github.com/user-attachments/assets/441f14af-52ff-4d71-8026-ea5e47e69f0c



## Testing

`yarn typecheck`, `yarn lint`, `yarn fmt:check` and `yarn test:unit` (117 pass) in
`dashboard/`. `bench --site testbuzz.localhost run-tests --module
buzz.api.events.test_events` — 44 tests, OK.

The time-comparison bug has a regression test in `eventDates.test.ts`; every existing
case there used padded hours, which is why it survived.

## Gotchas

A custom `#trigger` slot replaces the picker's own input, so `variant` never renders —
the cell and the timezone button draw their own outline. `TimePicker` has no `#trigger`
slot at all, only `prefix`/`suffix`, and the prefix region is icon-width, so a word-length
prefix sits under the value.

Not done here: `Where` on both pages and `About` on CreateEvent still use the bare
section-and-heading pattern, so `When` reads as the only elevated block. CreateEvent
also still asks the location question through `EventLocation` while the details page
uses `EventMedium`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aumrv6B2o9dWmZfj3hSNjB
