### PR TITLE
feat(dashboard): pick the hosting team when creating an event

### DIFF
--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
-import { Alert, Button, ErrorMessage, resolvedColorScheme, toast, useColorScheme } from "frappe-ui"
+import {
+	Alert,
+	Avatar,
+	Button,
+	Combobox,
+	ErrorMessage,
+	resolvedColorScheme,
+	toast,
+	useColorScheme,
+} from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
-import { computed, ref } from "vue"
+import { computed, ref, watch } from "vue"
 import { useRouter } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
@@ -9,20 +18,50 @@ import EventLocation from "@/components/dashboard/events/EventLocation.vue"
 import EventSchedule from "@/components/dashboard/events/EventSchedule.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
 import { createEvent } from "@/data/events"
-import { currentTeam } from "@/data/teams"
+import { currentTeam, teams } from "@/data/teams"
 import NotFound from "@/pages/NotFound.vue"
 import type { FrappeError } from "@/types"
 import { isEndBeforeStart } from "@/utils/eventDates"
-import { canCreateEvents } from "@/utils/teamRoles"
+import { hostableTeams } from "@/utils/teamRoles"
 import { currentTimeZone } from "@/utils/timeZones"
 
 const router = useRouter()
 
 const access = useTeamAccess()
 
-// The server refuses anything below Manager, so the form is shown read-only rather than
-// letting someone fill it in and lose the work to a 403 on save.
-const canCreate = computed(() => canCreateEvents(currentTeam.value?.team_role))
+const hostTeams = computed(() => hostableTeams(teams.value))
+
+// The stored team is only the opening guess; the picker decides which team hosts this
+// event, and the choice is not written back to the switcher.
+const team = ref(currentTeam.value?.name ?? "")
+const hostTeam = computed(() => hostTeams.value.find((option) => option.name === team.value))
+
+// The teams arrive after setup, and the seed can name a team this user may not host with.
+// Watching the list rather than the match keeps the correction off its own result.
+watch(
+	hostTeams,
+	(options) => {
+		if (!options.some((option) => option.name === team.value)) {
+			team.value = options[0]?.name ?? ""
+		}
+	},
+	{ immediate: true },
+)
+
+// Every option is already a team the server would accept, so having one picked is the
+// permission. The form is shown read-only otherwise rather than letting someone fill it
+// in and lose the work to a 403 on save.
+const canCreate = computed(() => Boolean(team.value))
+
+// `logo` is not part of the option shape, but Combobox passes the whole option to the
+// row slots, so the avatar comes along without a second lookup.
+const teamOptions = computed(() =>
+	hostTeams.value.map((option) => ({
+		label: option.team_name,
+		value: option.name,
+		logo: option.logo,
+	})),
+)
 
 const { colorScheme, setColorScheme } = useColorScheme()
 // `system` resolves against the OS, so the icon shows what is on screen rather than
@@ -44,6 +83,9 @@ const endTime = ref("")
 const timeZone = ref(currentTimeZone())
 
 const venue = ref("")
+// A venue belongs to one team, and the server refuses another team's, so the answer does
+// not survive the question changing.
+watch(team, () => (venue.value = ""))
 // The Zoom meeting can only be booked once the event exists, so save has to act on this.
 const zoomMeeting = ref(false)
 
@@ -68,7 +110,7 @@ async function save() {
 
 	await createEvent.submit({
 		event: {
-			team: currentTeam.value?.name,
+			team: team.value,
 			title: title.value.trim(),
 			start_date: startDate.value,
 			start_time: startTime.value,
@@ -97,7 +139,7 @@ async function save() {
 		enter-active-class="transition-opacity duration-150 ease-out motion-reduce:transition-none"
 		enter-from-class="opacity-0"
 	>
-		<div v-if="access === 'granted'" class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
+		<div v-if="access === 'granted'" class="m-auto max-w-[800px] w-full py-8 px-4 space-y-6">
 			<header class="space-y-4">
 				<div class="flex items-center justify-between">
 					<Button
@@ -140,14 +182,50 @@ async function save() {
 
 			<EventBanner v-model="bannerImage" :seed="title" :disabled="!canCreate" />
 
-			<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
-			<input
-				v-model="title"
-				aria-label="Event title"
-				placeholder="Name your event"
-				:disabled="!canCreate"
-				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5"
-			/>
+			<div class="flex flex-col gap-2">
+				<div class="flex items-center gap-2">
+					<span class="text-base text-ink-gray-5">Hosted by</span>
+
+					<Combobox
+						v-model="team"
+						:options="teamOptions"
+						placeholder="Search teams"
+						:disabled="!canCreate"
+						:hide-search="teamOptions.length < 8"
+					>
+						<!-- Mounted inside the popover trigger, so the press opens it on its own. -->
+						<template #trigger>
+							<Button variant="ghost" :disabled="!canCreate" aria-label="Hosted by">
+								<div class="flex items-center gap-2">
+									<Avatar
+										v-if="hostTeam"
+										shape="square"
+										:image="hostTeam.logo ?? undefined"
+										:label="hostTeam.team_name"
+									/>
+									<span class="text-base font-medium text-ink-gray-8">
+										{{ hostTeam?.team_name ?? "No team" }}
+									</span>
+									<span class="lucide-chevron-down size-4 text-ink-gray-5" aria-hidden="true" />
+								</div>
+							</Button>
+						</template>
+
+						<template #item-prefix="{ item }">
+							<Avatar shape="square" :image="item.logo ?? undefined" :label="item.label" />
+						</template>
+					</Combobox>
+				</div>
+
+				<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
+				<input
+					v-model="title"
+					aria-label="Event title"
+					placeholder="Name your event"
+					:disabled="!canCreate"
+					class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5"
+				/>
+			</div>
 
 			<div class="grid gap-8 md:grid-cols-5">
 				<section class="space-y-3 md:col-span-3">
@@ -186,7 +264,7 @@ async function save() {
 						<EventLocation
 							v-model:venue="venue"
 							v-model:zoom-meeting="zoomMeeting"
-							:team="currentTeam?.name ?? ''"
+							:team="team"
 							:disabled="!canCreate"
 						/>
 					</section>

--- a/dashboard/src/utils/teamRoles.test.ts
+++ b/dashboard/src/utils/teamRoles.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { canCreateEvents, canManageMembers } from "./teamRoles.ts"
+import type { TeamOption } from "../types.ts"
+import { canCreateEvents, canManageMembers, hostableTeams } from "./teamRoles.ts"
 
 test("a manager can create events", () => {
 	assert.equal(canCreateEvents("Manager"), true)
@@ -32,4 +33,30 @@ test("an owner and an admin can manage members", () => {
 test("a manager cannot manage members", () => {
 	assert.equal(canManageMembers("Manager"), false)
 	assert.equal(canManageMembers(undefined), false)
+})
+
+const team = (name: string, team_role: string): TeamOption => ({
+	name,
+	team_name: name,
+	logo: null,
+	team_role,
+	members: [],
+})
+
+test("only teams that can create events can host one", () => {
+	const hostable = hostableTeams([
+		team("BTEAM-0001", "Owner"),
+		team("BTEAM-0002", "Viewer"),
+		team("BTEAM-0003", "Manager"),
+		team("BTEAM-0004", "Frontdesk"),
+		team("BTEAM-0005", "Admin"),
+	])
+	assert.deepEqual(
+		hostable.map((option) => option.name),
+		["BTEAM-0001", "BTEAM-0003", "BTEAM-0005"],
+	)
+})
+
+test("no teams means nothing to host with", () => {
+	assert.deepEqual(hostableTeams([]), [])
 })

--- a/dashboard/src/utils/teamRoles.ts
+++ b/dashboard/src/utils/teamRoles.ts
@@ -1,9 +1,16 @@
+import type { TeamOption } from "@/types"
+
 // Mirrors WRITE_ROLES in buzz/permissions.py, which is what the server actually enforces.
 const EVENT_WRITE_ROLES = ["Owner", "Admin", "Manager"]
 
 /** Whether a team role may create events. Used to gate the form, not to secure it. */
 export function canCreateEvents(teamRole: string | undefined): boolean {
 	return Boolean(teamRole && EVENT_WRITE_ROLES.includes(teamRole))
+}
+
+/** The teams an event can be hosted by: the ones this user may create events for. */
+export function hostableTeams(teams: TeamOption[]): TeamOption[] {
+	return teams.filter((team) => canCreateEvents(team.team_role))
 }
 
 // Mirrors ADMIN_ROLES in buzz/permissions.py; can_manage_members is the server's check.

--- a/e2e/tests/create-event.spec.ts
+++ b/e2e/tests/create-event.spec.ts
@@ -11,6 +11,7 @@ test.describe("Create event", () => {
 		await expect(page).toHaveURL(/\/b\/manage\/team\/events\/new$/, { timeout: 15000 })
 		await expect(page.getByRole("button", { name: "Add a banner" })).toBeVisible()
 		await expect(page.getByRole("textbox", { name: "Event title" })).toBeVisible()
+		await expect(page.getByRole("button", { name: "Hosted by" })).toBeVisible()
 		// Nothing is filled in yet, so the page must not offer to create anything.
 		await expect(page.getByRole("button", { name: "Create event" })).toBeDisabled()
 	})


### PR DESCRIPTION
## What changed

The create form sent `team: currentTeam?.name`, which reads `localStorage["buzz:current-team"]` — a key nothing in the app has ever written. The only thing that sets it is the fallback inside `get_my_teams`'s `onSuccess`, so a member of several teams got whichever team the query returned first and had no way to change it.

Adds a **Hosted by** picker between the banner and the title. It lists only teams whose `team_role` may create events, via a new `hostableTeams()` beside the existing `canCreateEvents` in `utils/teamRoles.ts` — same client-side mirror of `permissions.py` we already keep, no new endpoint. The selection is local to the form and is deliberately *not* written back to the stored team; nothing else in the app reads `currentTeam`, so a global switcher would be inventing a feature nobody asked for.

`canCreate` now means "a hostable team is selected" rather than "the stored team's role is high enough". The options are already filtered, so having one picked *is* the permission. A Viewer-only user gets an empty picker and the same amber alert as before.

Switching teams clears the venue. `Buzz Event.validate_venue_team` refuses a venue owned by another team, and `EventLocation` already refetches on `:team` but keeps the stale selection — so without the reset you can hand the server a venue it will reject.

No backend change. `NewEvent.team` was already required and `create_event` already validates it with `has_team_access(new.team, "create", ...)`; `host_for(team)` mints the Event Host. The picker just stops guessing on the user's behalf.

Two frappe-ui gaps left alone, since fixing them here would make this one control inconsistent with every other: `Button` has no `:active` press feedback, and `Combobox`'s popover scales from centre rather than from its trigger.

## Demo

<!-- screenshots to attach: closed row and open popover, light and dark -->

## Testing

- `yarn typecheck`, `yarn lint`, `yarn fmt:check` — clean; scoped `pre-commit run --files` on the four touched files passes
- `yarn test:unit` — 126 pass, 0 fail (2 new cases for `hostableTeams`)
- `npx playwright test e2e/tests/create-event.spec.ts --project=chromium` — 4 passed, against a local bench on `localhost:8080`
- Driven by hand in that bench as a user in two teams: picking BWH clears an already-chosen Test Team venue (`""`), and the venue list refetches to BWH's, which offers only the Zoom option
- Not run here: the rest of the e2e suite, and `bench run-tests` — no Python changed
