### PR TITLE
feat: manage the talks proposed to an event

### DIFF
--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -194,8 +194,8 @@ def ticket_type_filter(ticket_types: str | None) -> list[str]:
 	return [chosen for chosen in (ticket_types or "").split(",") if chosen.strip()]
 
 
-def ensure_guest_list_access(event: str) -> None:
-	"""Read access to the event's team is the bar for everything about its guests."""
+def ensure_event_team_access(event: str) -> None:
+	"""Read access to the event's team is the bar for everything a manage page shows."""
 	if not frappe.db.exists("Buzz Event", event):
 		EventNotFound.throw()
 
@@ -220,7 +220,7 @@ def event_guests(
 	Ordered by when the ticket was registered, newest first by default, so a page is a
 	stable slice as the caller walks down the list.
 	"""
-	ensure_guest_list_access(event)
+	ensure_event_team_access(event)
 
 	filters = {"event": event, "docstatus": 1}
 	chosen_types = ticket_type_filter(ticket_types)
@@ -280,7 +280,7 @@ def registration_trend(event: str, days: int = TREND_DAYS) -> RegistrationTrend:
 	is read as a shape, and a missing row would draw as a shorter week or a band that
 	disappears mid-stack rather than a quiet one.
 	"""
-	ensure_guest_list_access(event)
+	ensure_event_team_access(event)
 
 	days = max(2, min(int(days), 90))
 	window = [add_days(getdate(), -offset) for offset in reversed(range(days))]

--- a/buzz/api/proposals/__init__.py
+++ b/buzz/api/proposals/__init__.py
@@ -1,7 +1,12 @@
 import frappe
 
 from buzz.api.proposals import services
-from buzz.api.proposals.schemas import EventProposalsResponse, ProposalListItem, ProposalTrend
+from buzz.api.proposals.schemas import (
+	AcceptedProposal,
+	EventProposalsResponse,
+	ProposalListItem,
+	ProposalTrend,
+)
 
 
 @frappe.whitelist()
@@ -31,3 +36,9 @@ def get_event_proposals(
 def get_event_proposal_trend(event: str, days: int = services.TREND_DAYS) -> ProposalTrend:
 	"""Submissions per day for an event, for the card above its proposal list."""
 	return services.proposal_trend(event, days)
+
+
+@frappe.whitelist(methods=["POST"])
+def accept_proposal(proposal: str) -> AcceptedProposal:
+	"""Accept a proposal and create the Event Talk it becomes."""
+	return services.accept_proposal(proposal)

--- a/buzz/api/proposals/__init__.py
+++ b/buzz/api/proposals/__init__.py
@@ -1,10 +1,33 @@
 import frappe
 
 from buzz.api.proposals import services
-from buzz.api.proposals.schemas import ProposalListItem
+from buzz.api.proposals.schemas import EventProposalsResponse, ProposalListItem, ProposalTrend
 
 
 @frappe.whitelist()
 def get_my_proposals() -> list[ProposalListItem]:
 	"""Proposals where the session user is the submitter or a listed speaker."""
 	return services.my_proposals()
+
+
+@frappe.whitelist()
+def get_event_proposals(
+	event: str,
+	search: str | None = None,
+	statuses: str | None = None,
+	order: str = "desc",
+	start: int = 0,
+	limit: int = services.PROPOSALS_PAGE_SIZE,
+) -> EventProposalsResponse:
+	"""One page of the talk proposals submitted to an event, for its team.
+
+	`statuses` is comma-joined rather than a list: a GET query string carries one, and it
+	is the same string the dashboard keeps the filter in.
+	"""
+	return services.event_proposals(event, search, statuses, order, start, limit)
+
+
+@frappe.whitelist()
+def get_event_proposal_trend(event: str, days: int = services.TREND_DAYS) -> ProposalTrend:
+	"""Submissions per day for an event, for the card above its proposal list."""
+	return services.proposal_trend(event, days)

--- a/buzz/api/proposals/schemas.py
+++ b/buzz/api/proposals/schemas.py
@@ -38,6 +38,9 @@ class EventProposalsResponse(APIResponse):
 	matched: int
 	proposals: list[ProposalListItem]
 	has_next_page: bool = False
+	# Whether this reader may change a proposal, so the drawer offers the control only to
+	# someone the server will accept it from. Read access alone is a Viewer or Frontdesk.
+	can_write: bool = False
 
 
 class DailySubmissions(APIResponse):

--- a/buzz/api/proposals/schemas.py
+++ b/buzz/api/proposals/schemas.py
@@ -60,3 +60,11 @@ class ProposalTrend(APIResponse):
 	per_day: list[DailySubmissions]
 	# All-time, like `total` — the window is a shape over time, a status is a share of a whole.
 	by_status: list[StatusTotal] = Field(default_factory=list)
+
+
+class AcceptedProposal(APIResponse):
+	"""What an acceptance produced: the proposal's new status and the talk behind it."""
+
+	proposal: str
+	status: str
+	talk: str

--- a/buzz/api/proposals/schemas.py
+++ b/buzz/api/proposals/schemas.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime, timedelta
 
+from pydantic import Field
+
 from buzz.api.schemas import APIResponse
 
 
@@ -25,3 +27,33 @@ class ProposalListItem(APIResponse):
 	creation: datetime
 	modified: datetime
 	speakers: list[ProposalSpeakerItem]
+
+
+class EventProposalsResponse(APIResponse):
+	"""One page of an event's talk proposals, with the counts the header reads."""
+
+	title: str | None = None
+	# Everyone who submitted, then everyone the current search and filters match.
+	total: int
+	matched: int
+	proposals: list[ProposalListItem]
+	has_next_page: bool = False
+
+
+class DailySubmissions(APIResponse):
+	date: date
+	count: int
+
+
+class StatusTotal(APIResponse):
+	status: str
+	count: int
+
+
+class ProposalTrend(APIResponse):
+	"""How submissions have run, for the card above the proposal list."""
+
+	total: int
+	per_day: list[DailySubmissions]
+	# All-time, like `total` — the window is a shape over time, a status is a share of a whole.
+	by_status: list[StatusTotal] = Field(default_factory=list)

--- a/buzz/api/proposals/services.py
+++ b/buzz/api/proposals/services.py
@@ -11,6 +11,7 @@ from buzz.api.proposals.schemas import (
 	ProposalTrend,
 	StatusTotal,
 )
+from buzz.permissions import has_team_access
 
 # The columns behind one proposal card. The event ones come over a link hop, so a
 # deleted event leaves them empty.
@@ -120,12 +121,14 @@ def event_proposals(
 
 	total = frappe.db.count("Talk Proposal", {"event": event})
 	matched = count_proposals(filters, or_filters) if or_filters or chosen else total
+	title, team = frappe.db.get_value("Buzz Event", event, ["title", "team"])
 	return EventProposalsResponse(
-		title=frappe.db.get_value("Buzz Event", event, "title"),
+		title=title,
 		total=total,
 		matched=matched,
 		proposals=[ProposalListItem(**row, speakers=speakers.get(row.name, [])) for row in rows],
 		has_next_page=start + len(rows) < matched,
+		can_write=has_team_access(team, "write", frappe.session.user),
 	)
 
 

--- a/buzz/api/proposals/services.py
+++ b/buzz/api/proposals/services.py
@@ -1,9 +1,11 @@
 import frappe
+from frappe import _
 from frappe.query_builder.functions import Count, Date
 from frappe.utils import add_days, getdate
 
 from buzz.api.events.services import ensure_event_team_access
 from buzz.api.proposals.schemas import (
+	AcceptedProposal,
 	DailySubmissions,
 	EventProposalsResponse,
 	ProposalListItem,
@@ -11,7 +13,7 @@ from buzz.api.proposals.schemas import (
 	ProposalTrend,
 	StatusTotal,
 )
-from buzz.permissions import has_team_access
+from buzz.permissions import derived_has_permission, has_team_access
 
 # The columns behind one proposal card. The event ones come over a link hop, so a
 # deleted event leaves them empty.
@@ -209,3 +211,29 @@ def counts_by_status(event: str) -> list:
 		.where(proposal.event == event)
 		.groupby(proposal.status)
 	).run(as_dict=True)
+
+
+ACCEPTED = "Accepted"
+
+
+def accept_proposal(proposal: str) -> AcceptedProposal:
+	"""Accept a proposal, and put the talk it becomes on the event's programme.
+
+	`create_talk` is the only path that builds the Event Talk and the speaker accounts,
+	and the Desk button that used to be its only caller hides once the status reads
+	Accepted — so a status written straight to Accepted stranded the proposal with no
+	programme entry and no way back to make one.
+	"""
+	doc = frappe.get_doc("Talk Proposal", proposal)
+	if not derived_has_permission(doc, ptype="write"):
+		# A listed speaker holds write on their own proposal, which is not the same thing.
+		frappe.throw(_("Only the event's team can accept a proposal."), frappe.PermissionError)
+
+	existing = frappe.db.get_value("Event Talk", {"proposal": doc.name}, "name")
+	if not existing:
+		return AcceptedProposal(proposal=doc.name, talk=str(doc.create_talk().name), status=doc.status)
+
+	# Accepted once already and moved away since: the talk stands, only the status returns.
+	doc.status = ACCEPTED
+	doc.save()
+	return AcceptedProposal(proposal=doc.name, talk=str(existing), status=doc.status)

--- a/buzz/api/proposals/services.py
+++ b/buzz/api/proposals/services.py
@@ -1,6 +1,34 @@
 import frappe
+from frappe.query_builder.functions import Count, Date
+from frappe.utils import add_days, getdate
 
-from buzz.api.proposals.schemas import ProposalListItem, ProposalSpeakerItem
+from buzz.api.events.services import ensure_event_team_access
+from buzz.api.proposals.schemas import (
+	DailySubmissions,
+	EventProposalsResponse,
+	ProposalListItem,
+	ProposalSpeakerItem,
+	ProposalTrend,
+	StatusTotal,
+)
+
+# The columns behind one proposal card. The event ones come over a link hop, so a
+# deleted event leaves them empty.
+PROPOSAL_LIST_FIELDS = [
+	"name",
+	"title",
+	"event",
+	"event.title as event_title",
+	"event.start_date",
+	"event.start_time",
+	"event.end_date",
+	"event.venue",
+	"event.banner_image",
+	"event.allow_editing_talks_after_acceptance",
+	"status",
+	"creation",
+	"modified",
+]
 
 
 def my_proposals() -> list[ProposalListItem]:
@@ -23,21 +51,7 @@ def my_proposals() -> list[ProposalListItem]:
 			"submitted_by": user,
 			"name": ["in", speaker_proposal_names],
 		},
-		fields=[
-			"name",
-			"title",
-			"event",
-			"event.title as event_title",
-			"event.start_date",
-			"event.start_time",
-			"event.end_date",
-			"event.venue",
-			"event.banner_image",
-			"event.allow_editing_talks_after_acceptance",
-			"status",
-			"creation",
-			"modified",
-		],
+		fields=PROPOSAL_LIST_FIELDS,
 		order_by="creation desc",
 	)
 
@@ -62,3 +76,133 @@ def speakers_by_proposal(proposal_names: list[str]) -> dict[str, list[ProposalSp
 	for row in rows:
 		grouped.setdefault(row.pop("parent"), []).append(ProposalSpeakerItem(**row))
 	return grouped
+
+
+PROPOSALS_PAGE_SIZE = 20
+TREND_DAYS = 14
+
+
+def event_proposals(
+	event: str,
+	search: str | None = None,
+	statuses: str | None = None,
+	order: str = "desc",
+	start: int = 0,
+	limit: int = PROPOSALS_PAGE_SIZE,
+) -> EventProposalsResponse:
+	"""One page of the talk proposals submitted to an event, newest first by default.
+
+	Read access to the event's team is the bar, the same one its guest list uses.
+	"""
+	ensure_event_team_access(event)
+
+	filters: dict = {"event": event}
+	chosen = [status for status in (statuses or "").split(",") if status.strip()]
+	if chosen:
+		filters["status"] = ["in", chosen]
+	or_filters = proposal_search_filters(search)
+	limit = max(1, min(int(limit), 100))
+	start = max(0, int(start))
+	# Interpolated into ORDER BY, so it can only ever be one of two literals.
+	direction = "asc" if str(order).lower() == "asc" else "desc"
+
+	rows = frappe.get_all(
+		"Talk Proposal",
+		filters=filters,
+		or_filters=or_filters,
+		fields=PROPOSAL_LIST_FIELDS,
+		order_by=f"creation {direction}, name {direction}",
+		limit_start=start,
+		limit_page_length=limit,
+		ignore_permissions=True,
+	)
+	speakers = speakers_by_proposal([row.name for row in rows])
+
+	total = frappe.db.count("Talk Proposal", {"event": event})
+	matched = count_proposals(filters, or_filters) if or_filters or chosen else total
+	return EventProposalsResponse(
+		title=frappe.db.get_value("Buzz Event", event, "title"),
+		total=total,
+		matched=matched,
+		proposals=[ProposalListItem(**row, speakers=speakers.get(row.name, [])) for row in rows],
+		has_next_page=start + len(rows) < matched,
+	)
+
+
+def proposal_search_filters(search: str | None) -> list[list] | None:
+	"""Title, or the name or email of a listed speaker — what a manager reads off the card."""
+	term = (search or "").strip()
+	if not term:
+		return None
+
+	matched_speakers = frappe.get_all(
+		"Proposal Speaker",
+		filters={"parenttype": "Talk Proposal"},
+		or_filters=[
+			["first_name", "like", f"%{term}%"],
+			["last_name", "like", f"%{term}%"],
+			["email", "like", f"%{term}%"],
+		],
+		pluck="parent",
+	)
+	return [
+		["title", "like", f"%{term}%"],
+		# A proposal with no matching speaker still has to fail this arm, and an empty
+		# `in` list is what does that.
+		["name", "in", matched_speakers],
+	]
+
+
+def count_proposals(filters: dict, or_filters: list[list] | None) -> int:
+	return len(
+		frappe.get_all(
+			"Talk Proposal",
+			filters=filters,
+			or_filters=or_filters,
+			pluck="name",
+			ignore_permissions=True,
+		)
+	)
+
+
+def proposal_trend(event: str, days: int = TREND_DAYS) -> ProposalTrend:
+	"""Proposals submitted per day, oldest day first, with the all-time status split.
+
+	Every day of the window is zero-filled: the series is read as a shape, and a missing
+	row would draw as a shorter week rather than a quiet one.
+	"""
+	ensure_event_team_access(event)
+
+	days = max(2, min(int(days), 90))
+	window = [add_days(getdate(), -offset) for offset in reversed(range(days))]
+	counted = submissions_by_day(event, window[0])
+
+	return ProposalTrend(
+		total=frappe.db.count("Talk Proposal", {"event": event}),
+		per_day=[DailySubmissions(date=day, count=counted.get(day, 0)) for day in window],
+		by_status=[StatusTotal(status=str(row.status), count=row.count) for row in counts_by_status(event)],
+	)
+
+
+def submissions_by_day(event: str, since) -> dict:
+	"""Counts keyed by day, in one grouped query."""
+	proposal = frappe.qb.DocType("Talk Proposal")
+	day = Date(proposal.creation)
+	rows = (
+		frappe.qb.from_(proposal)
+		.select(day.as_("day"), Count("*").as_("count"))
+		.where((proposal.event == event) & (day >= since))
+		.groupby(day)
+	).run(as_dict=True)
+	return {getdate(row.day): row.count for row in rows}
+
+
+def counts_by_status(event: str) -> list:
+	"""An event's proposals counted per status, in one grouped query."""
+	proposal = frappe.qb.DocType("Talk Proposal")
+	return (
+		frappe.qb.from_(proposal)
+		.select(proposal.status, Count("*").as_("count"))
+		.where(proposal.event == event)
+		.groupby(proposal.status)
+	).run(as_dict=True)

--- a/buzz/api/proposals/test_proposals.py
+++ b/buzz/api/proposals/test_proposals.py
@@ -1,10 +1,12 @@
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils.data import cstr
+from frappe.utils.data import cstr, getdate
 from frappe.utils.response import json_handler
 
+from buzz.api.events.exceptions import CannotManageEvent, EventNotFound
 from buzz.api.forms.test_forms import ensure_prompt_named_record
-from buzz.api.proposals import get_my_proposals
+from buzz.api.proposals import get_event_proposal_trend, get_event_proposals, get_my_proposals
+from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team
 from buzz.proposals.doctype.talk_proposal.test_talk_proposal import (
 	make_guest_proposal,
 	make_test_event,
@@ -129,3 +131,120 @@ class TestGetMyProposals(IntegrationTestCase):
 		frappe.set_user(self.speaker_user)
 		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
 		self.assertRegex(json_handler(row["creation"]), r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
+
+
+class TestGetEventProposals(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Event Proposals Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Event Proposals Host")
+		cls.manager = make_test_user("proposals-manager@example.com")
+		cls.outsider = make_test_user("proposals-outsider@example.com")
+		cls.team = create_owned_team(f"Proposals Team {frappe.generate_hash(length=6)}", cls.manager)
+		cls.event = cstr(make_test_event(cls.category, cls.host, team=cls.team))
+		cls.other_event = cstr(make_test_event(cls.category, cls.host, team=cls.team))
+		cls.pending = make_guest_proposal(cls.event, "one@example.com", title="Pending Kubernetes")
+		cls.accepted = make_guest_proposal(cls.event, "two@example.com", title="Accepted Rust")
+		frappe.db.set_value("Talk Proposal", cls.accepted, "status", "Accepted")
+		cls.elsewhere = make_guest_proposal(cls.other_event, "three@example.com")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def listed(self, **kwargs) -> list[str]:
+		frappe.set_user(self.manager)
+		response = get_event_proposals(self.event, **kwargs)
+		return [proposal.name for proposal in response.proposals]
+
+	def test_lists_only_this_events_proposals(self):
+		names = self.listed()
+		self.assertIn(self.pending, names)
+		self.assertIn(self.accepted, names)
+		self.assertNotIn(self.elsewhere, names)
+
+	def test_lists_proposals_the_manager_is_not_a_speaker_on(self):
+		"""The team reads its whole pipeline, not just the talks it happens to be on."""
+		frappe.set_user(self.manager)
+		self.assertEqual(get_event_proposals(self.event).total, 2)
+
+	def test_outsider_cannot_read_the_pipeline(self):
+		frappe.set_user(self.outsider)
+		with self.assertRaises(CannotManageEvent):
+			get_event_proposals(self.event)
+
+	def test_unknown_event_is_not_found(self):
+		frappe.set_user(self.manager)
+		with self.assertRaises(EventNotFound):
+			get_event_proposals("does-not-exist")
+
+	def test_status_filter_narrows_the_page(self):
+		self.assertEqual(self.listed(statuses="Accepted"), [self.accepted])
+
+	def test_search_matches_the_title(self):
+		self.assertEqual(self.listed(search="Kubernetes"), [self.pending])
+
+	def test_search_matches_a_speaker_email(self):
+		self.assertEqual(self.listed(search="two@example.com"), [self.accepted])
+
+	def test_search_that_matches_nothing_returns_nothing(self):
+		self.assertEqual(self.listed(search="Fortran"), [])
+
+	def test_matched_counts_the_filter_while_total_counts_the_event(self):
+		frappe.set_user(self.manager)
+		response = get_event_proposals(self.event, statuses="Accepted")
+		self.assertEqual(response.matched, 1)
+		self.assertEqual(response.total, 2)
+
+	def test_page_reports_whether_more_are_waiting(self):
+		frappe.set_user(self.manager)
+		first = get_event_proposals(self.event, limit=1)
+		self.assertTrue(first.has_next_page)
+		self.assertFalse(get_event_proposals(self.event, start=1, limit=1).has_next_page)
+
+	def test_order_reverses_the_page(self):
+		self.assertEqual(list(reversed(self.listed())), self.listed(order="asc"))
+
+	def test_rows_carry_their_speakers(self):
+		frappe.set_user(self.manager)
+		row = next(p for p in get_event_proposals(self.event).proposals if p.name == self.pending)
+		self.assertEqual([speaker.email for speaker in row.speakers], ["one@example.com"])
+
+
+class TestGetEventProposalTrend(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Proposal Trend Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Proposal Trend Host")
+		cls.manager = make_test_user("trend-manager@example.com")
+		cls.outsider = make_test_user("trend-outsider@example.com")
+		cls.team = create_owned_team(f"Trend Team {frappe.generate_hash(length=6)}", cls.manager)
+		cls.event = cstr(make_test_event(cls.category, cls.host, team=cls.team))
+		cls.proposal = make_guest_proposal(cls.event, "trend@example.com")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_window_is_zero_filled_and_ends_today(self):
+		frappe.set_user(self.manager)
+		trend = get_event_proposal_trend(self.event, days=7)
+		self.assertEqual(len(trend.per_day), 7)
+		self.assertEqual(trend.per_day[-1].date, getdate())
+		self.assertEqual(trend.per_day[-1].count, 1)
+
+	def test_total_and_status_split_agree(self):
+		frappe.set_user(self.manager)
+		trend = get_event_proposal_trend(self.event)
+		self.assertEqual(trend.total, 1)
+		self.assertEqual(sum(row.count for row in trend.by_status), trend.total)
+
+	def test_days_are_clamped_to_a_sane_window(self):
+		frappe.set_user(self.manager)
+		self.assertEqual(len(get_event_proposal_trend(self.event, days=500).per_day), 90)
+		self.assertEqual(len(get_event_proposal_trend(self.event, days=0).per_day), 2)
+
+	def test_outsider_cannot_read_the_trend(self):
+		frappe.set_user(self.outsider)
+		with self.assertRaises(CannotManageEvent):
+			get_event_proposal_trend(self.event)

--- a/buzz/api/proposals/test_proposals.py
+++ b/buzz/api/proposals/test_proposals.py
@@ -210,6 +210,28 @@ class TestGetEventProposals(IntegrationTestCase):
 		row = next(p for p in get_event_proposals(self.event).proposals if p.name == self.pending)
 		self.assertEqual([speaker.email for speaker in row.speakers], ["one@example.com"])
 
+	def test_a_writer_is_told_they_may_change_a_status(self):
+		frappe.set_user(self.manager)
+		self.assertTrue(get_event_proposals(self.event).can_write)
+
+	def test_a_read_only_member_reads_the_pipeline_without_the_write_flag(self):
+		"""Viewer and Frontdesk pass the read check the list uses and fail the write one."""
+		viewer = make_test_user("proposals-viewer@example.com")
+		frappe.get_doc(
+			{
+				"doctype": "Buzz Team Membership",
+				"team": self.team,
+				"user": viewer,
+				"team_role": "Viewer",
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user(viewer)
+		response = get_event_proposals(self.event)
+		self.assertEqual(response.total, 2)
+		self.assertFalse(response.can_write)
+
 
 class TestGetEventProposalTrend(IntegrationTestCase):
 	@classmethod

--- a/buzz/api/proposals/test_proposals.py
+++ b/buzz/api/proposals/test_proposals.py
@@ -5,7 +5,12 @@ from frappe.utils.response import json_handler
 
 from buzz.api.events.exceptions import CannotManageEvent, EventNotFound
 from buzz.api.forms.test_forms import ensure_prompt_named_record
-from buzz.api.proposals import get_event_proposal_trend, get_event_proposals, get_my_proposals
+from buzz.api.proposals import (
+	accept_proposal,
+	get_event_proposal_trend,
+	get_event_proposals,
+	get_my_proposals,
+)
 from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team
 from buzz.proposals.doctype.talk_proposal.test_talk_proposal import (
 	make_guest_proposal,
@@ -270,3 +275,57 @@ class TestGetEventProposalTrend(IntegrationTestCase):
 		frappe.set_user(self.outsider)
 		with self.assertRaises(CannotManageEvent):
 			get_event_proposal_trend(self.event)
+
+
+class TestAcceptProposal(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Accept Proposal Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Accept Proposal Host")
+		cls.manager = make_test_user("accept-manager@example.com")
+		cls.outsider = make_test_user("accept-outsider@example.com")
+		cls.team = create_owned_team(f"Accept Team {frappe.generate_hash(length=6)}", cls.manager)
+		cls.event = cstr(make_test_event(cls.category, cls.host, team=cls.team))
+
+	def setUp(self):
+		self.proposal = make_guest_proposal(self.event, "accept-speaker@example.com")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_accepting_creates_the_talk_and_sets_the_status(self):
+		frappe.set_user(self.manager)
+		accepted = accept_proposal(self.proposal)
+
+		self.assertEqual(accepted.status, "Accepted")
+		self.assertEqual(frappe.db.get_value("Talk Proposal", self.proposal, "status"), "Accepted")
+		self.assertEqual(frappe.db.get_value("Event Talk", accepted.talk, "proposal"), self.proposal)
+
+	def test_the_talk_carries_the_proposal_speakers(self):
+		frappe.set_user(self.manager)
+		talk = frappe.get_doc("Event Talk", accept_proposal(self.proposal).talk)
+		self.assertEqual(len(talk.speakers), 1)
+
+	def test_accepting_twice_reuses_the_talk_rather_than_duplicating_it(self):
+		"""A reviewer can move a proposal off Accepted and back; the programme has one entry."""
+		frappe.set_user(self.manager)
+		first = accept_proposal(self.proposal)
+		frappe.db.set_value("Talk Proposal", self.proposal, "status", "Shortlisted")
+
+		second = accept_proposal(self.proposal)
+		self.assertEqual(second.talk, first.talk)
+		self.assertEqual(second.status, "Accepted")
+		self.assertEqual(frappe.db.count("Event Talk", {"proposal": self.proposal}), 1)
+
+	def test_a_speaker_cannot_accept_their_own_proposal(self):
+		"""A listed speaker holds write on the document; accepting is the team's call."""
+		speaker = make_test_user("accept-speaker@example.com")
+		frappe.set_user(speaker)
+		with self.assertRaises(frappe.PermissionError):
+			accept_proposal(self.proposal)
+
+	def test_an_outsider_cannot_accept(self):
+		frappe.set_user(self.outsider)
+		with self.assertRaises(frappe.PermissionError):
+			accept_proposal(self.proposal)

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.py
@@ -150,6 +150,9 @@ class TalkProposal(Document):
 			frappe.throw(_("Only the event's team can accept a proposal."), frappe.PermissionError)
 
 		talk = get_mapped_doc("Talk Proposal", self.name, {"Talk Proposal": {"doctype": "Event Talk"}})
+		# Event Talk.validate refuses a second talk for the same proposal, and the mapper
+		# cannot fill a field the source doctype does not have.
+		talk.proposal = self.name
 
 		for speaker in self.speakers:
 			user = frappe.db.exists("User", speaker.email)

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -49,6 +49,7 @@ declare module 'vue' {
     EventRoute: typeof import('./src/components/dashboard/events/EventRoute.vue')['default']
     EventSchedule: typeof import('./src/components/dashboard/events/EventSchedule.vue')['default']
     EventSelector: typeof import('./src/components/EventSelector.vue')['default']
+    EventTalkProposalDrawer: typeof import('./src/components/dashboard/proposals/EventTalkProposalDrawer.vue')['default']
     FilterBar: typeof import('./src/components/common/filters/FilterBar.vue')['default']
     FormFieldSections: typeof import('./src/components/FormFieldSections.vue')['default']
     GuestInfoDrawer: typeof import('./src/components/dashboard/events/GuestInfoDrawer.vue')['default']

--- a/dashboard/src/components/dashboard/events/GuestInfoDrawer.vue
+++ b/dashboard/src/components/dashboard/events/GuestInfoDrawer.vue
@@ -66,12 +66,7 @@ const ticket = computed<TicketWithEvent | null>(() => {
 			<template v-if="guest">
 				<div class="flex items-center gap-1 p-4 pb-0">
 					<DrawerClose as-child>
-						<Button
-							variant="ghost"
-							size="sm"
-							icon="lucide-chevrons-right"
-							aria-label="Close guest"
-						/>
+						<Button size="sm" icon="lucide-chevrons-right" aria-label="Close guest" />
 					</DrawerClose>
 
 					<!-- Paging sits at the far end, so the list can be walked without going back

--- a/dashboard/src/components/dashboard/proposals/EventTalkProposalDrawer.vue
+++ b/dashboard/src/components/dashboard/proposals/EventTalkProposalDrawer.vue
@@ -1,0 +1,272 @@
+<script setup lang="ts">
+import { Avatar, Button, Select, Skeleton, dayjsLocal, toast } from "frappe-ui"
+import { computed, ref, watch } from "vue"
+
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerTitle,
+} from "@/components/common/drawer"
+import { useCopyToClipboard } from "@/composables/useCopyToClipboard"
+import { useProposalStatuses } from "@/composables/useProposalStatuses"
+import { useProposal } from "@/data/proposals"
+import type { ProposalListItem, ProposalSpeaker } from "@/types"
+import { speakerName } from "@/utils/speakerByline"
+
+const props = defineProps<{ proposal: ProposalListItem | null }>()
+
+const open = defineModel<boolean>("open", { required: true })
+
+const emit = defineEmits<{ changed: [] }>()
+
+const { statuses, getStatusDot } = useProposalStatuses()
+
+// The card's row fills the drawer at once; the document carries what the list call
+// leaves out — the description, the phone and the event's own form answers.
+const proposalDoc = useProposal(() => props.proposal?.name)
+
+// The row's speakers show at once; the document's replace them. Its rows are full child
+// documents — the drawer only reads the three fields the list already carries.
+const speakers = computed<ProposalSpeaker[]>(() =>
+	(proposalDoc.doc?.speakers ?? props.proposal?.speakers ?? []).map((speaker) => ({
+		first_name: speaker.first_name,
+		last_name: speaker.last_name ?? null,
+		email: speaker.email,
+	})),
+)
+
+// The select is seeded from the row and re-seeded whenever the drawer moves to another
+// proposal, so a failed write leaves the control showing what is actually stored.
+const status = ref("")
+watch(
+	() => props.proposal?.status,
+	(current) => (status.value = current || ""),
+	{ immediate: true },
+)
+
+// A dot rather than `option.icon`: the status's own colour reads faster than seven
+// lucide glyphs. Select renders `description` natively when one is written per status.
+const statusOptions = computed(() =>
+	(statuses.data || []).map((row: { name: string }) => ({ value: row.name, label: row.name })),
+)
+
+// Picking a status only arms the change: the footer's button is what writes it, so a
+// mis-click on a decision the speaker gets told about is still recoverable.
+const changed = computed(() => Boolean(status.value) && status.value !== props.proposal?.status)
+
+async function updateStatus() {
+	if (!changed.value) return
+	try {
+		await proposalDoc.setValue.submit({ status: status.value })
+		toast.success(`Marked ${status.value.toLowerCase()}`)
+		emit("changed")
+	} catch {
+		status.value = props.proposal?.status || ""
+		toast.error("Could not change the status")
+	}
+}
+
+const copyId = useCopyToClipboard()
+
+// One theme per speaker, stable across renders so a face keeps its colour.
+const AVATAR_THEMES = ["blue", "green", "amber", "red", "violet"] as const
+const avatarTheme = (email: string) => {
+	const seed = [...email].reduce((total, character) => total + character.charCodeAt(0), 0)
+	return AVATAR_THEMES[seed % AVATAR_THEMES.length]
+}
+
+// creation and modified are full timestamps in the site's timezone, so these convert.
+const submittedOn = computed(() =>
+	props.proposal ? dayjsLocal(props.proposal.creation).format("D MMM YYYY") : "",
+)
+const lastUpdated = computed(() =>
+	props.proposal ? dayjsLocal(props.proposal.modified).format("D MMM'YY, h:mm A") : "",
+)
+
+// The reviewer's own reading order: who and when first, then the form's own answers.
+const fields = computed(() => [
+	{ label: "Submitted on", value: submittedOn.value },
+	{ label: "Phone", value: proposalDoc.doc?.phone || "—" },
+	...(proposalDoc.doc?.additional_fields || [])
+		.filter((field) => field.value)
+		.map((field) => ({ label: field.label, value: field.value })),
+])
+</script>
+
+<template>
+	<Drawer v-model:open="open" swipe-direction="right">
+		<DrawerContent size="lg">
+			<template v-if="proposal">
+				<div class="flex items-center gap-2 p-4 pb-0">
+					<DrawerClose as-child>
+						<Button size="sm" icon="lucide-chevrons-right" aria-label="Close proposal" />
+					</DrawerClose>
+					<button
+						type="button"
+						class="copy-id cursor-copy font-mono text-sm tracking-wider uppercase text-ink-gray-5 hover:text-ink-gray-7"
+						:aria-label="`Copy proposal id ${proposal.name}`"
+						@click="copyId(proposal.name)"
+					>
+						#{{ proposal.name }}
+					</button>
+				</div>
+
+				<div class="flex flex-1 flex-col space-y-4 overflow-y-auto p-4">
+					<!-- The decision leads: it is what the reviewer opened the drawer to make. -->
+					<Select
+						v-model="status"
+						class="w-fit"
+						size="md"
+						aria-label="Review status"
+						side="bottom"
+						:options="statusOptions"
+						:disabled="proposalDoc.setValue.loading"
+					>
+						<!-- The trigger reuses this slot for the selected option, so the dot is
+						     defined once and shows in both places. -->
+						<template #item-prefix="{ item }">
+							<span
+								class="size-2 shrink-0 rounded-full transition-colors duration-150"
+								:class="getStatusDot(String(item.value))"
+								aria-hidden="true"
+							/>
+						</template>
+					</Select>
+
+					<DrawerTitle class="text-4xl font-semibold text-pretty text-ink-gray-9">
+						{{ proposal.title }}
+					</DrawerTitle>
+					<!-- Spoken, not drawn: the speakers and the date are both below, and reka
+					     wants the panel described. -->
+					<DrawerDescription class="sr-only">
+						{{ speakers.length }} speaker{{ speakers.length === 1 ? "" : "s" }}, submitted
+						{{ submittedOn }}
+					</DrawerDescription>
+
+					<!-- Who is proposing this leads: the panel decides on people as much as topics. -->
+					<div v-if="speakers.length" class="space-y-2">
+						<h3 class="text-base text-ink-gray-5">Speakers</h3>
+						<ul class="space-y-1">
+							<li
+								v-for="speaker in speakers"
+								:key="speaker.email"
+								class="flex min-w-0 items-center gap-2 rounded-4 px-1 py-1 transition-colors hover:bg-surface-gray-1"
+							>
+								<Avatar
+									size="md"
+									:label="speakerName(speaker)"
+									:theme="avatarTheme(speaker.email)"
+								/>
+								<span class="min-w-0 truncate text-base text-ink-gray-8">
+									{{ speakerName(speaker) }}
+								</span>
+								<span class="ml-auto min-w-0 truncate text-base text-ink-gray-5">
+									{{ speaker.email }}
+								</span>
+							</li>
+						</ul>
+					</div>
+
+					<div class="grid grid-cols-2 gap-x-5 gap-y-3">
+						<div v-for="field in fields" :key="field.label" class="space-y-0.5">
+							<p class="text-base text-ink-gray-5">{{ field.label }}</p>
+							<p class="text-base text-ink-gray-8">{{ field.value }}</p>
+						</div>
+					</div>
+
+					<div class="space-y-2">
+						<h3 class="text-base text-ink-gray-5">Description</h3>
+						<!-- Only the document carries the description, so it arrives a beat later. -->
+						<Skeleton v-if="proposalDoc.loading" class="h-16 w-full rounded-4" />
+						<!-- Description is a Text Editor field, so it arrives as sanitized HTML. -->
+						<div
+							v-else-if="proposalDoc.doc?.description"
+							class="description prose prose-sm max-w-none text-base leading-[1.6] text-ink-gray-7"
+							v-html="proposalDoc.doc.description"
+						/>
+						<p v-else class="text-base leading-[1.6] text-ink-gray-7">
+							No description was submitted.
+						</p>
+					</div>
+				</div>
+			</template>
+
+			<template v-if="proposal" #footer>
+				<!-- Arriving rather than appearing: the buttons showing up is the confirmation
+				     that the pick registered, so the footer is not allowed to jump. -->
+				<div v-if="changed" class="status-actions flex items-center gap-2">
+					<Button
+						variant="solid"
+						size="md"
+						label="Update"
+						:loading="proposalDoc.setValue.loading"
+						@click="updateStatus"
+					/>
+					<Button size="md" label="Cancel" @click="status = proposal.status" />
+				</div>
+				<p class="ml-auto flex items-center gap-1 text-xs text-ink-gray-5">
+					<span class="lucide-clock-fading size-3.5 shrink-0" aria-hidden="true" />
+					Last updated {{ lastUpdated }}
+				</p>
+			</template>
+		</DrawerContent>
+	</Drawer>
+</template>
+
+<style scoped>
+.status-actions,
+.description,
+.copy-id {
+	--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.status-actions {
+	transition:
+		opacity 160ms var(--ease-out),
+		transform 160ms var(--ease-out);
+}
+
+@starting-style {
+	.status-actions {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+}
+
+/* The description lands a beat after the row it belongs to, so it fades in rather than
+   replacing its own skeleton in one frame. */
+.description {
+	transition: opacity 200ms var(--ease-out);
+}
+
+@starting-style {
+	.description {
+		opacity: 0;
+	}
+}
+
+.copy-id {
+	transition:
+		color 160ms var(--ease-out),
+		transform 160ms var(--ease-out);
+}
+
+.copy-id:active {
+	transform: scale(0.97);
+}
+
+/* Gentler, not none: the fade still explains what happened, nothing travels. */
+@media (prefers-reduced-motion: reduce) {
+	.copy-id:active {
+		transform: none;
+	}
+
+	@starting-style {
+		.status-actions {
+			transform: none;
+		}
+	}
+}
+</style>

--- a/dashboard/src/components/dashboard/proposals/EventTalkProposalDrawer.vue
+++ b/dashboard/src/components/dashboard/proposals/EventTalkProposalDrawer.vue
@@ -15,11 +15,11 @@ import { useProposal } from "@/data/proposals"
 import type { ProposalListItem, ProposalSpeaker } from "@/types"
 import { speakerName } from "@/utils/speakerByline"
 
-const props = defineProps<{ proposal: ProposalListItem | null }>()
+const props = defineProps<{ proposal: ProposalListItem | null; canWrite?: boolean }>()
 
 const open = defineModel<boolean>("open", { required: true })
 
-const emit = defineEmits<{ changed: [] }>()
+const emit = defineEmits<{ changed: [status: string] }>()
 
 const { statuses, getStatusDot } = useProposalStatuses()
 
@@ -53,7 +53,8 @@ const statusOptions = computed(() =>
 )
 
 // Picking a status only arms the change: the footer's button is what writes it, so a
-// mis-click on a decision the speaker gets told about is still recoverable.
+// mis-click on a decision the speaker gets told about is still recoverable. A reader the
+// server would refuse never gets the control — read access alone is a Viewer or Frontdesk.
 const changed = computed(() => Boolean(status.value) && status.value !== props.proposal?.status)
 
 async function updateStatus() {
@@ -61,7 +62,7 @@ async function updateStatus() {
 	try {
 		await proposalDoc.setValue.submit({ status: status.value })
 		toast.success(`Marked ${status.value.toLowerCase()}`)
-		emit("changed")
+		emit("changed", status.value)
 	} catch {
 		status.value = props.proposal?.status || ""
 		toast.error("Could not change the status")
@@ -122,7 +123,7 @@ const fields = computed(() => [
 						aria-label="Review status"
 						side="bottom"
 						:options="statusOptions"
-						:disabled="proposalDoc.setValue.loading"
+						:disabled="!canWrite || proposalDoc.setValue.loading"
 					>
 						<!-- The trigger reuses this slot for the selected option, so the dot is
 						     defined once and shows in both places. -->
@@ -196,7 +197,7 @@ const fields = computed(() => [
 			<template v-if="proposal" #footer>
 				<!-- Arriving rather than appearing: the buttons showing up is the confirmation
 				     that the pick registered, so the footer is not allowed to jump. -->
-				<div v-if="changed" class="status-actions flex items-center gap-2">
+				<div v-if="canWrite && changed" class="status-actions flex items-center gap-2">
 					<Button
 						variant="solid"
 						size="md"

--- a/dashboard/src/components/dashboard/proposals/EventTalkProposalDrawer.vue
+++ b/dashboard/src/components/dashboard/proposals/EventTalkProposalDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Avatar, Button, Select, Skeleton, dayjsLocal, toast } from "frappe-ui"
+import { Avatar, Button, Dialog, Select, Skeleton, dayjsLocal, toast } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 
 import {
@@ -11,7 +11,7 @@ import {
 } from "@/components/common/drawer"
 import { useCopyToClipboard } from "@/composables/useCopyToClipboard"
 import { useProposalStatuses } from "@/composables/useProposalStatuses"
-import { useProposal } from "@/data/proposals"
+import { useAcceptProposal, useProposal } from "@/data/proposals"
 import type { ProposalListItem, ProposalSpeaker } from "@/types"
 import { speakerName } from "@/utils/speakerByline"
 
@@ -57,15 +57,42 @@ const statusOptions = computed(() =>
 // server would refuse never gets the control — read access alone is a Viewer or Frontdesk.
 const changed = computed(() => Boolean(status.value) && status.value !== props.proposal?.status)
 
-async function updateStatus() {
+// Accepting is the one status that is not a status write: it creates the talk the
+// programme is made of, and an account for any speaker who has none. Worth a confirmation.
+const ACCEPTED = "Accepted"
+
+const accept = useAcceptProposal()
+const confirmingAcceptance = ref(false)
+
+const saving = computed(() => proposalDoc.setValue.loading || accept.loading)
+
+function updateStatus() {
 	if (!changed.value) return
+	if (status.value === ACCEPTED) {
+		confirmingAcceptance.value = true
+		return
+	}
+	write(() => proposalDoc.setValue.submit({ status: status.value }))
+}
+
+async function acceptProposal() {
+	const name = props.proposal?.name
+	if (!name) return
+	if (await write(() => accept.submit({ proposal: name }))) confirmingAcceptance.value = false
+}
+
+async function write(save: () => Promise<unknown>): Promise<boolean> {
 	try {
-		await proposalDoc.setValue.submit({ status: status.value })
+		await save()
 		toast.success(`Marked ${status.value.toLowerCase()}`)
 		emit("changed", status.value)
+		return true
 	} catch {
+		// The select goes back to what is actually stored, so the footer stops offering
+		// an update that has already failed.
 		status.value = props.proposal?.status || ""
 		toast.error("Could not change the status")
+		return false
 	}
 }
 
@@ -123,7 +150,7 @@ const fields = computed(() => [
 						aria-label="Review status"
 						side="bottom"
 						:options="statusOptions"
-						:disabled="!canWrite || proposalDoc.setValue.loading"
+						:disabled="!canWrite || saving"
 					>
 						<!-- The trigger reuses this slot for the selected option, so the dot is
 						     defined once and shows in both places. -->
@@ -192,6 +219,24 @@ const fields = computed(() => [
 						</p>
 					</div>
 				</div>
+				<Dialog
+					v-model:open="confirmingAcceptance"
+					title="Accept this talk?"
+					message="This puts the talk on the event's programme. Any speaker without a Buzz account gets one."
+					size="md"
+				>
+					<template #actions>
+						<div class="flex justify-end gap-2">
+							<Button label="Not yet" @click="confirmingAcceptance = false" />
+							<Button
+								variant="solid"
+								label="Accept and create talk"
+								:loading="accept.loading"
+								@click="acceptProposal"
+							/>
+						</div>
+					</template>
+				</Dialog>
 			</template>
 
 			<template v-if="proposal" #footer>
@@ -202,7 +247,7 @@ const fields = computed(() => [
 						variant="solid"
 						size="md"
 						label="Update"
-						:loading="proposalDoc.setValue.loading"
+						:loading="saving"
 						@click="updateStatus"
 					/>
 					<Button size="md" label="Cancel" @click="status = proposal.status" />

--- a/dashboard/src/components/dashboard/proposals/ProposalCard.vue
+++ b/dashboard/src/components/dashboard/proposals/ProposalCard.vue
@@ -9,7 +9,10 @@ import { userResource } from "@/data/user"
 import type { ProposalWithEvent } from "@/types"
 import { speakerByline } from "@/utils/speakerByline"
 
-const props = defineProps<{ proposal: ProposalWithEvent }>()
+// The event line is noise on a page that is already scoped to one event.
+const props = withDefaults(defineProps<{ proposal: ProposalWithEvent; showEvent?: boolean }>(), {
+	showEvent: true,
+})
 
 const emit = defineEmits<{ open: [] }>()
 
@@ -79,7 +82,7 @@ const lastUpdatedExact = computed(() => modified.value.format("D MMM YYYY, h:mm 
 						</template>
 						<span class="ml-0.5">{{ proposal.status }}</span>
 					</Badge>
-					<p class="text-base text-ink-gray-7">
+					<p v-if="showEvent" class="text-base text-ink-gray-7">
 						For
 						<EventHoverCard
 							class="text-ink-gray-8"

--- a/dashboard/src/components/dashboard/proposals/ProposalDrawer.vue
+++ b/dashboard/src/components/dashboard/proposals/ProposalDrawer.vue
@@ -185,6 +185,9 @@ const fields = computed(() => [
 		<DrawerContent size="lg">
 			<template v-if="proposal">
 				<div class="flex items-center gap-2 p-4 pb-0">
+					<DrawerClose as-child>
+						<Button size="sm" icon="lucide-chevrons-right" aria-label="Close" />
+					</DrawerClose>
 					<button
 						type="button"
 						class="cursor-copy font-mono text-sm tracking-wider uppercase text-ink-gray-5"
@@ -193,9 +196,6 @@ const fields = computed(() => [
 					>
 						#{{ proposal.name }}
 					</button>
-					<DrawerClose as-child>
-						<Button class="ml-auto" variant="ghost" size="sm" icon="lucide-x" aria-label="Close" />
-					</DrawerClose>
 				</div>
 
 				<div class="flex flex-1 flex-col space-y-4 overflow-y-auto p-4">

--- a/dashboard/src/composables/useEventProposals.ts
+++ b/dashboard/src/composables/useEventProposals.ts
@@ -67,6 +67,22 @@ export function useEventProposals(
 		{ flush: "sync" },
 	)
 
+	/**
+	 * Carries a status change into the list without refetching.
+	 *
+	 * Refetching would not do it: past the first page `onSuccess` appends what it does
+	 * not already hold, so the changed row is discarded as a duplicate and the stale one
+	 * stays on screen. A row that no longer answers the active filter leaves the list.
+	 */
+	const applyStatus = (name: string, status: string) => {
+		const matchesFilter = !statuses.value.length || statuses.value.includes(status)
+		proposals.value = matchesFilter
+			? proposals.value.map((proposal) =>
+					proposal.name === name ? { ...proposal, status } : proposal,
+				)
+			: proposals.value.filter((proposal) => proposal.name !== name)
+	}
+
 	const loadMore = () => {
 		if (page.loading || !page.data?.has_next_page) return
 		start.value += PROPOSALS_PAGE_SIZE
@@ -74,6 +90,7 @@ export function useEventProposals(
 
 	return {
 		proposals,
+		applyStatus,
 		loadMore,
 		page,
 		// The first page is the only one that leaves the list empty while it loads.

--- a/dashboard/src/composables/useEventProposals.ts
+++ b/dashboard/src/composables/useEventProposals.ts
@@ -1,0 +1,83 @@
+import { refDebounced } from "@vueuse/core"
+import { useCall } from "frappe-ui"
+import { computed, type Ref, ref, watch } from "vue"
+
+import type { EventProposals, ProposalListItem } from "@/types"
+
+export const PROPOSALS_PAGE_SIZE = 20
+
+export type ProposalOrder = "desc" | "asc"
+
+/**
+ * One event's talk proposals, fetched a page at a time.
+ *
+ * Search, status filter and sort live on the server, so the browser only ever holds the
+ * pages it has walked down to. A page appends; a change of any control starts over.
+ *
+ * The controls are owned by the caller, so they can live in the query string and a
+ * filtered pipeline survives a reload.
+ */
+export function useEventProposals(
+	event: string,
+	search: Ref<string>,
+	order: Ref<ProposalOrder>,
+	statuses: Ref<string[]>,
+) {
+	// Typing rewrites the URL, and every rewrite is a request — wait for the pause.
+	const debouncedSearch = refDebounced(search, 300)
+	const start = ref(0)
+	const proposals = ref<ProposalListItem[]>([])
+
+	const page = useCall<EventProposals, Record<string, string | number>>({
+		url: "/api/v2/method/buzz.api.proposals.get_event_proposals",
+		params: () => ({
+			event,
+			search: debouncedSearch.value.trim(),
+			// Comma-joined, the shape the query string already holds them in.
+			statuses: statuses.value.join(","),
+			order: order.value,
+			start: start.value,
+			limit: PROPOSALS_PAGE_SIZE,
+		}),
+		// Off by default, so without this a new page or search would never be fetched.
+		refetch: true,
+		onSuccess: (data) => {
+			if (start.value === 0) {
+				proposals.value = data.proposals
+				return
+			}
+			// The offset is taken against a live list: a proposal submitted since the first
+			// page shifts every later one down, and the row on the boundary arrives twice.
+			const seen = new Set(proposals.value.map((proposal) => proposal.name))
+			proposals.value = [
+				...proposals.value,
+				...data.proposals.filter((proposal) => !seen.has(proposal.name)),
+			]
+		},
+	})
+
+	// Sync, so the offset is back at zero before useCall's own watcher rebuilds the URL —
+	// a pre-flush reset lets the stale offset go out as a request that is aborted a tick later.
+	watch(
+		[debouncedSearch, order, statuses],
+		() => {
+			start.value = 0
+			proposals.value = []
+		},
+		{ flush: "sync" },
+	)
+
+	const loadMore = () => {
+		if (page.loading || !page.data?.has_next_page) return
+		start.value += PROPOSALS_PAGE_SIZE
+	}
+
+	return {
+		proposals,
+		loadMore,
+		page,
+		// The first page is the only one that leaves the list empty while it loads.
+		loadingFirstPage: computed(() => page.loading && start.value === 0),
+		loadingMore: computed(() => page.loading && start.value > 0),
+	}
+}

--- a/dashboard/src/composables/useEventProposals.ts
+++ b/dashboard/src/composables/useEventProposals.ts
@@ -83,9 +83,12 @@ export function useEventProposals(
 			: proposals.value.filter((proposal) => proposal.name !== name)
 	}
 
+	// The offset is what the browser already holds, not the page number it is on. A row
+	// that a status change took out of the filter is gone from the server's results too,
+	// so every row behind it moved down one — counting pages would step over them.
 	const loadMore = () => {
 		if (page.loading || !page.data?.has_next_page) return
-		start.value += PROPOSALS_PAGE_SIZE
+		start.value = proposals.value.length
 	}
 
 	return {

--- a/dashboard/src/composables/useProposalStatuses.ts
+++ b/dashboard/src/composables/useProposalStatuses.ts
@@ -61,6 +61,17 @@ const statuses = createListResource({
 	auto: true,
 })
 
+// Tailwind emits only the classes it can see, so the dot colours are written out per
+// theme rather than interpolated. The `ink` scale is registered as a text colour, not a
+// background one, so the token is reached through its variable.
+const THEME_DOTS: Record<BadgeTheme, string> = {
+	blue: "bg-[--ink-blue-5]",
+	red: "bg-[--ink-red-5]",
+	green: "bg-[--ink-green-5]",
+	amber: "bg-[--ink-amber-5]",
+	gray: "bg-[--ink-gray-5]",
+}
+
 export function useProposalStatuses() {
 	const getStatusTheme = (status: string): BadgeTheme => {
 		const row = statuses.data?.find(
@@ -74,7 +85,9 @@ export function useProposalStatuses() {
 
 	const getStatusIcon = (status: string): string => STATUS_ICONS[status] ?? FALLBACK_ICON
 
+	const getStatusDot = (status: string): string => THEME_DOTS[getStatusTheme(status)]
+
 	const getStatusMessage = (status: string): string => STATUS_MESSAGES[status] ?? FALLBACK_MESSAGE
 
-	return { statuses, getStatusTheme, getStatusIcon, getStatusMessage }
+	return { statuses, getStatusTheme, getStatusIcon, getStatusDot, getStatusMessage }
 }

--- a/dashboard/src/data/proposals.ts
+++ b/dashboard/src/data/proposals.ts
@@ -1,6 +1,6 @@
 import { useCall, useDoc } from "frappe-ui"
 
-import type { ProposalListItem, ProposalTrend, TalkProposal } from "@/types"
+import type { AcceptedProposal, ProposalListItem, ProposalTrend, TalkProposal } from "@/types"
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
 // Uncached: cacheKey would persist this user's proposals to IndexedDB past a logout.
@@ -28,5 +28,20 @@ export function useProposalTrend(event: string) {
 	return useCall<ProposalTrend, { event: string }>({
 		url: "/api/v2/method/buzz.api.proposals.get_event_proposal_trend",
 		params: { event },
+	})
+}
+
+/**
+ * Accepting is not a status write.
+ *
+ * `create_talk` behind this endpoint builds the Event Talk the programme is made of, and
+ * an account for any speaker who has none. Setting the status alone would leave the
+ * proposal accepted with nothing on the programme, and no way back to make one.
+ */
+export function useAcceptProposal() {
+	return useCall<AcceptedProposal, { proposal: string }>({
+		url: "/api/v2/method/buzz.api.proposals.accept_proposal",
+		method: "POST",
+		immediate: false,
 	})
 }

--- a/dashboard/src/data/proposals.ts
+++ b/dashboard/src/data/proposals.ts
@@ -1,6 +1,6 @@
 import { useCall, useDoc } from "frappe-ui"
 
-import type { ProposalListItem, TalkProposal } from "@/types"
+import type { ProposalListItem, ProposalTrend, TalkProposal } from "@/types"
 
 // v2 path: useCall reads the payload from `data`, which /api/method names `message`.
 // Uncached: cacheKey would persist this user's proposals to IndexedDB past a logout.
@@ -21,4 +21,12 @@ export function useProposal(name: () => string | undefined) {
 	// useDoc holds its initial fetch until the name resolves, so the empty string is
 	// only ever the drawer before a card has been picked.
 	return useDoc<TalkProposal>({ doctype: "Talk Proposal", name: () => name() || "" })
+}
+
+// The card above an event's proposal list: how many have come in, and their split.
+export function useProposalTrend(event: string) {
+	return useCall<ProposalTrend, { event: string }>({
+		url: "/api/v2/method/buzz.api.proposals.get_event_proposal_trend",
+		params: { event },
+	})
 }

--- a/dashboard/src/pages/manage/events/EventTalks.vue
+++ b/dashboard/src/pages/manage/events/EventTalks.vue
@@ -1,0 +1,239 @@
+<script setup lang="ts">
+import { useIntersectionObserver } from "@vueuse/core"
+import { useRouteQuery } from "@vueuse/router"
+import { ErrorMessage, Skeleton } from "frappe-ui"
+import { DonutChart, NumberCard } from "frappe-ui/charts"
+import { computed, ref } from "vue"
+import { useRoute } from "vue-router"
+
+import { FilterBar, type FilterGroup, type FilterValues } from "@/components/common/filters"
+import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
+import EventTalkProposalDrawer from "@/components/dashboard/proposals/EventTalkProposalDrawer.vue"
+import ProposalCard from "@/components/dashboard/proposals/ProposalCard.vue"
+import { type ProposalOrder, useEventProposals } from "@/composables/useEventProposals"
+import { useProposalStatuses } from "@/composables/useProposalStatuses"
+import { useUrlFilters } from "@/composables/useUrlFilters"
+import { useProposalTrend } from "@/data/proposals"
+import type { FrappeError, ProposalWithEvent } from "@/types"
+
+const route = useRoute()
+const eventId = route.params.eventId as string
+
+// Both controls sit in the query string, so a searched or re-sorted pipeline survives a
+// reload and can be handed to a co-reviewer as a link.
+const filters = useUrlFilters(["order", "status"])
+const searchParam = useRouteQuery<string | null>("q", null)
+
+const search = computed<string>({
+	get: () => searchParam.value ?? "",
+	set: (term) => (searchParam.value = term.trim() ? term : null),
+})
+
+// Read-only: the filter bar owns the write, and routes it through `barFilters` so the
+// order and the status filter land in the query string as one assignment.
+const order = computed<ProposalOrder>(() => (filters.value.order?.[0] === "asc" ? "asc" : "desc"))
+
+const statuses = computed(() => filters.value.status || [])
+
+const { proposals, loadMore, page, loadingFirstPage, loadingMore } = useEventProposals(
+	eventId,
+	search,
+	order,
+	statuses,
+)
+
+const { statuses: statusList, getStatusTheme } = useProposalStatuses()
+
+const filterGroups = computed<FilterGroup[]>(() => [
+	{
+		key: "order",
+		label: "Sort by",
+		quick: true,
+		single: true,
+		options: [
+			{ value: "desc", label: "Newest first" },
+			{ value: "asc", label: "Oldest first" },
+		],
+	},
+	{
+		key: "status",
+		label: "Status",
+		options: (statusList.data || []).map((status: { name: string }) => ({
+			value: status.name,
+			label: status.name,
+		})),
+	},
+])
+
+const barFilters = computed<FilterValues>({
+	get: () => ({ order: [order.value], status: statuses.value }),
+	// One write rather than two: the query string is the store, and a second assignment
+	// would build on the value the first has not landed yet.
+	set: (next) => {
+		filters.value = {
+			order: next.order?.[0] === "asc" ? ["asc"] : [],
+			status: next.status || [],
+		}
+	},
+})
+
+const trend = useProposalTrend(eventId)
+
+const message = (error: unknown) => (error as FrappeError | null)?.messages?.join("\n")
+
+// echarts paints into a canvas, where a `var(--token)` never resolves, so the violet is
+// the palette's own 600 written out.
+const PROPOSAL_VIOLET = "oklch(0.54 0.245 292.717)"
+
+const perDay = computed(() => (trend.data?.per_day || []).map((day) => day.count))
+
+// A status nobody has used is left off the ring.
+const byStatus = computed(() =>
+	(trend.data?.by_status || []).filter((row) => row.count).map((row) => ({ ...row })),
+)
+
+const showStatuses = computed(() => byStatus.value.length > 1)
+
+const sinceYesterday = computed(() => {
+	const days = perDay.value
+	return days.length < 2 ? null : days[days.length - 1] - days[days.length - 2]
+})
+
+// The proposal is what is held, not its position. A card can be opened while a search is
+// still settling, and by the time the new page lands an index points at a different talk.
+const selectedId = ref<string | null>(null)
+
+const selected = computed(
+	() => proposals.value.find((proposal) => proposal.name === selectedId.value) ?? null,
+)
+
+const drawerOpen = computed<boolean>({
+	get: () => selected.value !== null,
+	set: (open) => !open && (selectedId.value = null),
+})
+
+// The next page is fetched when the foot of the list comes into view, a screen early so
+// the cards are already there by the time the scroll reaches them.
+const sentinel = ref<HTMLElement | null>(null)
+useIntersectionObserver(sentinel, ([entry]) => entry?.isIntersecting && loadMore(), {
+	rootMargin: "400px",
+})
+</script>
+
+<template>
+	<EventPageHeader :title="page.data?.title" section="Talks" />
+
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
+		<section class="space-y-2">
+			<h1 class="text-xl font-semibold text-ink-gray-9">How it's going</h1>
+
+			<!-- One row of readings. The donut only earns its half when more than one status
+				 is in play; with a single one the card takes the whole row. -->
+			<div class="grid gap-4 sm:grid-cols-2">
+				<NumberCard
+					:class="showStatuses ? '' : 'sm:col-span-2'"
+					title="Proposals"
+					:value="trend.data?.total ?? null"
+					:loading="trend.loading"
+					:delta="sinceYesterday"
+					delta-caption="vs yesterday"
+					:sparkline="{ data: perDay, type: 'line', color: PROPOSAL_VIOLET }"
+				/>
+
+				<div v-if="showStatuses && !trend.error" class="h-64 w-full">
+					<DonutChart
+						title="Review status"
+						:data="byStatus"
+						category="status"
+						value="count"
+						center-label="proposals"
+						:loading="trend.loading"
+					/>
+				</div>
+			</div>
+
+			<ErrorMessage :message="message(trend.error)" />
+		</section>
+
+		<section class="space-y-3">
+			<h2 class="text-xl font-semibold text-ink-gray-9">Talks</h2>
+
+			<FilterBar
+				v-model="barFilters"
+				v-model:search="search"
+				searchable
+				search-placeholder="Search by title or speaker"
+				:groups="filterGroups"
+			/>
+
+			<!-- Announced rather than only drawn: typing changes the list silently otherwise. -->
+			<p v-if="search.trim() || statuses.length" aria-live="polite" class="text-sm text-ink-gray-5">
+				{{ page.data?.matched ?? 0 }} of {{ page.data?.total ?? 0 }} proposals
+			</p>
+
+			<Transition
+				mode="out-in"
+				enter-active-class="transition-opacity duration-150 ease-out motion-reduce:transition-none"
+				enter-from-class="opacity-0"
+				leave-active-class="transition-opacity duration-100 ease-out motion-reduce:transition-none"
+				leave-to-class="opacity-0"
+			>
+				<!-- Cards shaped like the real ones, so the list settles into place instead of
+					 shoving the page down when it arrives. -->
+				<div v-if="loadingFirstPage" class="space-y-3">
+					<Skeleton v-for="row in 4" :key="row" class="h-[7.5rem] w-full rounded-8" />
+				</div>
+
+				<div v-else-if="page.error">
+					<ErrorMessage :message="message(page.error)" />
+				</div>
+
+				<div v-else>
+					<div v-if="proposals.length" class="space-y-3">
+						<ProposalCard
+							v-for="proposal in proposals"
+							:key="proposal.name"
+							:proposal="proposal as ProposalWithEvent"
+							:show-event="false"
+							@open="selectedId = proposal.name"
+						/>
+						<Skeleton v-if="loadingMore" class="h-[7.5rem] w-full rounded-8" />
+					</div>
+
+					<p v-else-if="search" class="text-base text-ink-gray-5">
+						No talk here matches “{{ search }}”.
+					</p>
+					<p v-else-if="statuses.length" class="text-base text-ink-gray-5">
+						No talk sits at one of these statuses.
+					</p>
+					<p v-else class="text-base text-ink-gray-5">No talks have been proposed yet.</p>
+
+					<div ref="sentinel" aria-hidden="true" />
+
+					<!-- The list has a floor, so the scroll ends on a statement rather than on
+						 cards that might still be coming. -->
+					<div
+						v-if="proposals.length && !page.data?.has_next_page && !loadingMore"
+						class="relative mt-6 flex justify-center"
+					>
+						<span
+							class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-surface-gray-2"
+							aria-hidden="true"
+						/>
+						<p
+							class="relative bg-surface-elevation-1 px-4 py-1 text-xs italic text-ink-gray-4 font-serif"
+						>
+							End of list
+						</p>
+					</div>
+				</div>
+			</Transition>
+		</section>
+	</div>
+
+	<EventTalkProposalDrawer
+		v-model:open="drawerOpen"
+		:proposal="selected"
+		@changed="page.reload()"
+	/>
+</template>

--- a/dashboard/src/pages/manage/events/EventTalks.vue
+++ b/dashboard/src/pages/manage/events/EventTalks.vue
@@ -140,7 +140,7 @@ useIntersectionObserver(sentinel, ([entry]) => entry?.isIntersecting && loadMore
 					:sparkline="{ data: perDay, type: 'line', color: PROPOSAL_VIOLET }"
 				/>
 
-				<div v-if="showStatuses && !trend.error" class="h-64 w-full">
+				<div v-if="showStatuses && !trend.error" class="status-donut h-64 w-full">
 					<DonutChart
 						title="Review status"
 						:data="byStatus"
@@ -237,3 +237,12 @@ useIntersectionObserver(sentinel, ([entry]) => entry?.isIntersecting && loadMore
 		@changed="page.reload()"
 	/>
 </template>
+
+<style scoped>
+/* DonutChart renders its legend whenever there is more than one slice, with no prop to
+   turn it off. Seven statuses make a wrapping row taller than the ring it explains; the
+   tooltip still names every slice. */
+.status-donut :deep([data-slot="chart-legend"]) {
+	display: none;
+}
+</style>

--- a/dashboard/src/pages/manage/events/EventTalks.vue
+++ b/dashboard/src/pages/manage/events/EventTalks.vue
@@ -35,7 +35,7 @@ const order = computed<ProposalOrder>(() => (filters.value.order?.[0] === "asc" 
 
 const statuses = computed(() => filters.value.status || [])
 
-const { proposals, loadMore, page, loadingFirstPage, loadingMore } = useEventProposals(
+const { proposals, applyStatus, loadMore, page, loadingFirstPage, loadingMore } = useEventProposals(
 	eventId,
 	search,
 	order,
@@ -111,6 +111,13 @@ const drawerOpen = computed<boolean>({
 	get: () => selected.value !== null,
 	set: (open) => !open && (selectedId.value = null),
 })
+
+// The row is patched rather than refetched — see applyStatus. The card above counts the
+// whole pipeline, so it is the one thing that does have to go back to the server.
+const onStatusChanged = (status: string) => {
+	if (selectedId.value) applyStatus(selectedId.value, status)
+	trend.reload()
+}
 
 // The next page is fetched when the foot of the list comes into view, a screen early so
 // the cards are already there by the time the scroll reaches them.
@@ -234,7 +241,8 @@ useIntersectionObserver(sentinel, ([entry]) => entry?.isIntersecting && loadMore
 	<EventTalkProposalDrawer
 		v-model:open="drawerOpen"
 		:proposal="selected"
-		@changed="page.reload()"
+		:can-write="page.data?.can_write"
+		@changed="onStatusChanged"
 	/>
 </template>
 

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -51,6 +51,11 @@ const routes: RouteRecordRaw[] = [
 				component: () => import("@/pages/manage/events/EventGuests.vue"),
 			},
 			{
+				path: "events/:eventId/talks",
+				name: "event-talks",
+				component: () => import("@/pages/manage/events/EventTalks.vue"),
+			},
+			{
 				path: "events/:eventId/:section",
 				component: () => import("@/pages/manage/WorkInProgress.vue"),
 			},

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -41,6 +41,32 @@ export interface ProposalListItem {
 	speakers: ProposalSpeaker[]
 }
 
+// buzz.api.proposals.get_event_proposals: one page of an event's own pipeline.
+export interface EventProposals {
+	title: string | null
+	total: number
+	matched: number
+	proposals: ProposalListItem[]
+	has_next_page: boolean
+}
+
+// buzz.api.proposals.get_event_proposal_trend
+export interface DailySubmissions {
+	date: string
+	count: number
+}
+
+export interface StatusTotal {
+	status: string
+	count: number
+}
+
+export interface ProposalTrend {
+	total: number
+	per_day: DailySubmissions[]
+	by_status: StatusTotal[]
+}
+
 // A proposal whose event row still resolves — the only kind the timeline can place.
 export type ProposalWithEvent = ProposalListItem & { event_title: string; start_date: string }
 

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -48,6 +48,8 @@ export interface EventProposals {
 	matched: number
 	proposals: ProposalListItem[]
 	has_next_page: boolean
+	// Read access alone is a Viewer or Frontdesk, who cannot change a status.
+	can_write: boolean
 }
 
 // buzz.api.proposals.get_event_proposal_trend

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -52,6 +52,13 @@ export interface EventProposals {
 	can_write: boolean
 }
 
+// buzz.api.proposals.accept_proposal
+export interface AcceptedProposal {
+	proposal: string
+	status: string
+	talk: string
+}
+
 // buzz.api.proposals.get_event_proposal_trend
 export interface DailySubmissions {
 	date: string

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -78,7 +78,10 @@ test.describe("Event workspace", () => {
 		await page.getByRole("link", { name: "Talks" }).click()
 
 		await expect(page).toHaveURL(/\/b\/manage\/events\/\d+\/talks$/)
-		await expect(page.getByText("Work in progress")).toBeVisible()
+		// Heading rather than text: the sidebar link is named Talks too.
+		await expect(page.getByRole("heading", { name: "Talks", level: 2 })).toBeVisible({
+			timeout: 15000,
+		})
 	})
 
 	test("leaves the workspace through the back button", async ({ page }) => {
@@ -250,13 +253,14 @@ test.describe("Guest list", () => {
 		expect(registrations).toBe(GUESTS.length)
 		await expect(page.getByText(/Registrations (are open|have closed)/)).toBeVisible()
 
-		// Sorted by name, so Ada is first, and she is the one holding the add-on. Both the
-		// ticket type and the add-on are autonamed, so a docname here would read as a bare
-		// number.
-		await expect(rows.first()).toContainText(GUESTS[0].email)
-		await expect(rows.first()).toContainText(TICKET_TYPE)
-		await expect(rows.first()).toContainText(ADD_ON)
-		await expect(rows.last()).not.toContainText(ADD_ON)
+		// Newest registration first, which is the reverse of the seeding above — so each
+		// row is found by its guest rather than by a position the sort order decides. Both
+		// the ticket type and the add-on are autonamed, so a docname here would read as a
+		// bare number.
+		const withAddOn = rows.filter({ hasText: GUESTS[0].email })
+		await expect(withAddOn).toContainText(TICKET_TYPE)
+		await expect(withAddOn).toContainText(ADD_ON)
+		await expect(rows.filter({ hasText: GUESTS[1].email })).not.toContainText(ADD_ON)
 	})
 
 	test("narrows the guest list by search", async ({ page }) => {
@@ -265,7 +269,7 @@ test.describe("Guest list", () => {
 		const rows = page.getByRole("list").getByRole("listitem")
 		await expect(rows).toHaveCount(GUESTS.length, { timeout: 15000 })
 
-		const search = page.getByRole("textbox", { name: "Search guests" })
+		const search = page.getByRole("textbox", { name: "Search by name or email" })
 		await search.fill(GUESTS[1].email)
 		await expect(rows).toHaveCount(1)
 		await expect(rows.first()).toContainText(GUESTS[1].email)


### PR DESCRIPTION
## What changed

The Talks item in the event sidebar landed on `WorkInProgress`. It now opens the
reviewer's counterpart to the guest list: a card reading how submissions have run, over a
searchable, filtered, paged list of proposal cards.

Two endpoints back it — `get_event_proposals` for one page of an event's pipeline, and
`get_event_proposal_trend` for submissions per day and the status split. `ProposalCard` is
reused as it is, minus the event line the page no longer needs.

Opening a card gives `EventTalkProposalDrawer`. Picking a status only arms the change; the
footer's Update button writes it. Accepting goes through `create_talk`, so the Event Talk
and its speaker accounts are created rather than the proposal being left accepted with
nothing on the programme.

`ensure_guest_list_access` is renamed `ensure_event_team_access` — the guard was never
about guests, and both manage pages now ask it the same question. One commit standardises
the close control across the four drawers; it is split out so it can be reverted alone.

Known gap: two reviewers accepting the same proposal at once can still create two talks —
https://github.com/bwhtech/buzz/issues/410.

## Demo

<!-- TODO: screenshots of the Talks page and the drawer -->
https://cap.so/s/svt6138y6qd3d00
## Testing

32 tests in `buzz.api.proposals.test_proposals` plus the 24 `talk_proposal` doctype tests,
all green. Covers access by team role, the status filter, search over title and speaker
email, paging, ordering, the trend window, and accepting twice.

Frontend checked with `vue-tsc` and pre-commit only — no browser pass, since Playwright has
no Chrome on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTCeWHp41WA2NsCQD2XGUU
