### PR TITLE
fix(dashboard): stop caching the team list

### DIFF
--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -10,7 +10,8 @@ const selectedTeamName = ref(localStorage.getItem(STORAGE_KEY) || "")
 
 const teamsResource = createResource<TeamOption[]>({
 	url: "buzz.api.teams.get_my_teams",
-	cache: "My Teams",
+	// Uncached: the key is not per-user, and a cached empty list restores as data, so
+	// `isTeamMember` would skip its fetch and keep denying a user who has since joined a team.
 	// Not `auto`: get_my_teams is not allow_guest, so a logged-out visitor on a public
 	// booking route would fire a 403 on module load.
 	onSuccess(myTeams: TeamOption[]) {


### PR DESCRIPTION
## What changed

`teamsResource` in `dashboard/src/data/teams.ts` passed `cache: "My Teams"`. frappe-ui
persists a cached resource to IndexedDB under that key, and restores it on module load
whenever the stored value is truthy — an empty array qualifies.

That turns a temporary state into a permanent one. A user who opens the dashboard while
they belong to no team caches `[]`. `isTeamMember()` only fetches when `teamsResource.data`
is unset, so once the cache restores, no request is ever made again: the user is added to
a team server-side, and the manager shell still renders its 404 for them in that browser.
The key is not per-user either, so the stale list follows the next person to log in there.

Dropping the cache is the fix. `get_my_teams` is one query behind a route guard; it does
not need to survive a reload.

Not touched: `cache: "User"` in `data/user.ts` has the same unscoped key, but the router
refetches it on every navigation, so it can only flash stale data rather than stick.

## Demo

No visual change — the manager shell renders as it always did, for the users who should
reach it. Applying `skip-demo`.

## Testing

Manual, on a site where a user had a team but was still being denied `/manage`: cleared
the browser's IndexedDB, confirmed `get_my_teams` fires on the guard and returns the team,
and the manager shell loads. No unit test — the change removes a resource option, and
nothing here is testable without mocking frappe-ui's whole resource layer.