### PR TITLE
fix: land Buzz users on the dashboard instead of desk

### DIFF
--- a/buzz/api/teams/test_invitations.py
+++ b/buzz/api/teams/test_invitations.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import frappe
+from frappe.apps import get_default_path
 from frappe.tests import IntegrationTestCase
 
 from buzz.api.teams import get_team_overview, invite_members, resend_invite, retract_invite
@@ -298,3 +299,11 @@ class TestInviteActions(IntegrationTestCase):
 			retract_invite(team, "twice@example.com")
 		with self.assertRaises(NoPendingInvite):
 			resend_invite(team, "twice@example.com")
+
+
+class TestDefaultPath(IntegrationTestCase):
+	def test_an_invitee_setting_their_password_lands_on_the_dashboard(self):
+		"""Core sends a System User to `get_default_path()` after a password reset, ignoring
+		the invitation's own redirect. Buzz roles have no desk access, so that path has to
+		be the dashboard."""
+		self.assertEqual(get_default_path(), "/b")

--- a/buzz/hooks.py
+++ b/buzz/hooks.py
@@ -95,7 +95,7 @@ add_to_apps_screen = [
 		"name": "buzz",
 		"logo": "/assets/buzz/images/buzz-logo-rounded.png",
 		"title": "Buzz",
-		"route": "/app/buzz",
+		"route": "/b",
 		"has_permission": "buzz.api.account.has_app_permission",
 	}
 ]


### PR DESCRIPTION
## What changed

Invitee accepts an invitation, sets a password, lands on the desk workspace — 417, since Buzz roles have no desk access.

The invitation's own `/b/manage` never gets a look in: core's `User.update_password` returns `frappe.apps.get_default_path()` for a System User and discards the caller's `redirect_to`. That resolves to the `add_to_apps_screen` route of the only non-frappe app installed, which was `/app/buzz`.

Route now points at `/b`. Never only about invitations — plain login, OAuth login, session `default_path` and the `/apps` tile read the same value and were all equally wrong.

Not changed: the desk workspace, still at `/app/buzz` for anyone with desk access.

## Testing

`TestDefaultPath` asserts `get_default_path() == "/b"`. 23 tests in `buzz.api.teams.test_invitations` pass.

Local gotcha: `buzz.localhost` and `testbuzz.localhost` carry a stale `Event Co Host` doctype from `feat/create-event-team-picker` and cannot run the suite until migrated. Used `buzz2.localhost` instead of migrating away someone's data.