### PR TITLE
feat(dashboard): rename Communications to Announcements

### DIFF
--- a/dashboard/src/components/dashboard/communications/CommunicationComposer.vue
+++ b/dashboard/src/components/dashboard/communications/CommunicationComposer.vue
@@ -23,7 +23,7 @@ const canSend = computed(() => props.canWrite && hasText(draft.value.message) &&
 		class="composer rounded-8 border border-outline-gray-2 bg-surface-white focus-within:border-outline-gray-4"
 	>
 		<p class="flex flex-wrap items-center gap-2 px-4 pt-4 text-base text-ink-gray-7">
-			Send a message to your
+			Send an announcement to your
 			<Select
 				v-model="draft.audience"
 				size="sm"

--- a/dashboard/src/components/dashboard/communications/CommunicationHistory.vue
+++ b/dashboard/src/components/dashboard/communications/CommunicationHistory.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Avatar, Badge, Tooltip, dayjsLocal } from "frappe-ui"
+import { Avatar, Badge, Icon, Tooltip, dayjsLocal } from "frappe-ui"
 
+import EmptyState from "@/components/common/EmptyState.vue"
 import type { CommunicationItem } from "@/types"
 import { excerpt } from "@/utils/communicationText"
 
@@ -51,5 +52,13 @@ const exact = (row: CommunicationItem) =>
 			</button>
 		</li>
 	</ul>
-	<p v-else class="text-base text-ink-gray-5">Nothing has been sent for this event yet.</p>
+	<EmptyState
+		v-else
+		title="No announcements yet"
+		description="Anything you send to this event's guests or speakers shows up here."
+	>
+		<template #illustration>
+			<Icon name="lucide-megaphone" class="size-8 text-ink-gray-4" />
+		</template>
+	</EmptyState>
 </template>

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -69,7 +69,7 @@ const items = computed(() => {
 		{ label: "Details", icon: "lucide-receipt-text", to: `${event}/details` },
 		{ label: "Guests", icon: "lucide-users-round", to: `${event}/guests` },
 		{ label: "Talks", icon: "lucide-presentation", to: `${event}/talks` },
-		{ label: "Communications", icon: "lucide-send", to: `${event}/communications` },
+		{ label: "Announcements", icon: "lucide-megaphone", to: `${event}/communications` },
 	]
 })
 </script>

--- a/dashboard/src/pages/manage/events/EventCommunications.vue
+++ b/dashboard/src/pages/manage/events/EventCommunications.vue
@@ -94,11 +94,11 @@ const canWrite = computed(() => !!page.data?.can_write)
 </script>
 
 <template>
-	<EventPageHeader :title="page.data?.title" section="Communications" />
+	<EventPageHeader :title="page.data?.title" section="Announcements" />
 
 	<PageWithSidebar>
 		<section class="space-y-3">
-			<h1 class="text-xl font-semibold text-ink-gray-9">Communications</h1>
+			<h1 class="text-xl font-semibold text-ink-gray-9">Announcements</h1>
 			<Skeleton v-if="page.loading && !page.data" class="h-40 w-full rounded-8" />
 			<CommunicationComposer
 				v-else

--- a/dashboard/src/pages/manage/events/EventCommunications.vue
+++ b/dashboard/src/pages/manage/events/EventCommunications.vue
@@ -98,7 +98,7 @@ const canWrite = computed(() => !!page.data?.can_write)
 
 	<PageWithSidebar>
 		<section class="space-y-3">
-			<h1 class="text-xl font-semibold text-ink-gray-9">Announcements</h1>
+			<h1 class="text-xl font-semibold text-ink-gray-9">Send an Announcement</h1>
 			<Skeleton v-if="page.loading && !page.data" class="h-40 w-full rounded-8" />
 			<CommunicationComposer
 				v-else

--- a/e2e/tests/event-communications.spec.ts
+++ b/e2e/tests/event-communications.spec.ts
@@ -42,7 +42,7 @@ test.describe("Event communications", () => {
 
 	test("sends a message to the guests and lists it", async ({ page }) => {
 		const text = `Doors open at nine ${Date.now()}`
-		await page.getByRole("heading", { name: "Communications" }).waitFor()
+		await page.getByRole("heading", { name: "Send an Announcement" }).waitFor()
 		const editor = page.locator(".composer .ProseMirror")
 		await editor.click()
 		await editor.fill(text)


### PR DESCRIPTION
## What changed

Sidebar item reads **Announcements** with a megaphone icon instead of **Communications**
with a send icon, and the page wording follows: heading "Send an Announcement", lead-in
"Send an announcement to your …". The sent list's bare grey line is now the shared
`EmptyState`.

Route (`/communications`), component names, and the API are untouched.

## Demo

| Announcements page | Empty state |
| --- | --- |
| <img width="576" alt="Announcements page with sent list" src="https://github.com/user-attachments/assets/b733ec18-0954-46d7-9564-1c7ed95fc1b2"> | <img width="576" alt="Empty state on an event with nothing sent" src="https://github.com/user-attachments/assets/a9920f0e-dfcd-419c-845a-3799156a5da8"> |

## Testing

Ran the branch locally and walked both states above. `yarn typecheck` clean. Updated the
heading selector in `e2e/tests/event-communications.spec.ts`, which asserted on
"Communications".
