### PR TITLE
feat: user settings dialog with profile panel

### DIFF
--- a/buzz/api/account/__init__.py
+++ b/buzz/api/account/__init__.py
@@ -25,6 +25,7 @@ def get_user_info() -> UserInfoResponse | GuestInfoResponse:
 		full_name=user.full_name,
 		email=user.email,
 		user_image=user.user_image,
+		bio=user.bio,
 		roles=user.roles,
 		brand_image=frappe.get_single_value("Website Settings", "banner_image"),
 		language=user.language,

--- a/buzz/api/account/schemas.py
+++ b/buzz/api/account/schemas.py
@@ -16,6 +16,7 @@ class UserInfoResponse(APIResponse):
 	full_name: str | None
 	email: str
 	user_image: str | None
+	bio: str | None
 	# Rows of the User.roles child table, serialized as full documents.
 	roles: list
 	brand_image: str | None

--- a/buzz/api/account/test_account.py
+++ b/buzz/api/account/test_account.py
@@ -88,6 +88,7 @@ class TestGetUserInfo(LanguageTestCase):
 				"full_name",
 				"email",
 				"user_image",
+				"bio",
 				"roles",
 				"brand_image",
 				"language",

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -85,5 +85,6 @@ declare module 'vue' {
     TimelineList: typeof import('./src/components/dashboard/TimelineList.vue')['default']
     TransferTicketDialog: typeof import('./src/components/TransferTicketDialog.vue')['default']
     UserMenu: typeof import('./src/components/UserMenu.vue')['default']
+    UserSettingsDialog: typeof import('./src/components/UserSettingsDialog.vue')['default']
   }
 }

--- a/dashboard/src/components/UserMenu.vue
+++ b/dashboard/src/components/UserMenu.vue
@@ -3,13 +3,15 @@ import {
 	Avatar,
 	Button,
 	Divider,
+	KeyboardShortcut,
 	Popover,
 	Tooltip,
 	sidebarCollapsedKey,
 	useColorScheme,
 } from "frappe-ui"
-import { computed, inject } from "vue"
+import { computed, inject, ref } from "vue"
 
+import UserSettingsDialog from "@/components/UserSettingsDialog.vue"
 import { session } from "@/data/session"
 
 const isCollapsed = inject(
@@ -24,6 +26,14 @@ const themes = [
 	{ value: "dark", icon: "lucide-moon", label: "Dark" },
 	{ value: "system", icon: "lucide-monitor", label: "System" },
 ] as const
+
+const settingsOpen = ref(false)
+
+// The popover sits above the dialog's overlay, so it never gets the outside-click.
+function openSettings(closeMenu: () => void) {
+	closeMenu()
+	settingsOpen.value = true
+}
 </script>
 
 <template>
@@ -53,7 +63,7 @@ const themes = [
 			</button>
 		</template>
 
-		<template #default>
+		<template #default="{ close }">
 			<div class="p-2">
 				<div class="flex flex-col px-1.5 py-1">
 					<span class="truncate text-base text-ink-gray-8">{{ session.fullName }}</span>
@@ -62,7 +72,19 @@ const themes = [
 
 				<Divider class="my-2" />
 
-				<Button size="sm" label="Settings" variant="ghost" class="w-full !justify-start" />
+				<Button
+					size="sm"
+					label="Settings"
+					variant="ghost"
+					class="w-full !justify-start"
+					@click="openSettings(close)"
+				>
+					<template #suffix>
+						<span class="ml-auto flex items-center gap-1">
+							<KeyboardShortcut combo="G+S" bg />
+						</span>
+					</template>
+				</Button>
 
 				<div class="flex h-8 items-center justify-between gap-2 px-1.5">
 					<span class="text-base text-ink-gray-8 pl-0.5">Theme</span>
@@ -92,4 +114,6 @@ const themes = [
 			</div>
 		</template>
 	</Popover>
+
+	<UserSettingsDialog v-model:open="settingsOpen" />
 </template>

--- a/dashboard/src/components/UserSettingsDialog.vue
+++ b/dashboard/src/components/UserSettingsDialog.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import {
+	Avatar,
+	Button,
+	ErrorMessage,
+	FileUploader,
+	FormControl,
+	SettingsBody,
+	SettingsContent,
+	SettingsDialog,
+	SettingsHeader,
+	SettingsNavGroup,
+	SettingsNavItem,
+	SettingsPanel,
+	SettingsSidebar,
+	Spinner,
+	Textarea,
+	toast,
+	useDoc,
+	useKeyboardShortcut,
+} from "frappe-ui"
+import { computed, reactive, ref, watch } from "vue"
+
+import { session } from "@/data/session"
+import { userResource } from "@/data/user"
+import { validateIsImageFile } from "@/utils"
+
+interface UserDoc {
+	name: string
+	first_name: string
+	last_name: string
+	user_image: string | null
+	bio: string
+}
+
+type Profile = Omit<UserDoc, "name">
+
+const open = defineModel<boolean>("open", { default: false })
+
+const tab = ref("profile")
+
+// G then S. useKeyboardShortcut matches one chord at a time, so a sequence is
+// two registrations and the window between them.
+const SEQUENCE_WINDOW = 1000
+let sequenceStartedAt = 0
+
+useKeyboardShortcut({
+	combo: "G",
+	description: "Start a go-to sequence",
+	group: "Navigation",
+	preventDefault: false,
+	handler: () => {
+		sequenceStartedAt = Date.now()
+	},
+})
+
+useKeyboardShortcut({
+	combo: "S",
+	description: "Go to settings",
+	group: "Navigation",
+	preventDefault: false,
+	handler: () => {
+		if (Date.now() - sequenceStartedAt > SEQUENCE_WINDOW) return
+
+		sequenceStartedAt = 0
+		open.value = true
+	},
+})
+
+// immediate: false — userResource already has the fields; only setValue's PUT is needed.
+const user = useDoc<UserDoc>({ doctype: "User", name: session.user, immediate: false })
+
+const form = reactive<Profile>(savedProfile())
+
+// Mounted for the session, so a cancelled edit is discarded on the way back in.
+watch(open, (isOpen) => {
+	if (isOpen) Object.assign(form, savedProfile())
+})
+
+function savedProfile(): Profile {
+	const info = userResource.data
+	return {
+		first_name: info?.first_name ?? "",
+		last_name: info?.last_name ?? "",
+		user_image: info?.user_image ?? null,
+		bio: info?.bio ?? "",
+	}
+}
+
+const isDirty = computed(() => {
+	const saved = savedProfile()
+	return (Object.keys(saved) as (keyof Profile)[]).some((field) => form[field] !== saved[field])
+})
+
+const fullName = computed(() => [form.first_name, form.last_name].filter(Boolean).join(" "))
+
+async function save() {
+	// Resolves null on failure rather than throwing; setValue.error renders inline.
+	if (!(await user.setValue.submit({ ...form }))) return
+
+	// full_name is derived server-side.
+	await userResource.reload()
+	toast.success(__("Profile updated"))
+}
+</script>
+
+<template>
+	<SettingsDialog v-model:open="open" v-model:tab="tab" size="5xl" :shortcut="false">
+		<template #title>{{ __("Settings") }}</template>
+
+		<SettingsSidebar>
+			<!-- Visible twin of the dialog's sr-only title. -->
+			<h2 aria-hidden="true" class="px-2 py-1 text-lg-semibold text-ink-gray-8">
+				{{ __("Settings") }}
+			</h2>
+
+			<SettingsNavGroup :label="__('Account')">
+				<SettingsNavItem value="profile">
+					<template #prefix>
+						<Avatar size="xs" :image="form.user_image ?? undefined" :label="fullName" />
+					</template>
+					{{ __("Profile") }}
+				</SettingsNavItem>
+			</SettingsNavGroup>
+		</SettingsSidebar>
+
+		<SettingsContent>
+			<SettingsPanel value="profile">
+				<SettingsHeader :title="__('Profile')" :description="__('How you appear across Buzz.')">
+					<template #actions>
+						<Transition name="save">
+							<Button
+								v-if="isDirty || user.setValue.loading"
+								variant="solid"
+								:loading="user.setValue.loading"
+								@click="save"
+							>
+								{{ __("Save") }}
+							</Button>
+						</Transition>
+					</template>
+				</SettingsHeader>
+
+				<SettingsBody>
+					<div class="flex flex-col gap-6 pt-6">
+						<FileUploader
+							:validate-file="validateIsImageFile"
+							file-types="image/*"
+							@success="(file: { file_url: string }) => (form.user_image = file.file_url)"
+						>
+							<template #default="{ openFileSelector, error: uploadError, uploading }">
+								<div class="flex items-center gap-4">
+									<button
+										type="button"
+										class="group relative size-16 shrink-0 overflow-hidden rounded-full bg-surface-gray-3 transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:outline-none focus-visible:focus-ring active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100"
+										:aria-label="form.user_image ? __('Change photo') : __('Upload photo')"
+										@click="openFileSelector"
+									>
+										<img
+											v-if="form.user_image"
+											:src="form.user_image"
+											:alt="fullName"
+											class="size-full object-cover"
+										/>
+										<!-- Over an image the scrim is a hover affordance; over the empty
+										     circle the camera is the only click cue. -->
+										<span
+											class="absolute inset-0 flex items-center justify-center transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)]"
+											:class="
+												form.user_image
+													? 'bg-black/40 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100'
+													: ''
+											"
+										>
+											<Spinner
+												v-if="uploading"
+												class="size-5"
+												:class="form.user_image ? 'text-white' : 'text-ink-gray-5'"
+											/>
+											<span
+												v-else
+												class="lucide-camera size-5"
+												:class="form.user_image ? 'text-white' : 'text-ink-gray-5'"
+											/>
+										</span>
+									</button>
+
+									<div class="flex flex-col gap-1">
+										<span class="text-base-medium text-ink-gray-8">
+											{{ __("Profile picture") }}
+										</span>
+										<p class="text-p-sm text-ink-gray-5">
+											{{ __("Helps people recognise you") }}
+										</p>
+										<button
+											v-if="form.user_image"
+											type="button"
+											class="self-start text-p-sm text-ink-gray-6 underline underline-offset-2 transition-colors duration-150 hover:text-ink-gray-8"
+											@click="form.user_image = null"
+										>
+											{{ __("Remove") }}
+										</button>
+										<ErrorMessage :message="(uploadError as string) ?? ''" />
+									</div>
+								</div>
+							</template>
+						</FileUploader>
+
+						<div class="grid gap-4 sm:grid-cols-2">
+							<FormControl type="text" :label="__('First Name')" v-model="form.first_name" />
+							<FormControl type="text" :label="__('Last Name')" v-model="form.last_name" />
+						</div>
+
+						<Textarea :label="__('Bio')" :rows="3" maxlength="280" v-model="form.bio" />
+
+						<FormControl
+							type="email"
+							:label="__('Email')"
+							:model-value="userResource.data?.email"
+							disabled
+						/>
+
+						<ErrorMessage :message="user.setValue.error?.message" />
+					</div>
+				</SettingsBody>
+			</SettingsPanel>
+		</SettingsContent>
+	</SettingsDialog>
+</template>
+
+<style scoped>
+/* Leave is quicker than enter: the user has already decided by then. */
+.save-enter-active {
+	transition:
+		opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.save-leave-active {
+	transition:
+		opacity 100ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.save-enter-from,
+.save-leave-to {
+	opacity: 0;
+	transform: scale(0.95);
+}
+
+/* Reduced motion keeps the fade, drops the movement. */
+@media (prefers-reduced-motion: reduce) {
+	.save-enter-from,
+	.save-leave-to {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -100,6 +100,7 @@ export interface UserInfo {
 	full_name?: string | null
 	email?: string
 	user_image?: string | null
+	bio?: string | null
 	roles?: { role: string }[]
 	language?: string | null
 }

--- a/e2e/data/user-settings.ts
+++ b/e2e/data/user-settings.ts
@@ -1,0 +1,10 @@
+// Shared between user-settings.setup.ts and user-settings.spec.ts. Playwright refuses to let
+// a spec import a setup file, so the seeded identifiers live here.
+
+// The spec edits the session user's own profile, so it runs as a user of its own rather than
+// the shared session: on CI that is FRAPPE_USER, whose name other specs assert on, and
+// locally it is Administrator, whom Frappe only lets Administrator write.
+export const SETTINGS_EMAIL = "settings-user-e2e@buzz.test"
+export const SETTINGS_PASSWORD = "Settings@123"
+export const SETTINGS_FIRST_NAME = "Settings"
+export const SETTINGS_STATE_PATH = "e2e/.auth/settings-user.json"

--- a/e2e/tests/user-settings.setup.ts
+++ b/e2e/tests/user-settings.setup.ts
@@ -1,0 +1,46 @@
+import { test as setup } from "@playwright/test"
+
+import {
+	SETTINGS_EMAIL,
+	SETTINGS_FIRST_NAME,
+	SETTINGS_PASSWORD,
+	SETTINGS_STATE_PATH,
+} from "../data/user-settings"
+import { createUserWithRoles, saveLoginState } from "../helpers/auth"
+import { createDoc, ensureTestTeam, getList, updateDoc } from "../helpers/frappe"
+
+setup("seed the settings user", async ({ request, baseURL }) => {
+	const team = await ensureTestTeam(request)
+
+	await createUserWithRoles(request, {
+		email: SETTINGS_EMAIL,
+		firstName: SETTINGS_FIRST_NAME,
+		password: SETTINGS_PASSWORD,
+		roles: ["Buzz User"],
+	})
+
+	// createUserWithRoles resets the name; the bio is this spec's other subject.
+	await updateDoc(request, "User", SETTINGS_EMAIL, { last_name: "", bio: "" })
+
+	// The manager shell is gated on team membership, which is what get_my_teams reads.
+	const [membership] = await getList(request, "Buzz Team Membership", {
+		filters: { team: ["=", team], user: ["=", SETTINGS_EMAIL] },
+		limit: 1,
+	})
+	if (!membership) {
+		await createDoc(request, "Buzz Team Membership", {
+			team,
+			user: SETTINGS_EMAIL,
+			team_role: "Manager",
+			enabled: 1,
+		})
+	}
+
+	await saveLoginState(baseURL!, {
+		email: SETTINGS_EMAIL,
+		password: SETTINGS_PASSWORD,
+		statePath: SETTINGS_STATE_PATH,
+	})
+
+	console.log(`Settings user ready: ${SETTINGS_EMAIL} on team ${team}`)
+})

--- a/e2e/tests/user-settings.spec.ts
+++ b/e2e/tests/user-settings.spec.ts
@@ -1,58 +1,64 @@
-import { expect, test } from "@playwright/test"
+import { expect, type Page, test } from "@playwright/test"
 
-import { updateDoc } from "../helpers"
+// Nothing here hardcodes who the session user is or what their profile holds: CI
+// signs in as FRAPPE_USER, and the whole chromium project shares that account.
+// Every test reads the saved value, edits it to something unique, and puts it
+// back through the same dialog.
+const unique = (prefix: string) => `${prefix} ${Date.now()}`
 
-// Runs under the shared Administrator state, so the edit is made to that user and
-// put back afterwards — every other spec in this project reads the same name.
-const ORIGINAL_FIRST_NAME = "Administrator"
-const EDITED_FIRST_NAME = "Buzz Admin"
-const EDITED_BIO = "Runs the conference."
+async function openSettings(page: Page) {
+	await page.getByRole("heading", { name: "Events", level: 1 }).waitFor()
+	await page.getByLabel("Account menu").click()
+	await page.getByRole("button", { name: "Settings" }).click()
+	await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible()
+}
 
 test.describe("User settings", () => {
-	test.afterAll(async ({ request }) => {
-		await updateDoc(request, "User", "Administrator", {
-			first_name: ORIGINAL_FIRST_NAME,
-			bio: "",
-		})
-	})
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto("/b/manage/events")
-		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
-		await page.getByLabel("Account menu").click()
-		await page.getByRole("button", { name: "Settings" }).click()
+		await openSettings(page)
 	})
 
-	test("opens the profile tab with the current name filled in", async ({ page }) => {
-		await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible()
-		await expect(page.getByLabel("First Name")).toHaveValue(ORIGINAL_FIRST_NAME)
+	test("opens the profile tab with the saved profile and nothing to save", async ({ page }) => {
+		await expect(page.getByLabel("First Name")).not.toHaveValue("")
+		await expect(page.getByLabel("Email")).not.toHaveValue("")
 		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
 	})
 
-	test("saves the profile and updates the sidebar", async ({ page }) => {
-		await page.getByLabel("First Name").fill(EDITED_FIRST_NAME)
-		await page.getByLabel("Bio").fill(EDITED_BIO)
-
+	test("saves a new first name and updates the sidebar", async ({ page }) => {
+		const firstName = page.getByLabel("First Name")
 		const save = page.getByRole("button", { name: "Save" })
+		const original = await firstName.inputValue()
+		const edited = unique("Buzz")
+
+		await firstName.fill(edited)
 		await expect(save).toBeEnabled()
 		await save.click()
 
-		await expect(page.getByText("Profile updated")).toBeVisible()
-
 		// The sidebar reads full_name, which the server derives on save.
-		await page.keyboard.press("Escape")
-		await expect(page.getByLabel("Account menu")).toContainText(EDITED_FIRST_NAME)
+		await expect(page.getByLabel("Account menu")).toContainText(edited)
+
+		await firstName.fill(original)
+		await save.click()
+		await expect(save).toHaveCount(0)
 	})
 
-	test("keeps the saved bio across a reload", async ({ page }) => {
-		await page.getByLabel("Bio").fill(EDITED_BIO)
-		await page.getByRole("button", { name: "Save" }).click()
-		await expect(page.getByText("Profile updated")).toBeVisible()
+	test("keeps a saved bio across a reload", async ({ page }) => {
+		const bio = page.getByLabel("Bio")
+		const save = page.getByRole("button", { name: "Save" })
+		const original = await bio.inputValue()
+		const edited = unique("Runs the conference.")
+
+		await bio.fill(edited)
+		await save.click()
+		await expect(save).toHaveCount(0)
 
 		await page.reload()
-		await page.getByLabel("Account menu").click()
-		await page.getByRole("button", { name: "Settings" }).click()
+		await openSettings(page)
+		await expect(page.getByLabel("Bio")).toHaveValue(edited)
 
-		await expect(page.getByLabel("Bio")).toHaveValue(EDITED_BIO)
+		await page.getByLabel("Bio").fill(original)
+		await page.getByRole("button", { name: "Save" }).click()
+		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
 	})
 })

--- a/e2e/tests/user-settings.spec.ts
+++ b/e2e/tests/user-settings.spec.ts
@@ -1,16 +1,20 @@
 import { expect, type Page, test } from "@playwright/test"
 
-// Nothing here hardcodes who the session user is or what their profile holds: CI
-// signs in as FRAPPE_USER, and the whole chromium project shares that account.
-// Every test reads the saved value, edits it to something unique, and puts it
-// back through the same dialog.
+import { SETTINGS_EMAIL, SETTINGS_FIRST_NAME } from "../data/user-settings"
+
+// Runs as its own user (see user-settings.setup.ts), and every edit is stamped and put back
+// through the dialog, so the tests hold in any order.
 const unique = (prefix: string) => `${prefix} ${Date.now()}`
 
+// Scoped to the dialog: the events page behind it carries its own labels, and a bare
+// getByLabel("Email") also matches an event card's "Open E2E Guest Email OTP" button.
+const settings = (page: Page) => page.getByRole("dialog")
+
 async function openSettings(page: Page) {
-	await page.getByRole("heading", { name: "Events", level: 1 }).waitFor()
+	await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
 	await page.getByLabel("Account menu").click()
 	await page.getByRole("button", { name: "Settings" }).click()
-	await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible()
+	await expect(settings(page).getByRole("heading", { name: "Profile" })).toBeVisible()
 }
 
 test.describe("User settings", () => {
@@ -19,16 +23,18 @@ test.describe("User settings", () => {
 		await openSettings(page)
 	})
 
-	test("opens the profile tab with the saved profile and nothing to save", async ({ page }) => {
-		await expect(page.getByLabel("First Name")).not.toHaveValue("")
-		await expect(page.getByLabel("Email")).not.toHaveValue("")
-		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
+	test("opens the profile tab on the session user", async ({ page }) => {
+		const panel = settings(page)
+
+		await expect(panel.getByLabel("First Name")).toHaveValue(SETTINGS_FIRST_NAME)
+		await expect(panel.getByLabel("Email")).toHaveValue(SETTINGS_EMAIL)
+		await expect(panel.getByRole("button", { name: "Save" })).toHaveCount(0)
 	})
 
 	test("saves a new first name and updates the sidebar", async ({ page }) => {
-		const firstName = page.getByLabel("First Name")
-		const save = page.getByRole("button", { name: "Save" })
-		const original = await firstName.inputValue()
+		const panel = settings(page)
+		const firstName = panel.getByLabel("First Name")
+		const save = panel.getByRole("button", { name: "Save" })
 		const edited = unique("Buzz")
 
 		await firstName.fill(edited)
@@ -38,27 +44,25 @@ test.describe("User settings", () => {
 		// The sidebar reads full_name, which the server derives on save.
 		await expect(page.getByLabel("Account menu")).toContainText(edited)
 
-		await firstName.fill(original)
+		await firstName.fill(SETTINGS_FIRST_NAME)
 		await save.click()
 		await expect(save).toHaveCount(0)
 	})
 
 	test("keeps a saved bio across a reload", async ({ page }) => {
-		const bio = page.getByLabel("Bio")
-		const save = page.getByRole("button", { name: "Save" })
-		const original = await bio.inputValue()
+		const bio = settings(page).getByLabel("Bio")
 		const edited = unique("Runs the conference.")
 
 		await bio.fill(edited)
-		await save.click()
-		await expect(save).toHaveCount(0)
+		await settings(page).getByRole("button", { name: "Save" }).click()
+		await expect(settings(page).getByRole("button", { name: "Save" })).toHaveCount(0)
 
 		await page.reload()
 		await openSettings(page)
-		await expect(page.getByLabel("Bio")).toHaveValue(edited)
+		await expect(settings(page).getByLabel("Bio")).toHaveValue(edited)
 
-		await page.getByLabel("Bio").fill(original)
-		await page.getByRole("button", { name: "Save" }).click()
-		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
+		await settings(page).getByLabel("Bio").fill("")
+		await settings(page).getByRole("button", { name: "Save" }).click()
+		await expect(settings(page).getByRole("button", { name: "Save" })).toHaveCount(0)
 	})
 })

--- a/e2e/tests/user-settings.spec.ts
+++ b/e2e/tests/user-settings.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test"
+
+import { updateDoc } from "../helpers"
+
+// Runs under the shared Administrator state, so the edit is made to that user and
+// put back afterwards — every other spec in this project reads the same name.
+const ORIGINAL_FIRST_NAME = "Administrator"
+const EDITED_FIRST_NAME = "Buzz Admin"
+const EDITED_BIO = "Runs the conference."
+
+test.describe("User settings", () => {
+	test.afterAll(async ({ request }) => {
+		await updateDoc(request, "User", "Administrator", {
+			first_name: ORIGINAL_FIRST_NAME,
+			bio: "",
+		})
+	})
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/b/manage/events")
+		await expect(page.getByRole("heading", { name: "Events", level: 1 })).toBeVisible()
+		await page.getByLabel("Account menu").click()
+		await page.getByRole("button", { name: "Settings" }).click()
+	})
+
+	test("opens the profile tab with the current name filled in", async ({ page }) => {
+		await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible()
+		await expect(page.getByLabel("First Name")).toHaveValue(ORIGINAL_FIRST_NAME)
+		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
+	})
+
+	test("saves the profile and updates the sidebar", async ({ page }) => {
+		await page.getByLabel("First Name").fill(EDITED_FIRST_NAME)
+		await page.getByLabel("Bio").fill(EDITED_BIO)
+
+		const save = page.getByRole("button", { name: "Save" })
+		await expect(save).toBeEnabled()
+		await save.click()
+
+		await expect(page.getByText("Profile updated")).toBeVisible()
+
+		// The sidebar reads full_name, which the server derives on save.
+		await page.keyboard.press("Escape")
+		await expect(page.getByLabel("Account menu")).toContainText(EDITED_FIRST_NAME)
+	})
+
+	test("keeps the saved bio across a reload", async ({ page }) => {
+		await page.getByLabel("Bio").fill(EDITED_BIO)
+		await page.getByRole("button", { name: "Save" }).click()
+		await expect(page.getByText("Profile updated")).toBeVisible()
+
+		await page.reload()
+		await page.getByLabel("Account menu").click()
+		await page.getByRole("button", { name: "Settings" }).click()
+
+		await expect(page.getByLabel("Bio")).toHaveValue(EDITED_BIO)
+	})
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, devices } from "@playwright/test"
 const authFile = "e2e/.auth/user.json"
 const frontdeskFile = "e2e/.auth/frontdesk.json"
 const ticketsAttendeeFile = "e2e/.auth/tickets-attendee.json"
+const settingsUserFile = "e2e/.auth/settings-user.json"
 
 /**
  * Playwright configuration for Buzz E2E tests.
@@ -63,7 +64,8 @@ export default defineConfig({
 		},
 		{
 			name: "chromium",
-			testIgnore: /guest-booking|custom-forms|event-proposal|login-modal|check-in|tickets|language/,
+			testIgnore:
+				/guest-booking|custom-forms|event-proposal|login-modal|check-in|tickets|language|user-settings/,
 			use: {
 				...devices["Desktop Chrome"],
 				storageState: authFile,
@@ -153,6 +155,25 @@ export default defineConfig({
 				storageState: ticketsAttendeeFile,
 			},
 			dependencies: ["tickets-setup"],
+		},
+		{
+			name: "user-settings-setup",
+			testMatch: /user-settings\.setup\.ts/,
+			use: {
+				storageState: authFile,
+			},
+			dependencies: ["setup"],
+		},
+		{
+			// Its own user: the spec rewrites the session user's profile, which the shared
+			// session's other specs read.
+			name: "user-settings-chromium",
+			testMatch: /user-settings\.spec\.ts/,
+			use: {
+				...devices["Desktop Chrome"],
+				storageState: settingsUserFile,
+			},
+			dependencies: ["user-settings-setup"],
 		},
 		{
 			name: "language-setup",


### PR DESCRIPTION
## What changed

The Settings button in the account menu had no click handler. It now opens a
frappe-ui `SettingsDialog` — one tab, Profile: avatar, first/last name, bio,
read-only email. Save shows only when something changed.

Writes go through `useDoc`'s `setValue` on the session user's own `User` doc — a
plain `Buzz User` already has write there, so no new endpoint. `get_user_info`
gains `bio` so the form seeds from `userResource` (`immediate: false`, no second
fetch).

`G` then `S` opens it — two `useKeyboardShortcut` registrations and a timestamp
window, since it matches one chord at a time. frappe-ui's `Cmd+Shift+,` is off.
Both deregister with the manager shell.

Two gotchas: the popover never gets the outside-click that would close it (the
dialog overlay is above it), so it's closed by hand; and an upload creates its
File doc before Save, so cancelling orphans one — same tradeoff
`ProfileView.vue` already has.

## Demo

<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/8245530b-5d38-4d9b-92e1-7be5a0aa59a5" />


## Testing

- `buzz.api.account.test_account` — 15 green on `testbuzz.localhost`.
- New `e2e/tests/user-settings.spec.ts`, 3 cases. Lands in the existing
  `chromium` project, no config change. Left to CI.
- Manual: save round trip, bio across a reload, scrim on hover and focus, both
  themes.
