### PR TITLE
fix: drop desk access from Buzz roles

### DIFF
--- a/buzz/events/doctype/buzz_team/buzz_team.py
+++ b/buzz/events/doctype/buzz_team/buzz_team.py
@@ -85,8 +85,8 @@ class BuzzTeam(Document):
 		"""Users who could still join this team, matched on email or full name.
 
 		Website users are in on purpose: frappe's own `user_query` hides them, but an attendee
-		is as likely to be a colleague as anyone. Adding one to a team grants a role with desk
-		access, which turns them into a System User.
+		is as likely to be a colleague as anyone. Team roles grant no desk access, so they
+		stay Website Users.
 		"""
 		self.check_can_manage_members()
 

--- a/buzz/events/doctype/buzz_team_membership/test_buzz_team_membership.py
+++ b/buzz/events/doctype/buzz_team_membership/test_buzz_team_membership.py
@@ -46,6 +46,14 @@ class TestBuzzTeamMembership(IntegrationTestCase):
 
 		self.assertIn("Event Manager", frappe.get_roles(user))
 
+	def test_membership_keeps_the_user_out_of_desk(self):
+		user = create_user("role-no-desk@example.com", "Portal")
+		team = create_team("No Desk Team")
+
+		add_member(team.name, user, "Manager")
+
+		self.assertEqual(frappe.db.get_value("User", user, "user_type"), "Website User")
+
 	def test_frontdesk_membership_grants_frontdesk_manager_only(self):
 		user = create_user("role-frontdesk@example.com", "Frontdesk")
 		team = create_team("Frontdesk Role Team")

--- a/buzz/fixtures/role.json
+++ b/buzz/fixtures/role.json
@@ -1,12 +1,25 @@
 [
  {
-  "desk_access": 1,
+  "desk_access": 0,
   "disabled": 0,
   "docstatus": 0,
   "doctype": "Role",
-  "home_page": null,
+  "home_page": "/dashboard",
   "is_custom": 0,
-  "modified": "2025-10-27 15:00:39.981840",
+  "modified": "2026-09-05 10:00:00.000000",
+  "name": "Event Manager",
+  "restrict_to_domain": null,
+  "role_name": "Event Manager",
+  "two_factor_auth": 0
+ },
+ {
+  "desk_access": 0,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "home_page": "/dashboard",
+  "is_custom": 0,
+  "modified": "2026-09-05 10:00:00.000000",
   "name": "Frontdesk Manager",
   "restrict_to_domain": null,
   "role_name": "Frontdesk Manager",

--- a/buzz/hooks.py
+++ b/buzz/hooks.py
@@ -76,7 +76,7 @@ doc_events = {
 	},
 }
 
-fixtures = [{"dt": "Role", "filters": {"name": ["in", ["Buzz User", "Frontdesk Manager"]]}}]
+fixtures = [{"dt": "Role", "filters": {"name": ["in", ["Buzz User", "Event Manager", "Frontdesk Manager"]]}}]
 
 user_invitation = {
 	"allowed_roles": {"Event Manager": ["Buzz User"], "Buzz User": ["Buzz User"]},


### PR DESCRIPTION
## Summary
- Fixture `Event Manager` alongside `Buzz User` and `Frontdesk Manager`, all with `desk_access: 0` and `/dashboard` home page.
- `Event Manager` was never fixtured, so it kept Frappe's default desk access and every team membership turned the user into a System User.
- Existing users keep their user type. Only users who earn a Buzz role from now on stay Website Users.

## Test plan
- [x] `test_buzz_team_membership` (23) and `test_team_members` (15) pass, including new `test_membership_keeps_the_user_out_of_desk`
- [x] `bench migrate` on local site: roles flip to `desk_access: 0`