### PR TITLE
fix(dashboard): drop redundant word from invite action labels

### DIFF
--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -79,12 +79,12 @@ function actionsFor(row: Row) {
 function inviteActions(row: Row) {
 	return [
 		{
-			label: __("Resend invitation"),
+			label: __("Resend"),
 			icon: "lucide-arrow-up-from-line",
 			onClick: () => resend(row),
 		},
 		{
-			label: __("Retract invitation"),
+			label: __("Retract"),
 			icon: "lucide-shredder",
 			theme: "red" as const,
 			onClick: () => confirmRetract(row),


### PR DESCRIPTION
## What changed

The pending-invite row's action menu said "Resend invitation" / "Retract invitation". The menu already only appears on invite rows, so the word was noise in every entry. Now reads "Resend" and "Retract".

The retract confirmation dialog keeps its "Retract invitation" title — that one is out of the menu's context and needs to name what it is about to undo.

## Demo

Label-only text change in the team members table action menu; no layout change. Applying `skip-demo`.

## Testing

No behaviour touched, so no new tests. Existing team-members specs still pass unchanged.