### PR TITLE
feat: resend and retract a pending team invite

### DIFF
--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -44,3 +44,13 @@ def invite_members(team: str, invites: list[dict]) -> list[InviteOutcome]:
 @frappe.whitelist(methods=["POST"])
 def update_team(team: str, team_name: str, logo: str | None = None) -> None:
 	services.update_team(team, team_name, logo)
+
+
+@frappe.whitelist(methods=["POST"])
+def resend_invite(team: str, email: str) -> None:
+	invitations.resend_invite(team, email)
+
+
+@frappe.whitelist(methods=["POST"])
+def retract_invite(team: str, email: str) -> None:
+	invitations.retract_invite(team, email)

--- a/buzz/api/teams/exceptions.py
+++ b/buzz/api/teams/exceptions.py
@@ -24,3 +24,8 @@ class CannotGrantOwnership(NotPermitted):
 class UnknownTeamRole(BuzzAPIError):
 	title = _lt("Invalid Role")
 	message = _lt("{team_role} is not a team role.")
+
+
+class NoPendingInvite(BuzzAPIError):
+	title = _lt("No Invitation")
+	message = _lt("There is no pending invitation for {email}.")

--- a/buzz/api/teams/invitations.py
+++ b/buzz/api/teams/invitations.py
@@ -1,7 +1,12 @@
 import frappe
-from frappe.core.api.user_invitation import invite_by_email
+from frappe.core.api.user_invitation import cancel_invitation, invite_by_email, resend_invitation
 
-from buzz.api.teams.exceptions import CannotGrantOwnership, CannotManageMembers, UnknownTeamRole
+from buzz.api.teams.exceptions import (
+	CannotGrantOwnership,
+	CannotManageMembers,
+	NoPendingInvite,
+	UnknownTeamRole,
+)
 from buzz.api.teams.schemas import InviteOutcome
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 from buzz.permissions import can_manage_members
@@ -66,3 +71,31 @@ def invite_one(team: str, invite: dict) -> InviteOutcome:
 		buzz_team_role=team_role,
 	)
 	return InviteOutcome(email=email, status="invited")
+
+
+def resend_invite(team: str, email: str) -> None:
+	"""Mail the invitation again. Core rotates the key, so the earlier link stops working."""
+	resend_invitation(name=pending_invite(team, email), app_name="buzz")
+
+
+def retract_invite(team: str, email: str) -> None:
+	"""Cancel the invitation. Core mails the invitee that it was withdrawn."""
+	cancel_invitation(name=pending_invite(team, email), app_name="buzz")
+
+
+def pending_invite(team: str, email: str) -> str:
+	"""The one pending buzz invitation for this address on this team.
+
+	Core allows at most one pending invitation per address per app, so the pair is a key.
+	Its own guards are app-wide rather than team-wide, which is why the team check lives here.
+	"""
+	if not can_manage_members(team):
+		CannotManageMembers.throw()
+
+	name = frappe.db.exists(
+		"User Invitation",
+		{"buzz_team": team, "email": email.strip().lower(), "status": "Pending", "app_name": "buzz"},
+	)
+	if not name:
+		NoPendingInvite.throw(email=email)
+	return name

--- a/buzz/api/teams/test_invitations.py
+++ b/buzz/api/teams/test_invitations.py
@@ -3,8 +3,13 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from buzz.api.teams import get_team_overview, invite_members
-from buzz.api.teams.exceptions import CannotGrantOwnership, CannotManageMembers, UnknownTeamRole
+from buzz.api.teams import get_team_overview, invite_members, resend_invite, retract_invite
+from buzz.api.teams.exceptions import (
+	CannotGrantOwnership,
+	CannotManageMembers,
+	NoPendingInvite,
+	UnknownTeamRole,
+)
 from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 
@@ -200,3 +205,96 @@ class TestTeamOverviewInvitations(IntegrationTestCase):
 
 		frappe.set_user(owner)
 		self.assertEqual(get_team_overview(team).invites, [])
+
+
+class TestInviteActions(IntegrationTestCase):
+	# Rollback is per class, not per test — every test owns its users and its team names.
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+		# Every invitation mails itself out on insert, which needs an outgoing email account.
+		self.enterContext(patch("frappe.sendmail"))
+
+	def invited_team(self, name: str, owner_email: str, invitee: str) -> tuple[str, str]:
+		"""A team with one pending invitation, and the owner who sent it."""
+		owner = create_user(owner_email, "Owner")
+		team = create_owned_team(name, owner)
+		frappe.set_user(owner)
+		invite_members(team, [{"email": invitee, "team_role": "Viewer"}])
+		return team, owner
+
+	def invitation_for(self, email: str) -> dict:
+		return frappe.db.get_value(
+			"User Invitation", {"email": email}, ["name", "key", "status"], as_dict=True
+		)
+
+	def test_resending_rotates_the_key_and_leaves_the_invitation_pending(self):
+		team, _ = self.invited_team("Resend Rotates", "resend-owner@example.com", "resend-me@example.com")
+		before = self.invitation_for("resend-me@example.com")
+
+		resend_invite(team, "resend-me@example.com")
+
+		after = self.invitation_for("resend-me@example.com")
+		self.assertEqual(after.status, "Pending")
+		# The plaintext key only ever exists in the mail, so a new hash is the proof.
+		self.assertNotEqual(after.key, before.key)
+
+	def test_retracting_cancels_the_invitation_and_drops_it_from_the_overview(self):
+		team, _ = self.invited_team("Retract Cancels", "retract-owner@example.com", "retract-me@example.com")
+
+		retract_invite(team, "retract-me@example.com")
+
+		self.assertEqual(self.invitation_for("retract-me@example.com").status, "Cancelled")
+		self.assertEqual(get_team_overview(team).invites, [])
+
+	def test_an_address_is_matched_regardless_of_case_or_padding(self):
+		team, _ = self.invited_team("Retract Untidy", "untidy-owner@example.com", "untidy@example.com")
+
+		retract_invite(team, "  Untidy@Example.com  ")
+
+		self.assertEqual(self.invitation_for("untidy@example.com").status, "Cancelled")
+
+	def test_a_manager_can_do_neither(self):
+		team, _ = self.invited_team(
+			"Actions Manager Guard", "actions-owner2@example.com", "guarded@example.com"
+		)
+		manager = create_user("actions-manager@example.com", "Manager")
+		upsert_membership(team, manager, "Manager")
+
+		frappe.set_user(manager)
+		with self.assertRaises(CannotManageMembers):
+			resend_invite(team, "guarded@example.com")
+		with self.assertRaises(CannotManageMembers):
+			retract_invite(team, "guarded@example.com")
+
+		self.assertEqual(self.invitation_for("guarded@example.com").status, "Pending")
+
+	def test_another_teams_owner_can_do_neither(self):
+		team, _ = self.invited_team("Actions Mine", "actions-owner3@example.com", "not-yours@example.com")
+		frappe.set_user("Administrator")
+		outsider = create_user("actions-other-owner@example.com", "Other")
+		create_owned_team("Actions Theirs", outsider)
+
+		# Core's own guards are app-wide: an Event Manager passes them for any buzz invitation.
+		frappe.set_user(outsider)
+		with self.assertRaises(CannotManageMembers):
+			resend_invite(team, "not-yours@example.com")
+		with self.assertRaises(CannotManageMembers):
+			retract_invite(team, "not-yours@example.com")
+
+		self.assertEqual(self.invitation_for("not-yours@example.com").status, "Pending")
+
+	def test_an_unknown_address_has_nothing_to_act_on(self):
+		team, _ = self.invited_team("Actions Unknown", "actions-owner4@example.com", "known@example.com")
+
+		with self.assertRaises(NoPendingInvite):
+			resend_invite(team, "stranger@example.com")
+
+	def test_a_retracted_invitation_cannot_be_retracted_again(self):
+		team, _ = self.invited_team("Actions Twice", "actions-owner5@example.com", "twice@example.com")
+		retract_invite(team, "twice@example.com")
+
+		with self.assertRaises(NoPendingInvite):
+			retract_invite(team, "twice@example.com")
+		with self.assertRaises(NoPendingInvite):
+			resend_invite(team, "twice@example.com")

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -3,7 +3,7 @@ import { Avatar, Button, Dropdown, dialog, toast } from "frappe-ui"
 import { computed } from "vue"
 
 import { session } from "@/data/session"
-import { removeMember } from "@/data/teams"
+import { removeMember, useResendInvite, useRetractInvite } from "@/data/teams"
 import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
 import { canManageMembers } from "@/utils/teamRoles"
 
@@ -23,6 +23,9 @@ interface Row {
 }
 
 const canManage = computed(() => canManageMembers(props.team.my_role))
+
+const resendInvite = useResendInvite()
+const retractInvite = useRetractInvite()
 
 // Members and pending invitations share one list so the table reads as the whole team,
 // with the people who have not accepted yet at the bottom.
@@ -52,14 +55,17 @@ function inviteRow(invite: TeamInvite): Row {
 	}
 }
 
-// The owner is locked server-side, leaving a team is its own flow rather than a
-// self-removal, and an invitation is revoked rather than removed.
+// The owner is locked server-side, and leaving a team is its own flow rather than a
+// self-removal.
 function canRemove(row: Row) {
 	if (!canManage.value || !row.member) return false
 	return row.member.team_role !== "Owner" && row.member.user !== session.user
 }
 
+// An invitation is resent or retracted; only a member is removed.
 function actionsFor(row: Row) {
+	if (!row.member) return canManage.value ? inviteActions(row) : []
+	if (!canRemove(row)) return []
 	return [
 		{
 			label: __("Remove from team"),
@@ -68,6 +74,29 @@ function actionsFor(row: Row) {
 			onClick: () => confirmRemove(row),
 		},
 	]
+}
+
+function inviteActions(row: Row) {
+	return [
+		{
+			label: __("Resend invitation"),
+			icon: "lucide-arrow-up-from-line",
+			onClick: () => resend(row),
+		},
+		{
+			label: __("Retract invitation"),
+			icon: "lucide-shredder",
+			theme: "red" as const,
+			onClick: () => confirmRetract(row),
+		},
+	]
+}
+
+// Nothing the table shows changes, so the overview is left alone.
+async function resend(row: Row) {
+	await resendInvite.submit({ team: props.team.name, email: row.email })
+	if (resendInvite.error) return toast.error(resendInvite.error.message)
+	toast.success(__("Invitation resent to {0}.", [row.email]))
 }
 
 function confirmRemove(row: Row) {
@@ -81,6 +110,24 @@ function confirmRemove(row: Row) {
 			await removeMember.submit({ team: props.team.name, user: row.email })
 			emit("removed")
 			toast.success(__("{0} was removed from the team.", [row.name]))
+		},
+	})
+}
+
+function confirmRetract(row: Row) {
+	dialog.confirm({
+		title: __("Retract invitation"),
+		message: __("{0} will be told the invitation was withdrawn, and the link will stop working.", [
+			row.email,
+		]),
+		theme: "red",
+		confirmLabel: __("Retract"),
+		onConfirm: async () => {
+			await retractInvite.submit({ team: props.team.name, email: row.email })
+			// useCall settles either way, so the failure has to be rethrown to reach the dialog.
+			if (retractInvite.error) throw retractInvite.error
+			emit("removed")
+			toast.success(__("The invitation to {0} was retracted.", [row.email]))
 		},
 	})
 }
@@ -115,9 +162,12 @@ function confirmRemove(row: Row) {
 					<span v-if="!row.member" class="font-normal text-ink-gray-5">({{ __("Invited") }})</span>
 				</span>
 
-				<Dropdown v-if="canRemove(row)" :options="actionsFor(row)" align="end">
+				<Dropdown v-if="actionsFor(row).length" :options="actionsFor(row)" align="end">
 					<!-- label is the accessible name here: an icon slot makes it icon-only. -->
-					<Button variant="ghost" :label="__('Member actions')">
+					<Button
+						variant="ghost"
+						:label="row.member ? __('Member actions') : __('Invitation actions')"
+					>
 						<template #icon>
 							<span class="lucide-ellipsis size-4" />
 						</template>

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -6,6 +6,12 @@ import type { InviteOutcome, TeamOption, TeamOverview } from "@/types"
 
 const STORAGE_KEY = "buzz:current-team"
 
+// A pending invitation is addressed by team and email: core allows only one per pair.
+interface InviteAction {
+	team: string
+	email: string
+}
+
 const selectedTeamName = ref(localStorage.getItem(STORAGE_KEY) || "")
 
 const teamsResource = createResource<TeamOption[]>({
@@ -61,4 +67,21 @@ export const updateTeam = createResource({
 export function selectTeam(name: string) {
 	selectedTeamName.value = name
 	localStorage.setItem(STORAGE_KEY, name)
+}
+
+// Imperative POSTs: `immediate: false` means nothing fires until `.submit(params)`.
+export function useResendInvite() {
+	return useCall<null, InviteAction>({
+		url: "/api/v2/method/buzz.api.teams.resend_invite",
+		method: "POST",
+		immediate: false,
+	})
+}
+
+export function useRetractInvite() {
+	return useCall<null, InviteAction>({
+		url: "/api/v2/method/buzz.api.teams.retract_invite",
+		method: "POST",
+		immediate: false,
+	})
 }


### PR DESCRIPTION
## What changed

The settings team panel listed pending invitations but offered no action on them — once an
invite was sent it could not be sent again or taken back. Invite rows now get the same
ellipsis menu members have, with **Resend invitation** and **Retract invitation**.

Frappe core already implements both on `User Invitation`. What it does not do is scope them
to a team: `resend_invitation` and `cancel_invitation` gate only on `frappe.only_for(allowed_roles)`,
which is app-wide, so any Buzz User could act on any team's invitation. The two new endpoints
are thin wrappers that add the `can_manage_members(team)` check and resolve `(team, email)` to
the invitation; core does the rest, including the status guards and the notification emails.

Resending rotates the invitation key, so a previously mailed link stops working. Retracting
mails the invitee that the invitation was withdrawn, which is why it confirms first.

## Demo

![Invitation actions menu on a pending invite row](https://github.com/user-attachments/assets/06953017-cc7d-4e49-8794-55fd1d1064a1)

![Retract invitation confirm dialog](https://github.com/user-attachments/assets/2f9b05c6-b056-45bb-a6a1-edf8b8557cd0)

## Testing

`bench --site testbuzz.localhost run-tests --module buzz.api.teams.test_invitations` — 22 tests,
green. New cases cover the key rotating on resend, the invite dropping out of the overview on
retract, address normalisation, `NoPendingInvite` on an unknown or already-retracted address,
and both a Manager and another team's Owner being refused.

Manually on `buzz.localhost`: resend rotated the stored key and left the status `Pending`;
retract flipped it to `Cancelled` and the row left the list. Manager guard re-checked in the
console with a plain (non-System Manager) user — `CannotManageMembers` on both.
