### PR TITLE
feat: team management in the settings dialog

### DIFF
--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -39,3 +39,8 @@ def remove_member(team: str, user: str) -> None:
 @frappe.whitelist(methods=["POST"])
 def invite_members(team: str, invites: list[dict]) -> list[InviteOutcome]:
 	return invitations.invite_members(team, invites)
+
+
+@frappe.whitelist(methods=["POST"])
+def update_team(team: str, team_name: str, logo: str | None = None) -> None:
+	services.update_team(team, team_name, logo)

--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -6,7 +6,7 @@ from buzz.api.teams.schemas import InviteOutcome, TeamOption, TeamOverview
 
 @frappe.whitelist()
 def get_my_teams() -> list[TeamOption]:
-	"""Teams the session user belongs to, for the dashboard team switcher.
+	"""Teams the session user belongs to, for the settings dialog.
 
 	Reads past permissions on purpose: Buzz Team is readable by Event Manager only, while a
 	Frontdesk or Viewer member still has to see the team they work in. Rows are filtered to
@@ -23,7 +23,7 @@ def get_my_teams() -> list[TeamOption]:
 		.where((membership.user == frappe.session.user) & (membership.enabled == 1))
 	).run(as_dict=True)
 
-	return [TeamOption(**my_team) for my_team in my_teams]
+	return [TeamOption(**my_team, members=services.members_of(my_team.name)) for my_team in my_teams]
 
 
 @frappe.whitelist()

--- a/buzz/api/teams/exceptions.py
+++ b/buzz/api/teams/exceptions.py
@@ -12,6 +12,10 @@ class CannotManageMembers(NotPermitted):
 	message = _lt("You cannot manage members of this team.")
 
 
+class CannotEditTeam(NotPermitted):
+	message = _lt("You cannot edit this team.")
+
+
 class CannotGrantOwnership(NotPermitted):
 	title = _lt("Not Permitted")
 	message = _lt("Ownership of a team cannot be granted.")

--- a/buzz/api/teams/schemas.py
+++ b/buzz/api/teams/schemas.py
@@ -1,18 +1,20 @@
 from buzz.api.schemas import APIResponse
 
 
-class TeamOption(APIResponse):
-	name: str
-	team_name: str
-	logo: str | None
-	team_role: str
-
-
 class TeamMember(APIResponse):
 	user: str
 	full_name: str | None
 	user_image: str | None
 	team_role: str
+
+
+class TeamOption(APIResponse):
+	name: str
+	team_name: str
+	logo: str | None
+	team_role: str
+	# The settings list shows who is on each team, not only how many.
+	members: list[TeamMember]
 
 
 class InviteOutcome(APIResponse):

--- a/buzz/api/teams/services.py
+++ b/buzz/api/teams/services.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.query_builder import Case
 
-from buzz.api.teams.exceptions import CannotManageMembers, NotATeamMember
+from buzz.api.teams.exceptions import CannotEditTeam, CannotManageMembers, NotATeamMember
 from buzz.api.teams.schemas import TeamInvite, TeamMember, TeamOverview
 from buzz.permissions import can_manage_members, team_role_of
 
@@ -86,3 +86,23 @@ def remove_member(team: str, user: str) -> None:
 	# Event Manager holds no write permission on the membership doctype, so the guard above
 	# is the authorization — the same shape as the Desk add-members flow.
 	membership.save(ignore_permissions=True)
+
+
+def update_team(team: str, team_name: str, logo: str | None) -> None:
+	"""Rename a team or change its logo.
+
+	Owner/Admin, the rule `team_doc_has_permission` applies to a write. Desk write on Buzz
+	Team is System Manager only, so the guard here is the authorization and the save skips
+	the doctype check — the same shape as `remove_member`.
+	"""
+	if not can_manage_members(team):
+		CannotEditTeam.throw()
+
+	team_name = team_name.strip()
+	if not team_name:
+		frappe.throw(frappe._("Team name is required"))
+
+	doc = frappe.get_doc("Buzz Team", team)
+	doc.team_name = team_name
+	doc.logo = logo or None
+	doc.save(ignore_permissions=True)

--- a/buzz/api/teams/test_teams.py
+++ b/buzz/api/teams/test_teams.py
@@ -1,8 +1,8 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from buzz.api.teams import get_my_teams, get_team_overview, remove_member
-from buzz.api.teams.exceptions import CannotManageMembers, NotATeamMember
+from buzz.api.teams import get_my_teams, get_team_overview, remove_member, update_team
+from buzz.api.teams.exceptions import CannotEditTeam, CannotManageMembers, NotATeamMember
 from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 
@@ -223,3 +223,41 @@ class TestRemoveMember(IntegrationTestCase):
 
 		remove_member(second, member)
 		self.assertNotIn("Event Manager", frappe.get_roles(member))
+
+
+class TestUpdateTeam(IntegrationTestCase):
+	# Rollback is per class, not per test — every test owns its users and its team names.
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def test_an_admin_renames_the_team_and_sets_its_logo(self):
+		owner = create_user("update-owner@example.com", "Owner")
+		admin = create_user("update-admin@example.com", "Admin")
+		team = create_owned_team("Update Before", owner)
+		upsert_membership(team, admin, "Admin")
+
+		frappe.set_user(admin)
+		update_team(team, "  Update After  ", "/files/logo.png")
+
+		details = frappe.db.get_value("Buzz Team", team, ["team_name", "logo"], as_dict=True)
+		self.assertEqual(details.team_name, "Update After")
+		self.assertEqual(details.logo, "/files/logo.png")
+
+	def test_a_manager_cannot_edit_the_team(self):
+		owner = create_user("update-owner2@example.com", "Owner")
+		manager = create_user("update-manager@example.com", "Manager")
+		team = create_owned_team("Update Locked", owner)
+		upsert_membership(team, manager, "Manager")
+
+		frappe.set_user(manager)
+		with self.assertRaises(CannotEditTeam):
+			update_team(team, "Renamed", None)
+
+	def test_a_blank_name_is_refused(self):
+		owner = create_user("update-owner3@example.com", "Owner")
+		team = create_owned_team("Update Blank", owner)
+
+		frappe.set_user(owner)
+		with self.assertRaises(frappe.ValidationError):
+			update_team(team, "   ", None)

--- a/buzz/api/teams/test_teams.py
+++ b/buzz/api/teams/test_teams.py
@@ -54,6 +54,17 @@ class TestGetMyTeams(IntegrationTestCase):
 
 		self.assertEqual(self.team_names_for(user), [])
 
+	def test_lists_each_teams_enabled_members(self):
+		owner = create_user("switcher-members-owner@example.com", "Owner")
+		viewer = create_user("switcher-members-viewer@example.com", "Viewer")
+		team = create_owned_team("Switcher Members", owner)
+		upsert_membership(team, viewer, "Viewer")
+
+		frappe.set_user(viewer)
+		members = get_my_teams()[0].members
+
+		self.assertEqual([member.user for member in members], [owner, viewer])
+
 	def test_returns_nothing_for_a_user_on_no_team(self):
 		user = create_user("switcher-teamless@example.com", "Teamless")
 

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -16,6 +16,7 @@ declare module 'vue' {
     AddSpeakerDialog: typeof import('./src/components/dashboard/proposals/AddSpeakerDialog.vue')['default']
     AddVenueDialog: typeof import('./src/components/dashboard/events/AddVenueDialog.vue')['default']
     AttendeeFormControl: typeof import('./src/components/AttendeeFormControl.vue')['default']
+    AvatarUploader: typeof import('./src/components/common/AvatarUploader.vue')['default']
     BackButton: typeof import('./src/components/common/BackButton.vue')['default']
     BaseCustomEventForm: typeof import('./src/components/BaseCustomEventForm.vue')['default']
     BillingDetails: typeof import('./src/components/BillingDetails.vue')['default']

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -11,6 +11,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AddMembersDialog: typeof import('./src/components/dashboard/teams/AddMembersDialog.vue')['default']
     AddOnPreferenceDialog: typeof import('./src/components/AddOnPreferenceDialog.vue')['default']
     AddSpeakerDialog: typeof import('./src/components/dashboard/proposals/AddSpeakerDialog.vue')['default']
     AddVenueDialog: typeof import('./src/components/dashboard/events/AddVenueDialog.vue')['default']
@@ -59,6 +60,7 @@ declare module 'vue' {
     LoginDialog: typeof import('./src/components/LoginDialog.vue')['default']
     LoginRequired: typeof import('./src/components/LoginRequired.vue')['default']
     ManagerSidebarHeader: typeof import('./src/components/dashboard/ManagerSidebarHeader.vue')['default']
+    ManageTeamPanel: typeof import('./src/components/dashboard/teams/ManageTeamPanel.vue')['default']
     Navbar: typeof import('./src/components/Navbar.vue')['default']
     OfflinePaymentDialog: typeof import('./src/components/OfflinePaymentDialog.vue')['default']
     PaymentGatewayDialog: typeof import('./src/components/PaymentGatewayDialog.vue')['default']
@@ -77,6 +79,8 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     SponsorshipPaymentDialog: typeof import('./src/components/SponsorshipPaymentDialog.vue')['default']
     SuccessMessage: typeof import('./src/components/SuccessMessage.vue')['default']
+    TeamMembersTable: typeof import('./src/components/dashboard/teams/TeamMembersTable.vue')['default']
+    TeamsPanel: typeof import('./src/components/dashboard/teams/TeamsPanel.vue')['default']
     TicketBookingDetails: typeof import('./src/components/dashboard/tickets/TicketBookingDetails.vue')['default']
     TicketCard: typeof import('./src/components/TicketCard.vue')['default']
     TicketDetailsModal: typeof import('./src/components/TicketDetailsModal.vue')['default']
@@ -84,6 +88,7 @@ declare module 'vue' {
     TicketTransferDialog: typeof import('./src/components/TicketTransferDialog.vue')['default']
     TimelineList: typeof import('./src/components/dashboard/TimelineList.vue')['default']
     TransferTicketDialog: typeof import('./src/components/TransferTicketDialog.vue')['default']
+    UserGroup: typeof import('./src/components/common/UserGroup.vue')['default']
     UserMenu: typeof import('./src/components/UserMenu.vue')['default']
     UserSettingsDialog: typeof import('./src/components/UserSettingsDialog.vue')['default']
   }

--- a/dashboard/src/components/UserSettingsDialog.vue
+++ b/dashboard/src/components/UserSettingsDialog.vue
@@ -21,7 +21,9 @@ import {
 } from "frappe-ui"
 import { computed, reactive, ref, watch } from "vue"
 
+import TeamsPanel from "@/components/dashboard/teams/TeamsPanel.vue"
 import { session } from "@/data/session"
+import { reloadTeams } from "@/data/teams"
 import { userResource } from "@/data/user"
 import { validateIsImageFile } from "@/utils"
 
@@ -74,7 +76,10 @@ const form = reactive<Profile>(savedProfile())
 
 // Mounted for the session, so a cancelled edit is discarded on the way back in.
 watch(open, (isOpen) => {
-	if (isOpen) Object.assign(form, savedProfile())
+	if (!isOpen) return
+	Object.assign(form, savedProfile())
+	// Memberships change under the cached list, so the teams tab reads a fresh one.
+	reloadTeams()
 })
 
 function savedProfile(): Profile {
@@ -105,7 +110,7 @@ async function save() {
 </script>
 
 <template>
-	<SettingsDialog v-model:open="open" v-model:tab="tab" size="5xl" :shortcut="false">
+	<SettingsDialog v-model:open="open" v-model:tab="tab" size="6xl" :shortcut="false">
 		<template #title>{{ __("Settings") }}</template>
 
 		<SettingsSidebar>
@@ -120,6 +125,15 @@ async function save() {
 						<Avatar size="xs" :image="form.user_image ?? undefined" :label="fullName" />
 					</template>
 					{{ __("Profile") }}
+				</SettingsNavItem>
+			</SettingsNavGroup>
+
+			<SettingsNavGroup :label="__('Team Management')">
+				<SettingsNavItem value="teams">
+					<template #prefix>
+						<span class="lucide-users size-4" />
+					</template>
+					{{ __("Teams") }}
 				</SettingsNavItem>
 			</SettingsNavGroup>
 		</SettingsSidebar>
@@ -223,6 +237,10 @@ async function save() {
 						<ErrorMessage :message="user.setValue.error?.message" />
 					</div>
 				</SettingsBody>
+			</SettingsPanel>
+
+			<SettingsPanel value="teams">
+				<TeamsPanel />
 			</SettingsPanel>
 		</SettingsContent>
 	</SettingsDialog>

--- a/dashboard/src/components/UserSettingsDialog.vue
+++ b/dashboard/src/components/UserSettingsDialog.vue
@@ -3,7 +3,6 @@ import {
 	Avatar,
 	Button,
 	ErrorMessage,
-	FileUploader,
 	FormControl,
 	SettingsBody,
 	SettingsContent,
@@ -13,7 +12,6 @@ import {
 	SettingsNavItem,
 	SettingsPanel,
 	SettingsSidebar,
-	Spinner,
 	Textarea,
 	toast,
 	useDoc,
@@ -21,11 +19,11 @@ import {
 } from "frappe-ui"
 import { computed, reactive, ref, watch } from "vue"
 
+import AvatarUploader from "@/components/common/AvatarUploader.vue"
 import TeamsPanel from "@/components/dashboard/teams/TeamsPanel.vue"
 import { session } from "@/data/session"
 import { reloadTeams } from "@/data/teams"
 import { userResource } from "@/data/user"
-import { validateIsImageFile } from "@/utils"
 
 interface UserDoc {
 	name: string
@@ -157,68 +155,12 @@ async function save() {
 
 				<SettingsBody>
 					<div class="flex flex-col gap-6 pt-6">
-						<FileUploader
-							:validate-file="validateIsImageFile"
-							file-types="image/*"
-							@success="(file: { file_url: string }) => (form.user_image = file.file_url)"
-						>
-							<template #default="{ openFileSelector, error: uploadError, uploading }">
-								<div class="flex items-center gap-4">
-									<button
-										type="button"
-										class="group relative size-16 shrink-0 overflow-hidden rounded-full bg-surface-gray-3 transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:outline-none focus-visible:focus-ring active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100"
-										:aria-label="form.user_image ? __('Change photo') : __('Upload photo')"
-										@click="openFileSelector"
-									>
-										<img
-											v-if="form.user_image"
-											:src="form.user_image"
-											:alt="fullName"
-											class="size-full object-cover"
-										/>
-										<!-- Over an image the scrim is a hover affordance; over the empty
-										     circle the camera is the only click cue. -->
-										<span
-											class="absolute inset-0 flex items-center justify-center transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)]"
-											:class="
-												form.user_image
-													? 'bg-black/40 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100'
-													: ''
-											"
-										>
-											<Spinner
-												v-if="uploading"
-												class="size-5"
-												:class="form.user_image ? 'text-white' : 'text-ink-gray-5'"
-											/>
-											<span
-												v-else
-												class="lucide-camera size-5"
-												:class="form.user_image ? 'text-white' : 'text-ink-gray-5'"
-											/>
-										</span>
-									</button>
-
-									<div class="flex flex-col gap-1">
-										<span class="text-base-medium text-ink-gray-8">
-											{{ __("Profile picture") }}
-										</span>
-										<p class="text-p-sm text-ink-gray-5">
-											{{ __("Helps people recognise you") }}
-										</p>
-										<button
-											v-if="form.user_image"
-											type="button"
-											class="self-start text-p-sm text-ink-gray-6 underline underline-offset-2 transition-colors duration-150 hover:text-ink-gray-8"
-											@click="form.user_image = null"
-										>
-											{{ __("Remove") }}
-										</button>
-										<ErrorMessage :message="(uploadError as string) ?? ''" />
-									</div>
-								</div>
-							</template>
-						</FileUploader>
+						<AvatarUploader
+							v-model="form.user_image"
+							:label="fullName"
+							:title="__('Profile picture')"
+							:description="__('Helps people recognise you')"
+						/>
 
 						<div class="grid gap-4 sm:grid-cols-2">
 							<FormControl type="text" :label="__('First Name')" v-model="form.first_name" />

--- a/dashboard/src/components/common/AvatarUploader.vue
+++ b/dashboard/src/components/common/AvatarUploader.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ErrorMessage, FileUploader, Spinner } from "frappe-ui"
+
+import { validateIsImageFile } from "@/utils"
+
+withDefaults(
+	defineProps<{
+		label: string
+		title: string
+		description?: string
+		shape?: "circle" | "square"
+	}>(),
+	{ description: "", shape: "circle" },
+)
+
+const image = defineModel<string | null>({ required: true })
+</script>
+
+<template>
+	<FileUploader
+		:validate-file="validateIsImageFile"
+		file-types="image/*"
+		@success="(file: { file_url: string }) => (image = file.file_url)"
+	>
+		<template #default="{ openFileSelector, error: uploadError, uploading }">
+			<div class="flex items-center gap-4">
+				<button
+					type="button"
+					class="group relative size-16 shrink-0 overflow-hidden bg-surface-gray-3 transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:outline-none focus-visible:focus-ring active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100"
+					:class="shape === 'circle' ? 'rounded-full' : 'rounded-6'"
+					:aria-label="image ? __('Change photo') : __('Upload photo')"
+					@click="openFileSelector"
+				>
+					<img v-if="image" :src="image" :alt="label" class="size-full object-cover" />
+					<!-- Over an image the scrim is a hover affordance; over the empty
+					     shape the camera is the only click cue. -->
+					<span
+						class="absolute inset-0 flex items-center justify-center transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)]"
+						:class="
+							image
+								? 'bg-black/40 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100'
+								: ''
+						"
+					>
+						<Spinner
+							v-if="uploading"
+							class="size-5"
+							:class="image ? 'text-white' : 'text-ink-gray-5'"
+						/>
+						<span
+							v-else
+							class="lucide-camera size-5"
+							:class="image ? 'text-white' : 'text-ink-gray-5'"
+						/>
+					</span>
+				</button>
+
+				<div class="flex flex-col gap-1">
+					<span class="text-base-medium text-ink-gray-8">{{ title }}</span>
+					<p v-if="description" class="text-p-sm text-ink-gray-5">{{ description }}</p>
+					<button
+						v-if="image"
+						type="button"
+						class="self-start text-p-sm text-ink-gray-6 underline underline-offset-2 transition-colors duration-150 hover:text-ink-gray-8"
+						@click="image = null"
+					>
+						{{ __("Remove") }}
+					</button>
+					<ErrorMessage :message="(uploadError as string) ?? ''" />
+				</div>
+			</div>
+		</template>
+	</FileUploader>
+</template>

--- a/dashboard/src/components/common/UserGroup.vue
+++ b/dashboard/src/components/common/UserGroup.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { Avatar } from "frappe-ui"
+import { computed } from "vue"
+
+interface GroupUser {
+	full_name?: string | null
+	user?: string
+	user_image?: string | null
+}
+
+const props = withDefaults(defineProps<{ users: GroupUser[]; max?: number }>(), { max: 3 })
+
+// A cached row from before members shipped still carries no list.
+const all = computed(() => props.users ?? [])
+
+const shown = computed(() => all.value.slice(0, props.max))
+
+const count = computed(() => all.value.length)
+
+const label = computed(() =>
+	count.value === 1 ? __("1 member") : __("{0} members", [String(count.value)]),
+)
+</script>
+
+<template>
+	<div class="flex items-center gap-2">
+		<!-- Overlap needs a margin; the row's gap alone would spread the stack apart. -->
+		<div v-if="shown.length" class="flex shrink-0 -space-x-1.5" aria-hidden="true">
+			<Avatar
+				v-for="user in shown"
+				:key="user.user ?? user.full_name ?? ''"
+				size="sm"
+				:image="user.user_image ?? undefined"
+				:label="user.full_name ?? user.user ?? ''"
+				class="ring-2 ring-surface-white"
+			/>
+		</div>
+		<span class="truncate text-base text-ink-gray-6">{{ label }}</span>
+	</div>
+</template>

--- a/dashboard/src/components/dashboard/teams/AddMembersDialog.vue
+++ b/dashboard/src/components/dashboard/teams/AddMembersDialog.vue
@@ -1,0 +1,272 @@
+<script setup lang="ts">
+import { Button, Dialog, ErrorMessage, FormControl, toast } from "frappe-ui"
+import { computed, nextTick, ref, watch } from "vue"
+
+import { inviteMembers } from "@/data/teams"
+import type { FrappeError, InviteOutcome } from "@/types"
+
+// Mirrors the membership doctype's own options, minus Owner. The server rejects
+// anything outside this set, so a drift here fails loudly rather than silently.
+const ROLE_OPTIONS = ["Admin", "Manager", "Frontdesk", "Viewer"]
+const DEFAULT_ROLE = "Manager"
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+interface InviteRow {
+	id: number
+	email: string
+	team_role: string
+}
+
+const props = defineProps<{ team: string }>()
+const isOpen = defineModel<boolean>({ required: true })
+const emit = defineEmits<{ success: [] }>()
+
+// Rows are spliced, so they need an identity of their own — a key by position would
+// hand Vue the wrong node the moment a row in the middle goes.
+let lastRowId = 0
+
+const rows = ref<InviteRow[]>([newRow()])
+const showErrors = ref(false)
+const form = ref<HTMLFormElement>()
+
+// createResource types its error as {}, so the message needs narrowing.
+const errorMessage = computed(() => (inviteMembers.error as FrappeError | null)?.message)
+
+const filled = computed(() => rows.value.filter((row) => row.email.trim()))
+
+const invalid = computed(() => filled.value.filter((row) => !EMAIL_PATTERN.test(row.email.trim())))
+
+function newRow(email = "", team_role = DEFAULT_ROLE): InviteRow {
+	lastRowId += 1
+	return { id: lastRowId, email, team_role }
+}
+
+function isInvalid(row: InviteRow) {
+	return showErrors.value && invalid.value.includes(row)
+}
+
+watch(isOpen, async (open) => {
+	if (!open) return
+	rows.value = [newRow()]
+	showErrors.value = false
+	inviteMembers.reset()
+	await nextTick()
+	form.value?.querySelector("input")?.focus()
+})
+
+// One watcher rather than an input handler: it only ever sees values the model has
+// already committed, so a paste cannot be read a keystroke late.
+watch(
+	rows,
+	(current) => {
+		splitPastedEmails(current)
+
+		// Typing in the last row opens the next one, so a second invite needs no click.
+		const last = current[current.length - 1]
+		if (last?.email.trim()) current.push(newRow("", last.team_role))
+	},
+	{ deep: true },
+)
+
+// A pasted list is the fastest way to invite a whole team, so commas become rows.
+function splitPastedEmails(current: InviteRow[]) {
+	const index = current.findIndex((row) => row.email.includes(","))
+	if (index < 0) return
+
+	const row = current[index]
+	const emails = row.email
+		.split(",")
+		.map((email) => email.trim())
+		.filter(Boolean)
+
+	row.email = emails[0] ?? ""
+	current.splice(index + 1, 0, ...emails.slice(1).map((email) => newRow(email, row.team_role)))
+}
+
+// The trailing blank row is not a member, so there is nothing to take off the list.
+function canRemove(index: number) {
+	return rows.value.length > 1 && index < rows.value.length - 1
+}
+
+function removeRow(index: number) {
+	rows.value.splice(index, 1)
+	if (!rows.value.length) rows.value.push(newRow())
+}
+
+function labelFor(outcome: InviteOutcome) {
+	return outcome.full_name || outcome.email
+}
+
+// Two names read better than a count; past that a count reads better than a queue.
+function nameList(outcomes: InviteOutcome[]) {
+	const [first, second] = outcomes.map(labelFor)
+	if (outcomes.length === 1) return first
+	if (outcomes.length === 2) return `${first} and ${second}`
+	return `${first} and ${outcomes.length - 1} others`
+}
+
+// An invited stranger does not appear in the table behind this dialog until they
+// accept, so the toast has to say so — otherwise they look like they went missing.
+function report(outcomes: InviteOutcome[]) {
+	const added = outcomes.filter((outcome) => outcome.status === "added")
+	const invited = outcomes.filter((outcome) => outcome.status === "invited")
+	const pending = "They'll show up here once they accept."
+
+	if (!added.length && !invited.length) {
+		toast.info("Everyone on that list is already on the team")
+		return
+	}
+
+	if (!invited.length) {
+		toast.success(`${nameList(added)} joined the team`)
+		return
+	}
+
+	if (!added.length) {
+		const title =
+			invited.length === 1
+				? `Invitation sent to ${nameList(invited)}`
+				: `${invited.length} invitations sent`
+		toast.success(title, { description: pending })
+		return
+	}
+
+	// Not "they" here — half of them are already in the table behind this toast.
+	toast.success(`${added.length} joined, ${invited.length} invited`, {
+		description: "The invitations show up here once they're accepted.",
+	})
+}
+
+// One bad address should cost the user that row, not the whole batch.
+async function submit() {
+	showErrors.value = true
+	if (!filled.value.length || invalid.value.length) return
+
+	const outcomes = await inviteMembers.submit({
+		team: props.team,
+		invites: filled.value.map((row) => ({
+			email: row.email.trim(),
+			team_role: row.team_role,
+		})),
+	})
+
+	report(outcomes ?? [])
+	emit("success")
+	isOpen.value = false
+}
+</script>
+
+<template>
+	<Dialog v-model="isOpen" title="Add members" size="xl">
+		<!-- novalidate: the action button lives outside this form, so the browser's own
+			 bubble would only ever fire on the Enter path. One rule for both. -->
+		<form ref="form" novalidate class="space-y-3" @submit.prevent="submit">
+			<p class="text-base text-ink-gray-5">
+				Colleagues who already have an account join straight away. Everyone else gets an email
+				invitation.
+			</p>
+
+			<div
+				class="grid grid-cols-[minmax(0,1fr)_9rem_2rem] items-center gap-2 text-sm text-ink-gray-5"
+			>
+				<span>Email</span>
+				<span>Role</span>
+			</div>
+
+			<TransitionGroup tag="div" name="row" class="relative space-y-2">
+				<div
+					v-for="(row, index) in rows"
+					:key="row.id"
+					class="grid grid-cols-[minmax(0,1fr)_9rem_2rem] items-center gap-2"
+				>
+					<FormControl
+						v-model="row.email"
+						type="email"
+						placeholder="colleague@example.com"
+						aria-label="Email"
+						:class="isInvalid(row) && '[&_input]:!border-outline-red-3'"
+					/>
+
+					<FormControl
+						v-model="row.team_role"
+						type="select"
+						aria-label="Role"
+						:options="ROLE_OPTIONS"
+					/>
+
+					<Button
+						v-if="canRemove(index)"
+						variant="ghost"
+						:label="`Remove ${row.email || 'row'}`"
+						@click="removeRow(index)"
+					>
+						<template #icon>
+							<span class="lucide-x size-4" />
+						</template>
+					</Button>
+				</div>
+			</TransitionGroup>
+
+			<ErrorMessage
+				:message="invalid.length && showErrors ? 'Check the highlighted addresses.' : errorMessage"
+			/>
+
+			<!-- Lets Enter submit from any field, since the actions live outside this form. -->
+			<button type="submit" class="hidden" />
+		</form>
+
+		<template #actions="{ close }">
+			<div class="flex gap-2">
+				<Button
+					variant="solid"
+					label="Send invites"
+					:loading="inviteMembers.loading"
+					:disabled="!filled.length"
+					@click="submit"
+				/>
+				<Button variant="outline" label="Cancel" @click="close" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<style scoped>
+/* Matches the members table behind this dialog: the leaving row drops out of flow so
+   the rows below start closing the gap straight away. */
+.row-leave-active {
+	position: absolute;
+	inset-inline: 0;
+	transition:
+		opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.row-leave-to {
+	opacity: 0;
+	transform: translateX(0.5rem);
+}
+
+.row-move {
+	transition: transform 250ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* Entry is opacity only, on purpose: a row arrives mid-keystroke, and anything that
+   moves under the caret reads as lag. */
+.row-enter-from {
+	opacity: 0;
+}
+
+.row-enter-active {
+	transition: opacity 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.row-leave-to {
+		transform: none;
+	}
+
+	.row-move {
+		transition: none;
+	}
+}
+</style>

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -1,10 +1,19 @@
 <script setup lang="ts">
-import { Button, ErrorMessage, SettingsBody, SettingsHeader, Skeleton } from "frappe-ui"
-import { computed, ref } from "vue"
+import {
+	Button,
+	ErrorMessage,
+	FormControl,
+	SettingsBody,
+	SettingsHeader,
+	Skeleton,
+	toast,
+} from "frappe-ui"
+import { computed, reactive, ref, watch } from "vue"
 
+import AvatarUploader from "@/components/common/AvatarUploader.vue"
 import AddMembersDialog from "@/components/dashboard/teams/AddMembersDialog.vue"
 import TeamMembersTable from "@/components/dashboard/teams/TeamMembersTable.vue"
-import { reloadTeams, useTeamOverview } from "@/data/teams"
+import { reloadTeams, updateTeam, useTeamOverview } from "@/data/teams"
 import { canManageMembers } from "@/utils/teamRoles"
 
 const props = defineProps<{ team: string; teamName: string }>()
@@ -13,7 +22,7 @@ defineEmits<{ back: [] }>()
 // Plain-language reading of the capability matrix in specs/v2/00-teams.
 const ROLES = [
 	{ name: "Owner", can: __("Created the team. Full control, and cannot be removed.") },
-	{ name: "Admin", can: __("Everything an owner can do, except renaming or deleting the team.") },
+	{ name: "Admin", can: __("Everything an owner can do, except deleting the team.") },
 	{
 		name: "Manager",
 		can: __("Creates and edits events. Cannot delete records or manage members."),
@@ -27,6 +36,31 @@ const isAdding = ref(false)
 const overview = useTeamOverview(props.team)
 
 const canManage = computed(() => canManageMembers(overview.data?.my_role))
+
+const form = reactive({ team_name: props.teamName, logo: null as string | null })
+
+// The overview arrives after the panel opens, so the form follows it in.
+watch(
+	() => overview.data,
+	(team) => team && Object.assign(form, { team_name: team.team_name, logo: team.logo }),
+)
+
+const isDirty = computed(
+	() =>
+		!!overview.data &&
+		(form.team_name !== overview.data.team_name || form.logo !== overview.data.logo),
+)
+
+const title = computed(() => overview.data?.team_name ?? props.teamName)
+
+async function save() {
+	// Rejects on failure; updateTeam.error renders inline, so the rejection is swallowed.
+	await updateTeam.submit({ team: props.team, ...form }).catch(() => null)
+	if (updateTeam.error) return
+
+	await refresh()
+	toast.success(__("Team updated"))
+}
 
 // The teams list behind this view shows member avatars, so it has to follow every change.
 async function refresh() {
@@ -45,19 +79,45 @@ async function refresh() {
 							<span class="lucide-chevron-left size-4" />
 						</template>
 					</Button>
-					<h2 class="truncate text-lg font-semibold text-ink-gray-8">{{ teamName }}</h2>
+					<h2 class="truncate text-lg font-semibold text-ink-gray-8">{{ title }}</h2>
 				</div>
-				<Button
-					v-if="canManage"
-					icon-left="lucide-plus"
-					:label="__('Add member')"
-					@click="isAdding = true"
-				/>
+				<div v-if="canManage" class="flex shrink-0 items-center gap-2">
+					<Transition name="save">
+						<Button
+							v-if="isDirty || updateTeam.loading"
+							variant="solid"
+							:loading="updateTeam.loading"
+							@click="save"
+						>
+							{{ __("Save") }}
+						</Button>
+					</Transition>
+					<Button icon-left="lucide-plus" :label="__('Add member')" @click="isAdding = true" />
+				</div>
 			</div>
 		</SettingsHeader>
 
 		<SettingsBody>
 			<div class="flex flex-col gap-6 pt-6">
+				<template v-if="canManage">
+					<AvatarUploader
+						v-model="form.logo"
+						shape="square"
+						:label="title"
+						:title="__('Team logo')"
+						:description="__('Shown wherever the team appears')"
+					/>
+
+					<FormControl
+						type="text"
+						class="max-w-sm"
+						:label="__('Team Name')"
+						v-model="form.team_name"
+					/>
+
+					<ErrorMessage :message="(updateTeam.error as Error | null)?.message" />
+				</template>
+
 				<section class="rounded-7 bg-surface-gray-1 p-4">
 					<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
 					<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
@@ -86,3 +146,31 @@ async function refresh() {
 		<AddMembersDialog v-model="isAdding" :team="team" @success="refresh" />
 	</div>
 </template>
+
+<style scoped>
+/* Same save affordance as the profile panel: leave quicker than enter. */
+.save-enter-active {
+	transition:
+		opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.save-leave-active {
+	transition:
+		opacity 100ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.save-enter-from,
+.save-leave-to {
+	opacity: 0;
+	transform: scale(0.95);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.save-enter-from,
+	.save-leave-to {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { Button, ErrorMessage, LoadingText, SettingsBody, SettingsHeader } from "frappe-ui"
+import { computed, ref } from "vue"
+
+import AddMembersDialog from "@/components/dashboard/teams/AddMembersDialog.vue"
+import TeamMembersTable from "@/components/dashboard/teams/TeamMembersTable.vue"
+import { reloadTeams, useTeamOverview } from "@/data/teams"
+
+const props = defineProps<{ team: string; teamName: string }>()
+defineEmits<{ back: [] }>()
+
+const MANAGING_ROLES = ["Owner", "Admin"]
+
+// Plain-language reading of the capability matrix in specs/v2/00-teams.
+const ROLES = [
+	{ name: "Owner", can: __("Created the team. Full control, and cannot be removed.") },
+	{ name: "Admin", can: __("Everything an owner can do, except renaming or deleting the team.") },
+	{
+		name: "Manager",
+		can: __("Creates and edits events. Cannot delete records or manage members."),
+	},
+	{ name: "Frontdesk", can: __("Checks attendees in at the door, and nothing else.") },
+	{ name: "Viewer", can: __("Reads the team's events and details. Changes nothing.") },
+]
+
+const isAdding = ref(false)
+
+const overview = useTeamOverview(props.team)
+
+const canManage = computed(() => MANAGING_ROLES.includes(overview.data?.my_role ?? ""))
+
+// The teams list behind this view shows member avatars, so it has to follow every change.
+async function refresh() {
+	await overview.reload()
+	reloadTeams()
+}
+</script>
+
+<template>
+	<SettingsHeader>
+		<div class="flex items-start justify-between gap-4">
+			<div class="flex min-w-0 items-center gap-1">
+				<Button variant="ghost" :label="__('Back to teams')" @click="$emit('back')">
+					<template #icon>
+						<span class="lucide-chevron-left size-4" />
+					</template>
+				</Button>
+				<h2 class="truncate text-lg font-semibold text-ink-gray-8">{{ teamName }}</h2>
+			</div>
+			<Button
+				v-if="canManage"
+				icon-left="plus"
+				:label="__('Add member')"
+				@click="isAdding = true"
+			/>
+		</div>
+	</SettingsHeader>
+
+	<SettingsBody>
+		<div class="flex flex-col gap-6 pt-6">
+			<LoadingText v-if="overview.loading" :text="__('Loading members…')" />
+			<ErrorMessage v-else-if="overview.error" :message="overview.error.message" />
+
+			<template v-else-if="overview.data">
+				<section class="rounded-7 bg-surface-gray-1 p-4">
+					<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
+					<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+						<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
+							<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>
+							<dd class="text-ink-gray-5">{{ role.can }}</dd>
+						</div>
+					</dl>
+				</section>
+
+				<TeamMembersTable :team="overview.data" @removed="refresh" />
+			</template>
+		</div>
+	</SettingsBody>
+
+	<AddMembersDialog v-model="isAdding" :team="team" @success="refresh" />
+</template>

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -5,11 +5,10 @@ import { computed, ref } from "vue"
 import AddMembersDialog from "@/components/dashboard/teams/AddMembersDialog.vue"
 import TeamMembersTable from "@/components/dashboard/teams/TeamMembersTable.vue"
 import { reloadTeams, useTeamOverview } from "@/data/teams"
+import { canManageMembers } from "@/utils/teamRoles"
 
 const props = defineProps<{ team: string; teamName: string }>()
 defineEmits<{ back: [] }>()
-
-const MANAGING_ROLES = ["Owner", "Admin"]
 
 // Plain-language reading of the capability matrix in specs/v2/00-teams.
 const ROLES = [
@@ -27,7 +26,7 @@ const isAdding = ref(false)
 
 const overview = useTeamOverview(props.team)
 
-const canManage = computed(() => MANAGING_ROLES.includes(overview.data?.my_role ?? ""))
+const canManage = computed(() => canManageMembers(overview.data?.my_role))
 
 // The teams list behind this view shows member avatars, so it has to follow every change.
 async function refresh() {

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -37,45 +37,47 @@ async function refresh() {
 </script>
 
 <template>
-	<SettingsHeader>
-		<div class="flex items-start justify-between gap-4">
-			<div class="flex min-w-0 items-center gap-1">
-				<Button variant="ghost" :label="__('Back to teams')" @click="$emit('back')">
-					<template #icon>
-						<span class="lucide-chevron-left size-4" />
-					</template>
-				</Button>
-				<h2 class="truncate text-lg font-semibold text-ink-gray-8">{{ teamName }}</h2>
+	<div class="flex min-h-0 flex-1 flex-col">
+		<SettingsHeader>
+			<div class="flex items-start justify-between gap-4">
+				<div class="flex min-w-0 items-center gap-1">
+					<Button variant="ghost" :label="__('Back to teams')" @click="$emit('back')">
+						<template #icon>
+							<span class="lucide-chevron-left size-4" />
+						</template>
+					</Button>
+					<h2 class="truncate text-lg font-semibold text-ink-gray-8">{{ teamName }}</h2>
+				</div>
+				<Button
+					v-if="canManage"
+					icon-left="lucide-plus"
+					:label="__('Add member')"
+					@click="isAdding = true"
+				/>
 			</div>
-			<Button
-				v-if="canManage"
-				icon-left="plus"
-				:label="__('Add member')"
-				@click="isAdding = true"
-			/>
-		</div>
-	</SettingsHeader>
+		</SettingsHeader>
 
-	<SettingsBody>
-		<div class="flex flex-col gap-6 pt-6">
-			<LoadingText v-if="overview.loading" :text="__('Loading members…')" />
-			<ErrorMessage v-else-if="overview.error" :message="overview.error.message" />
+		<SettingsBody>
+			<div class="flex flex-col gap-6 pt-6">
+				<LoadingText v-if="overview.loading" :text="__('Loading members…')" />
+				<ErrorMessage v-else-if="overview.error" :message="overview.error.message" />
 
-			<template v-else-if="overview.data">
-				<section class="rounded-7 bg-surface-gray-1 p-4">
-					<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
-					<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
-						<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
-							<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>
-							<dd class="text-ink-gray-5">{{ role.can }}</dd>
-						</div>
-					</dl>
-				</section>
+				<template v-else-if="overview.data">
+					<section class="rounded-7 bg-surface-gray-1 p-4">
+						<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
+						<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+							<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
+								<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>
+								<dd class="text-ink-gray-5">{{ role.can }}</dd>
+							</div>
+						</dl>
+					</section>
 
-				<TeamMembersTable :team="overview.data" @removed="refresh" />
-			</template>
-		</div>
-	</SettingsBody>
+					<TeamMembersTable :team="overview.data" @removed="refresh" />
+				</template>
+			</div>
+		</SettingsBody>
 
-	<AddMembersDialog v-model="isAdding" :team="team" @success="refresh" />
+		<AddMembersDialog v-model="isAdding" :team="team" @success="refresh" />
+	</div>
 </template>

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Button, ErrorMessage, LoadingText, SettingsBody, SettingsHeader } from "frappe-ui"
+import { Button, ErrorMessage, SettingsBody, SettingsHeader, Skeleton } from "frappe-ui"
 import { computed, ref } from "vue"
 
 import AddMembersDialog from "@/components/dashboard/teams/AddMembersDialog.vue"
@@ -59,22 +59,28 @@ async function refresh() {
 
 		<SettingsBody>
 			<div class="flex flex-col gap-6 pt-6">
-				<LoadingText v-if="overview.loading" :text="__('Loading members…')" />
-				<ErrorMessage v-else-if="overview.error" :message="overview.error.message" />
+				<section class="rounded-7 bg-surface-gray-1 p-4">
+					<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
+					<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+						<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
+							<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>
+							<dd class="text-ink-gray-5">{{ role.can }}</dd>
+						</div>
+					</dl>
+				</section>
 
-				<template v-else-if="overview.data">
-					<section class="rounded-7 bg-surface-gray-1 p-4">
-						<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
-						<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
-							<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
-								<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>
-								<dd class="text-ink-gray-5">{{ role.can }}</dd>
-							</div>
-						</dl>
-					</section>
+				<ErrorMessage v-if="overview.error" :message="overview.error.message" />
 
-					<TeamMembersTable :team="overview.data" @removed="refresh" />
-				</template>
+				<TeamMembersTable v-else-if="overview.data" :team="overview.data" @removed="refresh" />
+
+				<!-- Shaped like a TeamMembersTable row, so members land where the placeholders stood. -->
+				<ul v-else :aria-label="__('Loading members')" class="pt-7">
+					<li v-for="row in 3" :key="row" class="flex items-center gap-3 py-2">
+						<Skeleton class="size-8 shrink-0 rounded-full" />
+						<Skeleton class="h-4 w-36 rounded-4" />
+						<Skeleton class="ml-auto h-4 w-16 rounded-4" />
+					</li>
+				</ul>
 			</div>
 		</SettingsBody>
 

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -51,9 +51,14 @@ const isDirty = computed(
 		(form.team_name !== overview.data.team_name || form.logo !== overview.data.logo),
 )
 
+// A logo has no blur: an upload or a remove is the whole gesture.
+watch(() => form.logo, save)
+
 const title = computed(() => overview.data?.team_name ?? props.teamName)
 
 async function save() {
+	if (!isDirty.value || !form.team_name.trim()) return
+
 	// Rejects on failure; updateTeam.error renders inline, so the rejection is swallowed.
 	await updateTeam.submit({ team: props.team, ...form }).catch(() => null)
 	if (updateTeam.error) return
@@ -81,19 +86,12 @@ async function refresh() {
 					</Button>
 					<h2 class="truncate text-lg font-semibold text-ink-gray-8">{{ title }}</h2>
 				</div>
-				<div v-if="canManage" class="flex shrink-0 items-center gap-2">
-					<Transition name="save">
-						<Button
-							v-if="isDirty || updateTeam.loading"
-							variant="solid"
-							:loading="updateTeam.loading"
-							@click="save"
-						>
-							{{ __("Save") }}
-						</Button>
-					</Transition>
-					<Button icon-left="lucide-plus" :label="__('Add member')" @click="isAdding = true" />
-				</div>
+				<Button
+					v-if="canManage"
+					icon-left="lucide-plus"
+					:label="__('Add member')"
+					@click="isAdding = true"
+				/>
 			</div>
 		</SettingsHeader>
 
@@ -113,6 +111,7 @@ async function refresh() {
 						class="max-w-sm"
 						:label="__('Team Name')"
 						v-model="form.team_name"
+						@blur="save"
 					/>
 
 					<ErrorMessage :message="(updateTeam.error as Error | null)?.message" />
@@ -146,31 +145,3 @@ async function refresh() {
 		<AddMembersDialog v-model="isAdding" :team="team" @success="refresh" />
 	</div>
 </template>
-
-<style scoped>
-/* Same save affordance as the profile panel: leave quicker than enter. */
-.save-enter-active {
-	transition:
-		opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
-		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.save-leave-active {
-	transition:
-		opacity 100ms cubic-bezier(0.23, 1, 0.32, 1),
-		transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.save-enter-from,
-.save-leave-to {
-	opacity: 0;
-	transform: scale(0.95);
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.save-enter-from,
-	.save-leave-to {
-		transform: none;
-	}
-}
-</style>

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -117,8 +117,10 @@ async function refresh() {
 					<ErrorMessage :message="(updateTeam.error as Error | null)?.message" />
 				</template>
 
-				<section class="rounded-7 bg-surface-gray-1 p-4">
-					<h3 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h3>
+				<h3 class="text-base-semibold text-ink-gray-8">{{ __("Team Members") }}</h3>
+
+				<section class="-mt-3 rounded-7 bg-surface-gray-1 p-4">
+					<h4 class="text-sm font-medium text-ink-gray-7">{{ __("What each role can do") }}</h4>
 					<dl class="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
 						<div v-for="role in ROLES" :key="role.name" class="flex gap-2">
 							<dt class="w-20 shrink-0 font-medium text-ink-gray-7">{{ role.name }}</dt>

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -89,8 +89,8 @@ function confirmRemove(row: Row) {
 <template>
 	<div>
 		<div :class="COLUMNS" class="pb-2 text-sm text-ink-gray-5">
-			<span>{{ __("Name") }}</span>
-			<span>{{ __("Email") }}</span>
+			<span />
+			<span />
 			<span>{{ __("Role") }}</span>
 		</div>
 
@@ -107,7 +107,8 @@ function confirmRemove(row: Row) {
 					<span class="truncate text-base text-ink-gray-8">{{ row.name }}</span>
 				</div>
 
-				<span class="truncate text-base text-ink-gray-6">{{ row.email }}</span>
+				<!-- An invite has only an address, already shown as its name. -->
+				<span class="truncate text-base text-ink-gray-6">{{ row.member ? row.email : "" }}</span>
 
 				<span class="truncate text-base font-medium text-ink-gray-8">
 					{{ row.role }}

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { Avatar, Button, Dropdown, dialog, toast } from "frappe-ui"
+import { computed } from "vue"
+
+import { session } from "@/data/session"
+import { removeMember } from "@/data/teams"
+import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
+
+const props = defineProps<{ team: TeamOverview }>()
+const emit = defineEmits<{ removed: [] }>()
+
+const MANAGING_ROLES = ["Owner", "Admin"]
+// Header and rows share one grid so the columns line up without a table element.
+const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4"
+
+interface Row {
+	key: string
+	name: string
+	email: string
+	role: string
+	image?: string
+	member?: TeamMember
+}
+
+const canManage = computed(() => MANAGING_ROLES.includes(props.team.my_role))
+
+// Members and pending invitations share one list so the table reads as the whole team,
+// with the people who have not accepted yet at the bottom.
+const rows = computed<Row[]>(() => [
+	...props.team.members.map(memberRow),
+	...props.team.invites.map(inviteRow),
+])
+
+function memberRow(member: TeamMember): Row {
+	return {
+		key: member.user,
+		name: member.full_name ?? member.user,
+		email: member.user,
+		role: member.team_role,
+		image: member.user_image ?? undefined,
+		member,
+	}
+}
+
+// There is no user yet, so no name and no image — the address stands in for both.
+function inviteRow(invite: TeamInvite): Row {
+	return {
+		key: `invite:${invite.email}`,
+		name: invite.email,
+		email: invite.email,
+		role: invite.team_role,
+	}
+}
+
+// The owner is locked server-side, leaving a team is its own flow rather than a
+// self-removal, and an invitation is revoked rather than removed.
+function canRemove(row: Row) {
+	if (!canManage.value || !row.member) return false
+	return row.member.team_role !== "Owner" && row.member.user !== session.user
+}
+
+function actionsFor(row: Row) {
+	return [
+		{
+			label: __("Remove from team"),
+			icon: "trash-2",
+			theme: "red" as const,
+			onClick: () => confirmRemove(row),
+		},
+	]
+}
+
+function confirmRemove(row: Row) {
+	dialog.confirm({
+		title: __("Remove member"),
+		message: __("{0} will lose access to this team.", [row.name]),
+		theme: "red",
+		confirmLabel: __("Remove"),
+		// A rejected promise renders inline in the dialog, so failures need no branch here.
+		onConfirm: async () => {
+			await removeMember.submit({ team: props.team.name, user: row.email })
+			emit("removed")
+			toast.success(__("{0} was removed from the team.", [row.name]))
+		},
+	})
+}
+</script>
+
+<template>
+	<div>
+		<div :class="COLUMNS" class="pb-2 text-sm text-ink-gray-5">
+			<span>{{ __("Name") }}</span>
+			<span>{{ __("Email") }}</span>
+			<span>{{ __("Role") }}</span>
+		</div>
+
+		<!-- Removing a row would otherwise snap the rest of the list upwards. -->
+		<TransitionGroup tag="ul" name="member" :aria-label="__('Team members')" class="relative">
+			<li
+				v-for="row in rows"
+				:key="row.key"
+				:class="COLUMNS"
+				class="-mx-2 rounded-4 px-2 py-2 transition-colors duration-150 hover:bg-surface-gray-1"
+			>
+				<div class="flex min-w-0 items-center gap-3">
+					<Avatar :image="row.image" :label="row.name" size="lg" />
+					<span class="truncate text-base text-ink-gray-8">{{ row.name }}</span>
+				</div>
+
+				<span class="truncate text-base text-ink-gray-6">{{ row.email }}</span>
+
+				<span class="truncate text-base font-medium text-ink-gray-8">
+					{{ row.role }}
+					<span v-if="!row.member" class="font-normal text-ink-gray-5">({{ __("Invited") }})</span>
+				</span>
+
+				<Dropdown v-if="canRemove(row)" :options="actionsFor(row)" align="end">
+					<!-- label is the accessible name here: an icon slot makes it icon-only. -->
+					<Button variant="ghost" :label="__('Member actions')">
+						<template #icon>
+							<span class="lucide-ellipsis size-4" />
+						</template>
+					</Button>
+				</Dropdown>
+			</li>
+		</TransitionGroup>
+	</div>
+</template>
+
+<style scoped>
+/* The leaving row is taken out of flow so the rows below start closing the gap
+   straight away rather than waiting for the fade to finish. */
+.member-leave-active {
+	position: absolute;
+	inset-inline: 0;
+	transition:
+		opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.member-leave-to {
+	opacity: 0;
+	transform: translateX(0.5rem);
+}
+
+.member-move {
+	transition: transform 250ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.member-leave-to {
+		transform: none;
+	}
+
+	.member-move {
+		transition: none;
+	}
+}
+</style>

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -63,7 +63,7 @@ function actionsFor(row: Row) {
 	return [
 		{
 			label: __("Remove from team"),
-			icon: "trash-2",
+			icon: "lucide-trash-2",
 			theme: "red" as const,
 			onClick: () => confirmRemove(row),
 		},

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -5,11 +5,11 @@ import { computed } from "vue"
 import { session } from "@/data/session"
 import { removeMember } from "@/data/teams"
 import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
+import { canManageMembers } from "@/utils/teamRoles"
 
 const props = defineProps<{ team: TeamOverview }>()
 const emit = defineEmits<{ removed: [] }>()
 
-const MANAGING_ROLES = ["Owner", "Admin"]
 // Header and rows share one grid so the columns line up without a table element.
 const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4"
 
@@ -22,7 +22,7 @@ interface Row {
 	member?: TeamMember
 }
 
-const canManage = computed(() => MANAGING_ROLES.includes(props.team.my_role))
+const canManage = computed(() => canManageMembers(props.team.my_role))
 
 // Members and pending invitations share one list so the table reads as the whole team,
 // with the people who have not accepted yet at the bottom.

--- a/dashboard/src/components/dashboard/teams/TeamsPanel.vue
+++ b/dashboard/src/components/dashboard/teams/TeamsPanel.vue
@@ -20,66 +20,97 @@ const filtered = computed(() => {
 </script>
 
 <template>
-	<ManageTeamPanel
-		v-if="managing"
-		:team="managing.name"
-		:team-name="managing.team_name"
-		@back="managing = null"
-	/>
+	<Transition name="view" mode="out-in">
+		<ManageTeamPanel
+			v-if="managing"
+			:team="managing.name"
+			:team-name="managing.team_name"
+			@back="managing = null"
+		/>
 
-	<template v-else>
-		<SettingsHeader :title="__('Your Teams')" />
+		<div v-else class="flex min-h-0 flex-1 flex-col">
+			<SettingsHeader :title="__('Your Teams')" />
 
-		<SettingsBody>
-			<div class="flex flex-col gap-4 pt-6">
-				<FormControl
-					v-model="search"
-					type="text"
-					class="max-w-xs"
-					:placeholder="__('Search teams')"
-					:aria-label="__('Search teams')"
-				>
-					<template #prefix>
-						<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
-					</template>
-				</FormControl>
+			<SettingsBody>
+				<div class="flex flex-col gap-4 pt-6">
+					<FormControl
+						v-model="search"
+						type="text"
+						class="max-w-xs"
+						:placeholder="__('Search teams')"
+						:aria-label="__('Search teams')"
+					>
+						<template #prefix>
+							<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
+						</template>
+					</FormControl>
 
-				<EmptyState v-if="!filtered.length" :title="__('No teams found')" />
+					<EmptyState v-if="!filtered.length" :title="__('No teams found')" />
 
-				<div v-else>
-					<div :class="COLUMNS" class="border-b pb-2 text-sm text-ink-gray-5">
-						<span>{{ __("Team") }}</span>
-						<span>{{ __("Members") }}</span>
-					</div>
+					<div v-else>
+						<div :class="COLUMNS" class="border-b pb-2 text-sm text-ink-gray-5">
+							<span>{{ __("Team") }}</span>
+							<span>{{ __("Members") }}</span>
+						</div>
 
-					<ul :aria-label="__('Your teams')">
-						<li v-for="team in filtered" :key="team.name">
-							<button
-								type="button"
-								:class="COLUMNS"
-								class="w-full border-b py-3 text-left transition-colors duration-150 hover:bg-surface-gray-1 focus-visible:outline-none focus-visible:focus-ring"
-								@click="managing = team"
-							>
-								<div class="flex min-w-0 items-center gap-3">
-									<Avatar
-										shape="square"
-										size="lg"
-										:image="team.logo ?? undefined"
-										:label="team.team_name"
+						<ul :aria-label="__('Your teams')">
+							<li v-for="team in filtered" :key="team.name">
+								<button
+									type="button"
+									:class="COLUMNS"
+									class="group w-full border-b py-3 text-left transition-[background-color,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-surface-gray-1 active:scale-[0.99] focus-visible:outline-none focus-visible:focus-ring motion-reduce:active:scale-100"
+									@click="managing = team"
+								>
+									<div class="flex min-w-0 items-center gap-3">
+										<Avatar
+											shape="square"
+											size="lg"
+											:image="team.logo ?? undefined"
+											:label="team.team_name"
+										/>
+										<span class="truncate text-base font-medium text-ink-gray-8">{{
+											team.team_name
+										}}</span>
+									</div>
+
+									<UserGroup :users="team.members" />
+
+									<span
+										class="lucide-chevron-right size-4 text-ink-gray-5 transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:translate-x-0.5 motion-reduce:group-hover:translate-x-0"
+										aria-hidden="true"
 									/>
-									<span class="truncate text-base font-medium text-ink-gray-8">{{
-										team.team_name
-									}}</span>
-								</div>
-
-								<UserGroup :users="team.members" />
-
-								<span class="lucide-chevron-right size-4 text-ink-gray-5" aria-hidden="true" />
-							</button>
-						</li>
-					</ul>
+								</button>
+							</li>
+						</ul>
+					</div>
 				</div>
-			</div>
-		</SettingsBody>
-	</template>
+			</SettingsBody>
+		</div>
+	</Transition>
 </template>
+
+<style scoped>
+.view-enter-active,
+.view-leave-active {
+	transition:
+		opacity 120ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.view-enter-from {
+	opacity: 0;
+	transform: translateX(4px);
+}
+
+.view-leave-to {
+	opacity: 0;
+	transform: translateX(-4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.view-enter-from,
+	.view-leave-to {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/components/dashboard/teams/TeamsPanel.vue
+++ b/dashboard/src/components/dashboard/teams/TeamsPanel.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { Avatar, FormControl, SettingsBody, SettingsHeader } from "frappe-ui"
+import { computed, ref } from "vue"
+
+import EmptyState from "@/components/common/EmptyState.vue"
+import UserGroup from "@/components/common/UserGroup.vue"
+import ManageTeamPanel from "@/components/dashboard/teams/ManageTeamPanel.vue"
+import { teams } from "@/data/teams"
+import type { TeamOption } from "@/types"
+
+const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_1.5rem] items-center gap-4"
+
+const search = ref("")
+const managing = ref<TeamOption | null>(null)
+
+const filtered = computed(() => {
+	const query = search.value.trim().toLowerCase()
+	return teams.value.filter((team) => team.team_name.toLowerCase().includes(query))
+})
+</script>
+
+<template>
+	<ManageTeamPanel
+		v-if="managing"
+		:team="managing.name"
+		:team-name="managing.team_name"
+		@back="managing = null"
+	/>
+
+	<template v-else>
+		<SettingsHeader :title="__('Your Teams')" />
+
+		<SettingsBody>
+			<div class="flex flex-col gap-4 pt-6">
+				<FormControl
+					v-model="search"
+					type="text"
+					class="max-w-xs"
+					:placeholder="__('Search teams')"
+					:aria-label="__('Search teams')"
+				>
+					<template #prefix>
+						<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
+					</template>
+				</FormControl>
+
+				<EmptyState v-if="!filtered.length" :title="__('No teams found')" />
+
+				<div v-else>
+					<div :class="COLUMNS" class="border-b pb-2 text-sm text-ink-gray-5">
+						<span>{{ __("Team") }}</span>
+						<span>{{ __("Members") }}</span>
+					</div>
+
+					<ul :aria-label="__('Your teams')">
+						<li v-for="team in filtered" :key="team.name">
+							<button
+								type="button"
+								:class="COLUMNS"
+								class="w-full border-b py-3 text-left transition-colors duration-150 hover:bg-surface-gray-1 focus-visible:outline-none focus-visible:focus-ring"
+								@click="managing = team"
+							>
+								<div class="flex min-w-0 items-center gap-3">
+									<Avatar
+										shape="square"
+										size="lg"
+										:image="team.logo ?? undefined"
+										:label="team.team_name"
+									/>
+									<span class="truncate text-base font-medium text-ink-gray-8">{{
+										team.team_name
+									}}</span>
+								</div>
+
+								<UserGroup :users="team.members" />
+
+								<span class="lucide-chevron-right size-4 text-ink-gray-5" aria-hidden="true" />
+							</button>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</SettingsBody>
+	</template>
+</template>

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -1,8 +1,8 @@
-import { createResource } from "frappe-ui"
+import { createResource, useCall } from "frappe-ui"
 import { computed, ref } from "vue"
 
 import { session } from "@/data/session"
-import type { TeamOption } from "@/types"
+import type { InviteOutcome, TeamOption, TeamOverview } from "@/types"
 
 const STORAGE_KEY = "buzz:current-team"
 
@@ -32,6 +32,26 @@ export async function isTeamMember(): Promise<boolean> {
 	if (!teamsResource.data) await teamsResource.fetch()
 	return teams.value.length > 0
 }
+
+export function reloadTeams() {
+	return teamsResource.reload()
+}
+
+// v2 path: useCall reads the payload from `data`, which /api/method names `message`.
+export function useTeamOverview(team: string) {
+	return useCall<TeamOverview, { team: string }>({
+		url: "/api/v2/method/buzz.api.teams.get_team_overview",
+		params: { team },
+	})
+}
+
+export const removeMember = createResource({
+	url: "buzz.api.teams.remove_member",
+})
+
+export const inviteMembers = createResource<InviteOutcome[]>({
+	url: "buzz.api.teams.invite_members",
+})
 
 export function selectTeam(name: string) {
 	selectedTeamName.value = name

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -53,6 +53,10 @@ export const inviteMembers = createResource<InviteOutcome[]>({
 	url: "buzz.api.teams.invite_members",
 })
 
+export const updateTeam = createResource({
+	url: "buzz.api.teams.update_team",
+})
+
 export function selectTeam(name: string) {
 	selectedTeamName.value = name
 	localStorage.setItem(STORAGE_KEY, name)

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -105,13 +105,44 @@ export interface UserInfo {
 	language?: string | null
 }
 
+export interface TeamMember {
+	user: string
+	full_name: string | null
+	user_image: string | null
+	team_role: string
+}
+
 // Rows from buzz.api.teams.get_my_teams: the session user's enabled memberships
-// with the team title and logo joined on.
+// with the team title, logo and members joined on.
 export interface TeamOption {
 	name: string
 	team_name: string
 	logo: string | null
 	team_role: string
+	members: TeamMember[]
+}
+
+// Someone invited by email who has not accepted yet, so has no User row.
+export interface TeamInvite {
+	email: string
+	team_role: string
+}
+
+export interface TeamOverview {
+	name: string
+	team_name: string
+	slug: string | null
+	logo: string | null
+	my_role: string
+	members: TeamMember[]
+	invites: TeamInvite[]
+}
+
+// buzz.api.teams.invite_members: one row per address, saying which route it took.
+export interface InviteOutcome {
+	email: string
+	status: "added" | "invited" | "already_a_member"
+	full_name?: string | null
 }
 
 // buzz.api.events.get_my_events: events the user's teams host, plus events they

--- a/dashboard/src/utils/teamRoles.test.ts
+++ b/dashboard/src/utils/teamRoles.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { canCreateEvents } from "./teamRoles.ts"
+import { canCreateEvents, canManageMembers } from "./teamRoles.ts"
 
 test("a manager can create events", () => {
 	assert.equal(canCreateEvents("Manager"), true)
@@ -22,4 +22,14 @@ test("a frontdesk member cannot create events", () => {
 
 test("no team selected cannot create events", () => {
 	assert.equal(canCreateEvents(undefined), false)
+})
+
+test("an owner and an admin can manage members", () => {
+	assert.equal(canManageMembers("Owner"), true)
+	assert.equal(canManageMembers("Admin"), true)
+})
+
+test("a manager cannot manage members", () => {
+	assert.equal(canManageMembers("Manager"), false)
+	assert.equal(canManageMembers(undefined), false)
 })

--- a/dashboard/src/utils/teamRoles.ts
+++ b/dashboard/src/utils/teamRoles.ts
@@ -5,3 +5,11 @@ const EVENT_WRITE_ROLES = ["Owner", "Admin", "Manager"]
 export function canCreateEvents(teamRole: string | undefined): boolean {
 	return Boolean(teamRole && EVENT_WRITE_ROLES.includes(teamRole))
 }
+
+// Mirrors ADMIN_ROLES in buzz/permissions.py; can_manage_members is the server's check.
+const MEMBER_WRITE_ROLES = ["Owner", "Admin"]
+
+/** Whether a team role may invite and remove members. Gates the UI, not the API. */
+export function canManageMembers(teamRole: string | undefined): boolean {
+	return Boolean(teamRole && MEMBER_WRITE_ROLES.includes(teamRole))
+}

--- a/e2e/tests/user-settings.spec.ts
+++ b/e2e/tests/user-settings.spec.ts
@@ -65,4 +65,24 @@ test.describe("User settings", () => {
 		await settings(page).getByRole("button", { name: "Save" }).click()
 		await expect(settings(page).getByRole("button", { name: "Save" })).toHaveCount(0)
 	})
+
+	test("lists the user's teams and opens one to manage", async ({ page }) => {
+		const panel = settings(page)
+
+		await panel.getByRole("tab", { name: "Teams" }).click()
+		await expect(panel.getByRole("heading", { name: "Your Teams" })).toBeVisible()
+
+		const teams = panel.getByRole("list", { name: "Your teams" }).getByRole("listitem")
+		await expect(teams.first()).toContainText("members", { timeout: 15000 })
+
+		await teams.first().getByRole("button").click()
+
+		// The Manager role can read the roster but not change it.
+		const members = panel.getByRole("list", { name: "Team members" }).getByRole("listitem")
+		await expect(members.first()).toContainText("Owner", { timeout: 15000 })
+		await expect(panel.getByRole("button", { name: "Add member" })).toHaveCount(0)
+
+		await panel.getByRole("button", { name: "Back to teams" }).click()
+		await expect(panel.getByRole("heading", { name: "Your Teams" })).toBeVisible()
+	})
 })


### PR DESCRIPTION
## Summary
- Settings dialog gains a **Team Management → Teams** tab: searchable list of the user's teams with a member avatar stack and count.
- Clicking a team opens the members roster inside the dialog (back button in header), restoring the old `/manage/team/members` table, add-members dialog and remove confirmation, now scoped to the picked team.
- `get_my_teams` returns each team's members so the list needs no per-row request.
- Dialog widened to 6xl. Role legend paints instantly; skeleton rows while the roster loads. Press/hover/crossfade motion on the list.

## Demo
https://cap.so/s/bxcsjf5j1e1x57b

## Test plan
- [x] `bench run-tests --module buzz.api.teams.test_teams` (18 pass, 1 new)
- [x] `playwright --project=user-settings-chromium` (6 pass, 1 new)
- [x] Manual: list, search, manage, add dialog, remove confirm, back
