### PR TITLE
feat(teams): change a member's role from the roster

### DIFF
--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -37,6 +37,11 @@ def remove_member(team: str, user: str) -> None:
 
 
 @frappe.whitelist(methods=["POST"])
+def change_role(team: str, user: str, team_role: str) -> None:
+	services.change_role(team, user, team_role)
+
+
+@frappe.whitelist(methods=["POST"])
 def invite_members(team: str, invites: list[dict]) -> list[InviteOutcome]:
 	return invitations.invite_members(team, invites)
 

--- a/buzz/api/teams/invitations.py
+++ b/buzz/api/teams/invitations.py
@@ -1,13 +1,9 @@
 import frappe
 from frappe.core.api.user_invitation import cancel_invitation, invite_by_email, resend_invitation
 
-from buzz.api.teams.exceptions import (
-	CannotGrantOwnership,
-	CannotManageMembers,
-	NoPendingInvite,
-	UnknownTeamRole,
-)
+from buzz.api.teams.exceptions import CannotManageMembers, NoPendingInvite
 from buzz.api.teams.schemas import InviteOutcome
+from buzz.api.teams.services import validate_role
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 from buzz.permissions import can_manage_members
 
@@ -32,19 +28,6 @@ def invite_members(team: str, invites: list[dict]) -> list[InviteOutcome]:
 		validate_role(invite["team_role"])
 
 	return [invite_one(team, invite) for invite in invites]
-
-
-def validate_role(team_role: str) -> None:
-	if team_role == "Owner":
-		CannotGrantOwnership.throw()
-	if team_role not in assignable_roles():
-		UnknownTeamRole.throw(team_role=team_role)
-
-
-def assignable_roles() -> list[str]:
-	"""The membership doctype's own options, minus the one nobody may be given."""
-	options = frappe.get_meta("Buzz Team Membership").get_field("team_role").options
-	return [role for role in options.split("\n") if role and role != "Owner"]
 
 
 def invite_one(team: str, invite: dict) -> InviteOutcome:

--- a/buzz/api/teams/services.py
+++ b/buzz/api/teams/services.py
@@ -1,11 +1,30 @@
 import frappe
 from frappe.query_builder import Case
 
-from buzz.api.teams.exceptions import CannotEditTeam, CannotManageMembers, NotATeamMember
+from buzz.api.teams.exceptions import (
+	CannotEditTeam,
+	CannotGrantOwnership,
+	CannotManageMembers,
+	NotATeamMember,
+	UnknownTeamRole,
+)
 from buzz.api.teams.schemas import TeamInvite, TeamMember, TeamOverview
 from buzz.permissions import can_manage_members, team_role_of
 
 TEAM_FIELDS = ("name", "team_name", "slug", "logo")
+
+
+def validate_role(team_role: str) -> None:
+	if team_role == "Owner":
+		CannotGrantOwnership.throw()
+	if team_role not in assignable_roles():
+		UnknownTeamRole.throw(team_role=team_role)
+
+
+def assignable_roles() -> list[str]:
+	"""The membership doctype's own options, minus the one nobody may be given."""
+	options = frappe.get_meta("Buzz Team Membership").get_field("team_role").options
+	return [role for role in options.split("\n") if role and role != "Owner"]
 
 
 def team_overview(team: str) -> TeamOverview:
@@ -85,6 +104,27 @@ def remove_member(team: str, user: str) -> None:
 	membership.enabled = 0
 	# Event Manager holds no write permission on the membership doctype, so the guard above
 	# is the authorization — the same shape as the Desk add-members flow.
+	membership.save(ignore_permissions=True)
+
+
+def change_role(team: str, user: str, team_role: str) -> None:
+	"""Move a member to another role.
+
+	Ownership is out of reach from both ends: `validate_role` refuses it as a target, and
+	the membership controller refuses to take it away from the row that holds it.
+	"""
+	if not can_manage_members(team):
+		CannotManageMembers.throw()
+	validate_role(team_role)
+
+	name = frappe.db.exists("Buzz Team Membership", {"team": team, "user": user, "enabled": 1})
+	if not name:
+		NotATeamMember.throw()
+
+	membership = frappe.get_doc("Buzz Team Membership", name)
+	membership.team_role = team_role
+	# Same shape as `remove_member`: the guard above is the authorization, since Event
+	# Manager holds no write permission on the membership doctype.
 	membership.save(ignore_permissions=True)
 
 

--- a/buzz/api/teams/test_teams.py
+++ b/buzz/api/teams/test_teams.py
@@ -1,8 +1,14 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from buzz.api.teams import get_my_teams, get_team_overview, remove_member, update_team
-from buzz.api.teams.exceptions import CannotEditTeam, CannotManageMembers, NotATeamMember
+from buzz.api.teams import change_role, get_my_teams, get_team_overview, remove_member, update_team
+from buzz.api.teams.exceptions import (
+	CannotEditTeam,
+	CannotGrantOwnership,
+	CannotManageMembers,
+	NotATeamMember,
+	UnknownTeamRole,
+)
 from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 
@@ -223,6 +229,128 @@ class TestRemoveMember(IntegrationTestCase):
 
 		remove_member(second, member)
 		self.assertNotIn("Event Manager", frappe.get_roles(member))
+
+
+class TestChangeRole(IntegrationTestCase):
+	# Rollback is per class, not per test — every test owns its users and its team names.
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def role(self, team: str, user: str) -> str:
+		return frappe.db.get_value("Buzz Team Membership", {"team": team, "user": user}, "team_role")
+
+	def test_an_admin_promotes_a_manager(self):
+		owner = create_user("role-owner@example.com", "Owner")
+		admin = create_user("role-admin@example.com", "Admin")
+		member = create_user("role-member@example.com", "Member")
+		team = create_owned_team("Role Promote", owner)
+		upsert_membership(team, admin, "Admin")
+		upsert_membership(team, member, "Manager")
+
+		frappe.set_user(admin)
+		change_role(team, member, "Admin")
+
+		self.assertEqual(self.role(team, member), "Admin")
+
+	def test_a_demoted_member_loses_the_desk_role_the_old_one_earned(self):
+		owner = create_user("role-demote-owner@example.com", "Owner")
+		member = create_user("role-demote-member@example.com", "Member")
+		team = create_owned_team("Role Demote", owner)
+		upsert_membership(team, member, "Manager")
+		self.assertIn("Event Manager", frappe.get_roles(member))
+
+		frappe.set_user(owner)
+		change_role(team, member, "Viewer")
+
+		self.assertNotIn("Event Manager", frappe.get_roles(member))
+
+	def test_an_admin_may_demote_another_admin(self):
+		owner = create_user("role-peer-owner@example.com", "Owner")
+		admin = create_user("role-peer-admin@example.com", "Admin")
+		peer = create_user("role-peer@example.com", "Peer")
+		team = create_owned_team("Role Peer", owner)
+		upsert_membership(team, admin, "Admin")
+		upsert_membership(team, peer, "Admin")
+
+		frappe.set_user(admin)
+		change_role(team, peer, "Viewer")
+
+		self.assertEqual(self.role(team, peer), "Viewer")
+
+	def test_a_manager_cannot_change_anyone(self):
+		owner = create_user("role-manager-owner@example.com", "Owner")
+		manager = create_user("role-manager@example.com", "Manager")
+		member = create_user("role-managers-target@example.com", "Target")
+		team = create_owned_team("Role Manager", owner)
+		upsert_membership(team, manager, "Manager")
+		upsert_membership(team, member, "Viewer")
+
+		frappe.set_user(manager)
+		with self.assertRaises(CannotManageMembers):
+			change_role(team, member, "Manager")
+
+	def test_an_outsider_cannot_change_anyone(self):
+		owner = create_user("role-outsider-owner@example.com", "Owner")
+		outsider = create_user("role-outsider@example.com", "Outsider")
+		member = create_user("role-outsiders-target@example.com", "Target")
+		team = create_owned_team("Role Outsider", owner)
+		upsert_membership(team, member, "Viewer")
+
+		frappe.set_user(outsider)
+		with self.assertRaises(CannotManageMembers):
+			change_role(team, member, "Manager")
+
+	def test_the_owner_cannot_be_given_another_role(self):
+		owner = create_user("role-locked-owner@example.com", "Owner")
+		admin = create_user("role-owners-admin@example.com", "Admin")
+		team = create_owned_team("Role Owner", owner)
+		upsert_membership(team, admin, "Admin")
+
+		frappe.set_user(admin)
+		with self.assertRaises(frappe.ValidationError):
+			change_role(team, owner, "Viewer")
+
+	def test_ownership_cannot_be_granted(self):
+		owner = create_user("role-grant-owner@example.com", "Owner")
+		member = create_user("role-grant-member@example.com", "Member")
+		team = create_owned_team("Role Grant", owner)
+		upsert_membership(team, member, "Manager")
+
+		frappe.set_user(owner)
+		with self.assertRaises(CannotGrantOwnership):
+			change_role(team, member, "Owner")
+
+	def test_an_unknown_role_is_refused(self):
+		owner = create_user("role-unknown-owner@example.com", "Owner")
+		member = create_user("role-unknown-member@example.com", "Member")
+		team = create_owned_team("Role Unknown", owner)
+		upsert_membership(team, member, "Manager")
+
+		frappe.set_user(owner)
+		with self.assertRaises(UnknownTeamRole):
+			change_role(team, member, "Overlord")
+
+	def test_refuses_a_user_who_is_not_on_the_team(self):
+		owner = create_user("role-stranger-owner@example.com", "Owner")
+		stranger = create_user("role-stranger@example.com", "Stranger")
+		team = create_owned_team("Role Stranger", owner)
+
+		frappe.set_user(owner)
+		with self.assertRaises(NotATeamMember):
+			change_role(team, stranger, "Manager")
+
+	def test_refuses_a_member_whose_membership_is_disabled(self):
+		owner = create_user("role-disabled-owner@example.com", "Owner")
+		member = create_user("role-disabled-member@example.com", "Member")
+		team = create_owned_team("Role Disabled", owner)
+		upsert_membership(team, member, "Manager")
+
+		frappe.set_user(owner)
+		remove_member(team, member)
+
+		with self.assertRaises(NotATeamMember):
+			change_role(team, member, "Viewer")
 
 
 class TestUpdateTeam(IntegrationTestCase):

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -28,6 +28,7 @@ declare module 'vue' {
     BuzzLogo: typeof import('./src/components/common/BuzzLogo.vue')['default']
     CancellationRequestDialog: typeof import('./src/components/CancellationRequestDialog.vue')['default']
     CancellationRequestNotice: typeof import('./src/components/CancellationRequestNotice.vue')['default']
+    ChangeRoleDialog: typeof import('./src/components/dashboard/teams/ChangeRoleDialog.vue')['default']
     CheckInQrDialog: typeof import('./src/components/dashboard/tickets/CheckInQrDialog.vue')['default']
     CommunicationActions: typeof import('./src/components/dashboard/communications/CommunicationActions.vue')['default']
     CommunicationComposer: typeof import('./src/components/dashboard/communications/CommunicationComposer.vue')['default']

--- a/dashboard/src/components/dashboard/teams/AddMembersDialog.vue
+++ b/dashboard/src/components/dashboard/teams/AddMembersDialog.vue
@@ -4,10 +4,8 @@ import { computed, nextTick, ref, watch } from "vue"
 
 import { inviteMembers } from "@/data/teams"
 import type { FrappeError, InviteOutcome } from "@/types"
+import { ASSIGNABLE_TEAM_ROLES } from "@/utils/teamRoles"
 
-// Mirrors the membership doctype's own options, minus Owner. The server rejects
-// anything outside this set, so a drift here fails loudly rather than silently.
-const ROLE_OPTIONS = ["Admin", "Manager", "Frontdesk", "Viewer"]
 const DEFAULT_ROLE = "Manager"
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -191,7 +189,7 @@ async function submit() {
 						v-model="row.team_role"
 						type="select"
 						aria-label="Role"
-						:options="ROLE_OPTIONS"
+						:options="ASSIGNABLE_TEAM_ROLES"
 					/>
 
 					<Button

--- a/dashboard/src/components/dashboard/teams/ChangeRoleDialog.vue
+++ b/dashboard/src/components/dashboard/teams/ChangeRoleDialog.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { Button, Dialog, ErrorMessage, FormControl, toast } from "frappe-ui"
+import { computed, ref, watch } from "vue"
+
+import { useChangeRole } from "@/data/teams"
+import type { TeamMember } from "@/types"
+import { ASSIGNABLE_TEAM_ROLES } from "@/utils/teamRoles"
+
+const props = defineProps<{ team: string; member: TeamMember | null }>()
+const isOpen = defineModel<boolean>({ required: true })
+const emit = defineEmits<{ success: [] }>()
+
+const changeRole = useChangeRole()
+const role = ref("")
+// `useCall`'s own reset only drops the submitted params, so a failure would otherwise still
+// be on screen the next time the dialog opens.
+const errorMessage = ref("")
+
+const name = computed(() => props.member?.full_name || props.member?.user || "")
+
+// The panel's role legend explains the roles; this only guards a pointless save.
+const unchanged = computed(() => !props.member || role.value === props.member.team_role)
+
+// The member arrives with the dialog, so the select is seeded on open rather than on mount.
+watch(isOpen, (open) => {
+	if (!open) return
+	role.value = props.member?.team_role ?? ""
+	errorMessage.value = ""
+})
+
+async function submit() {
+	if (!props.member || unchanged.value) return
+
+	await changeRole.submit({ team: props.team, user: props.member.user, team_role: role.value })
+	// useCall settles either way, so the failure has to be read off the composable.
+	if (changeRole.error) {
+		errorMessage.value = changeRole.error.message
+		return
+	}
+
+	emit("success")
+	isOpen.value = false
+	toast.success(__("{0} is now {1}.", [name.value, role.value]))
+}
+</script>
+
+<template>
+	<Dialog v-model="isOpen" :title="__('Change role')">
+		<div class="space-y-3">
+			<p class="text-base text-ink-gray-5">
+				{{ __("{0} keeps their place on the team, with a different set of permissions.", [name]) }}
+			</p>
+
+			<FormControl
+				v-model="role"
+				type="select"
+				:label="__('Role')"
+				:options="ASSIGNABLE_TEAM_ROLES"
+			/>
+
+			<ErrorMessage :message="errorMessage" />
+		</div>
+
+		<template #actions="{ close }">
+			<div class="flex gap-2">
+				<Button
+					variant="solid"
+					:label="__('Save')"
+					:loading="changeRole.loading"
+					:disabled="unchanged"
+					@click="submit"
+				/>
+				<Button variant="outline" :label="__('Cancel')" @click="close" />
+			</div>
+		</template>
+	</Dialog>
+</template>

--- a/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
+++ b/dashboard/src/components/dashboard/teams/ManageTeamPanel.vue
@@ -131,7 +131,7 @@ async function refresh() {
 
 				<ErrorMessage v-if="overview.error" :message="overview.error.message" />
 
-				<TeamMembersTable v-else-if="overview.data" :team="overview.data" @removed="refresh" />
+				<TeamMembersTable v-else-if="overview.data" :team="overview.data" @changed="refresh" />
 
 				<!-- Shaped like a TeamMembersTable row, so members land where the placeholders stood. -->
 				<ul v-else :aria-label="__('Loading members')" class="pt-7">

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import { Avatar, Button, Dropdown, dialog, toast } from "frappe-ui"
-import { computed } from "vue"
+import { computed, ref } from "vue"
 
+import ChangeRoleDialog from "@/components/dashboard/teams/ChangeRoleDialog.vue"
 import { session } from "@/data/session"
 import { removeMember, useResendInvite, useRetractInvite } from "@/data/teams"
 import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
 import { canManageMembers } from "@/utils/teamRoles"
 
 const props = defineProps<{ team: TeamOverview }>()
-const emit = defineEmits<{ removed: [] }>()
+// One event for both actions: the roster is reloaded either way.
+const emit = defineEmits<{ changed: [] }>()
 
 // Header and rows share one grid so the columns line up without a table element.
 const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4"
@@ -23,6 +25,9 @@ interface Row {
 }
 
 const canManage = computed(() => canManageMembers(props.team.my_role))
+
+const changing = ref<TeamMember | null>(null)
+const isChangingRole = ref(false)
 
 const resendInvite = useResendInvite()
 const retractInvite = useRetractInvite()
@@ -55,25 +60,36 @@ function inviteRow(invite: TeamInvite): Row {
 	}
 }
 
-// The owner is locked server-side, and leaving a team is its own flow rather than a
-// self-removal.
-function canRemove(row: Row) {
-	if (!canManage.value || !row.member) return false
-	return row.member.team_role !== "Owner" && row.member.user !== session.user
+// The owner is locked server-side, and changing your own standing on a team — leaving it,
+// or demoting yourself out of managing it — is not something to do from the roster.
+function canAdminister(member: TeamMember) {
+	if (!canManage.value) return false
+	return member.team_role !== "Owner" && member.user !== session.user
 }
 
-// An invitation is resent or retracted; only a member is removed.
+// An invitation is resent or retracted; a member is re-roled or removed.
 function actionsFor(row: Row) {
-	if (!row.member) return canManage.value ? inviteActions(row) : []
-	if (!canRemove(row)) return []
+	const member = row.member
+	if (!member) return canManage.value ? inviteActions(row) : []
+	if (!canAdminister(member)) return []
 	return [
 		{
-			label: __("Remove from team"),
+			label: __("Change role"),
+			icon: "lucide-refresh-ccw",
+			onClick: () => openRoleChange(member),
+		},
+		{
+			label: __("Remove"),
 			icon: "lucide-trash-2",
 			theme: "red" as const,
 			onClick: () => confirmRemove(row),
 		},
 	]
+}
+
+function openRoleChange(member: TeamMember) {
+	changing.value = member
+	isChangingRole.value = true
 }
 
 function inviteActions(row: Row) {
@@ -108,7 +124,7 @@ function confirmRemove(row: Row) {
 		// A rejected promise renders inline in the dialog, so failures need no branch here.
 		onConfirm: async () => {
 			await removeMember.submit({ team: props.team.name, user: row.email })
-			emit("removed")
+			emit("changed")
 			toast.success(__("{0} was removed from the team.", [row.name]))
 		},
 	})
@@ -126,7 +142,7 @@ function confirmRetract(row: Row) {
 			await retractInvite.submit({ team: props.team.name, email: row.email })
 			// useCall settles either way, so the failure has to be rethrown to reach the dialog.
 			if (retractInvite.error) throw retractInvite.error
-			emit("removed")
+			emit("changed")
 			toast.success(__("The invitation to {0} was retracted.", [row.email]))
 		},
 	})
@@ -175,6 +191,13 @@ function confirmRetract(row: Row) {
 				</Dropdown>
 			</li>
 		</TransitionGroup>
+
+		<ChangeRoleDialog
+			v-model="isChangingRole"
+			:team="team.name"
+			:member="changing"
+			@success="emit('changed')"
+		/>
 	</div>
 </template>
 

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -85,3 +85,11 @@ export function useRetractInvite() {
 		immediate: false,
 	})
 }
+
+export function useChangeRole() {
+	return useCall<null, { team: string; user: string; team_role: string }>({
+		url: "/api/v2/method/buzz.api.teams.change_role",
+		method: "POST",
+		immediate: false,
+	})
+}

--- a/dashboard/src/utils/teamRoles.ts
+++ b/dashboard/src/utils/teamRoles.ts
@@ -13,3 +13,7 @@ const MEMBER_WRITE_ROLES = ["Owner", "Admin"]
 export function canManageMembers(teamRole: string | undefined): boolean {
 	return Boolean(teamRole && MEMBER_WRITE_ROLES.includes(teamRole))
 }
+
+// Mirrors the membership doctype's Select options, minus Owner. The server rejects anything
+// outside this set, so a drift here fails loudly rather than silently.
+export const ASSIGNABLE_TEAM_ROLES = ["Admin", "Manager", "Frontdesk", "Viewer"]


### PR DESCRIPTION
## What changed

Team roles were set once, at invite or add time, and never again — re-inviting an
existing member leaves their role untouched, so promoting or demoting someone meant
removing them and inviting them back.

Each member row now has a **Change role** action opening a dialog with a role select.
`services.change_role` mirrors `remove_member`: `can_manage_members` guards it,
`validate_role` refuses `Owner` as a target, and the membership controller refuses to
take `Owner` away from the row that holds it. `sync_frappe_roles` already runs on
update, so a demotion drops the Desk role the old team role had earned.

Neither **Change role** nor **Remove** is offered for the Owner or for yourself — one
shared `canAdminister` gate instead of two copies of the rule. Pending invites keep
resend/retract; changing one means retract and re-invite.

`validate_role` / `assignable_roles` moved from `invitations.py` to `services.py`, and
the dashboard's role list to `teamRoles.ts`, now that two callers need each.

## Demo

Row menu — no menu at all on the Owner row, or your own:

![02-menu.png](https://github.com/user-attachments/assets/7b3e2312-89ea-4bd2-bb53-1cf2151dc183)

The dialog. `Owner` is not in the list:

![03-dialog.png](https://github.com/user-attachments/assets/907b0183-b3d8-41cb-80d6-554605246fec)

After saving:

![04-after.png](https://github.com/user-attachments/assets/c343a592-8e3e-4979-a0a3-e13a0d7f3cff)

## Testing

- `TestChangeRole` in `buzz/api/teams/test_teams.py` — 10 cases: admin promotes, admin
  demotes a peer admin, demotion drops `Event Manager`, manager/outsider refused, Owner
  as target refused, Owner as target role refused, unknown role refused, non-member and
  disabled membership refused. `run-tests --module buzz.api.teams.test_teams` — 31 pass.
- `test_invitations` (22) and `test_buzz_team_membership` (23) green, since
  `validate_role` moved.
- Manual: the screenshots above, driven end to end against a local site.
