### PR TITLE
feat(dashboard): explain what a new event still needs

### DIFF
--- a/dashboard/src/components/dashboard/events/EventLocation.vue
+++ b/dashboard/src/components/dashboard/events/EventLocation.vue
@@ -12,8 +12,8 @@ const ZOOM = "__zoom__"
 // A page that asks for the medium separately picks a venue and nothing else, so the
 // Zoom option would be a second way to answer a question already answered.
 const props = withDefaults(
-	defineProps<{ team: string; disabled?: boolean; showVirtual?: boolean }>(),
-	{ showVirtual: true },
+	defineProps<{ team: string; disabled?: boolean; showVirtual?: boolean; error?: string }>(),
+	{ showVirtual: true, error: "" },
 )
 
 const venue = defineModel<string>("venue", { default: "" })
@@ -86,8 +86,9 @@ async function onVenueCreated(name: string) {
 		v-model="selected"
 		:options="options"
 		placeholder="Search venues, or add one"
-		class="w-full mt-2"
+		class="w-full"
 		:disabled="disabled"
+		:error="error"
 	/>
 
 	<AddVenueDialog

--- a/dashboard/src/components/dashboard/events/EventSchedule.vue
+++ b/dashboard/src/components/dashboard/events/EventSchedule.vue
@@ -99,6 +99,7 @@ const zoneOptions = computed(() =>
 					<DateTimePicker v-model="startAt" :min="today" :disabled="disabled">
 						<template #trigger="{ toggle, open }">
 							<button
+								id="event-schedule-start"
 								type="button"
 								:class="[cellClass, open && 'bg-surface-gray-1']"
 								:disabled="disabled"
@@ -115,6 +116,7 @@ const zoneOptions = computed(() =>
 					<DateTimePicker v-model="endAt" :min="earliestEnd" :disabled="disabled">
 						<template #trigger="{ toggle, open }">
 							<button
+								id="event-schedule-end"
 								type="button"
 								:class="[cellClass, open && 'bg-surface-gray-1']"
 								:disabled="disabled"

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -13,6 +13,7 @@ import { currentTeam } from "@/data/teams"
 import NotFound from "@/pages/NotFound.vue"
 import type { FrappeError } from "@/types"
 import { defaultSchedule } from "@/utils/eventDates"
+import type { ChecklistItem } from "@/utils/eventValidation"
 import { eventDraftChecklist, isDraftComplete } from "@/utils/eventValidation"
 import { canCreateEvents } from "@/utils/teamRoles"
 import { currentTimeZone } from "@/utils/timeZones"
@@ -102,6 +103,11 @@ const saveAttempted = ref(false)
 
 const missingItems = computed(() => checklist.value.filter((item) => !item.done))
 
+function iconColor(item: ChecklistItem) {
+	if (item.done) return "text-ink-green-7"
+	return saveAttempted.value ? "text-ink-red-7" : "text-ink-gray-6"
+}
+
 // Combobox draws its own error region, so Where says what it is missing in place.
 const locationError = computed(() =>
 	saveAttempted.value && !venue.value && !zoomMeeting.value
@@ -116,7 +122,9 @@ const listFormat = new Intl.ListFormat("en", { style: "long", type: "conjunction
 // The checklist is a summary; the fields themselves have to show which one is meant.
 function focusFirstMissing() {
 	const target = document.getElementById(missingItems.value[0]?.field ?? "")
-	target?.scrollIntoView({ behavior: "smooth", block: "center" })
+	// A full-page smooth scroll is exactly the motion a vestibular user turns off.
+	const smooth = !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	target?.scrollIntoView({ behavior: smooth ? "smooth" : "auto", block: "center" })
 	const focusable = target?.matches("input") ? target : target?.querySelector("input, button")
 	;(focusable as HTMLElement | null)?.focus({ preventScroll: true })
 }
@@ -279,16 +287,10 @@ async function save() {
 						:key="item.label"
 						class="flex items-center gap-2 text-base text-ink-gray-8"
 					>
+						<!-- A row turning green is the only reward in this flow; a hard cut spends it. -->
 						<span
-							class="size-4 shrink-0"
-							:class="[
-								item.done ? 'lucide-check' : 'lucide-x',
-								item.done
-									? 'text-ink-green-7'
-									: saveAttempted
-										? 'text-ink-red-7'
-										: 'text-ink-gray-6',
-							]"
+							class="size-4 shrink-0 transition-colors duration-150 ease-out motion-reduce:transition-none"
+							:class="[item.done ? 'lucide-check' : 'lucide-x', iconColor(item)]"
 							aria-hidden="true"
 						/>
 						<span>{{ item.label }}</span>

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -18,6 +18,8 @@ import { eventDraftChecklist, isDraftComplete } from "@/utils/eventValidation"
 import { canCreateEvents } from "@/utils/teamRoles"
 import { currentTimeZone } from "@/utils/timeZones"
 
+const MANAGER_REQUIRED = "Ask an admin to make you a Manager to create events."
+
 const router = useRouter()
 
 const access = useTeamAccess()
@@ -111,7 +113,7 @@ function iconColor(item: ChecklistItem) {
 // Combobox draws its own error region, so Where says what it is missing in place.
 const locationError = computed(() =>
 	saveAttempted.value && !venue.value && !zoomMeeting.value
-		? "Pick a venue or an online meeting"
+		? "Pick a venue, or create a Zoom meeting"
 		: "",
 )
 
@@ -125,14 +127,19 @@ function focusFirstMissing() {
 	// A full-page smooth scroll is exactly the motion a vestibular user turns off.
 	const smooth = !window.matchMedia("(prefers-reduced-motion: reduce)").matches
 	target?.scrollIntoView({ behavior: smooth ? "smooth" : "auto", block: "center" })
-	const focusable = target?.matches("input") ? target : target?.querySelector("input, button")
+	const focusable = target?.matches("input, button")
+		? target
+		: target?.querySelector("input, button")
 	;(focusable as HTMLElement | null)?.focus({ preventScroll: true })
 }
 
 // The button stays live and the checklist says what is still missing, rather than
 // leaving the organiser to guess what would enable it.
 async function save() {
-	if (!canCreate.value) return
+	if (!canCreate.value) {
+		toast.error(MANAGER_REQUIRED)
+		return
+	}
 	saveAttempted.value = true
 	if (!isDraftComplete(draft.value)) {
 		// Labels are sentence-cased for the list, which reads as one sentence.
@@ -200,7 +207,7 @@ async function save() {
 					 click that explains the state. The checklist is named instead. -->
 					<Button
 						variant="solid"
-						label="Create event"
+						label="Create"
 						:loading="createEvent.loading"
 						aria-describedby="event-requirements"
 						@click="save"
@@ -214,7 +221,7 @@ async function save() {
 				v-if="!canCreate"
 				theme="amber"
 				title="You cannot create events"
-				description="Ask an admin to make you a Manager to create events."
+				:description="MANAGER_REQUIRED"
 				:dismissible="false"
 			/>
 
@@ -253,7 +260,6 @@ async function save() {
 
 				<div class="space-y-8 md:col-span-2">
 					<EventSchedule
-						id="event-schedule"
 						:disabled="!canCreate"
 						v-model:start-date="startDate"
 						v-model:start-time="startTime"

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { Alert, Button, ErrorMessage, resolvedColorScheme, toast, useColorScheme } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
-import { computed, ref } from "vue"
-import { useRouter } from "vue-router"
+import { computed, onBeforeUnmount, onMounted, ref } from "vue"
+import { onBeforeRouteLeave, useRouter } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
 import EventLocation from "@/components/dashboard/events/EventLocation.vue"
@@ -12,7 +12,8 @@ import { createEvent } from "@/data/events"
 import { currentTeam } from "@/data/teams"
 import NotFound from "@/pages/NotFound.vue"
 import type { FrappeError } from "@/types"
-import { isEndBeforeStart } from "@/utils/eventDates"
+import { defaultSchedule } from "@/utils/eventDates"
+import { eventDraftChecklist, isDraftComplete } from "@/utils/eventValidation"
 import { canCreateEvents } from "@/utils/teamRoles"
 import { currentTimeZone } from "@/utils/timeZones"
 
@@ -35,10 +36,12 @@ const isDark = computed(
 const title = ref("")
 const about = ref("")
 const bannerImage = ref("")
-const startDate = ref("")
-const startTime = ref("")
-const endDate = ref("")
-const endTime = ref("")
+
+const opening = defaultSchedule()
+const startDate = ref(opening.startDate)
+const startTime = ref(opening.startTime)
+const endDate = ref(opening.endDate)
+const endTime = ref(opening.endTime)
 // The organiser's own zone is the safe opening guess; they change it if the event is
 // somewhere else.
 const timeZone = ref(currentTimeZone())
@@ -47,24 +50,89 @@ const venue = ref("")
 // The Zoom meeting can only be booked once the event exists, so save has to act on this.
 const zoomMeeting = ref(false)
 
-// About is optional: an event needs a name, when it runs, and where.
-const canSave = computed(() =>
-	Boolean(
-		canCreate.value &&
-		title.value.trim() &&
-		startDate.value &&
-		startTime.value &&
-		endTime.value &&
-		!isEndBeforeStart(startDate.value, endDate.value, startTime.value, endTime.value) &&
-		(venue.value || zoomMeeting.value),
-	),
-)
+const draft = computed(() => ({
+	title: title.value,
+	startDate: startDate.value,
+	startTime: startTime.value,
+	endDate: endDate.value,
+	endTime: endTime.value,
+	venue: venue.value,
+	zoomMeeting: zoomMeeting.value,
+}))
+
+const checklist = computed(() => eventDraftChecklist(draft.value))
 
 // createResource types its error as {}, so the message needs narrowing.
 const errorMessage = computed(() => (createEvent.error as FrappeError | null)?.messages?.join("\n"))
 
+// The time zone and the opening slot come pre-filled, so they say nothing about whether
+// the organiser has started — only a schedule moved off those defaults does.
+const isDirty = computed(() =>
+	Boolean(
+		title.value ||
+		about.value ||
+		bannerImage.value ||
+		venue.value ||
+		zoomMeeting.value ||
+		startDate.value !== opening.startDate ||
+		startTime.value !== opening.startTime ||
+		endDate.value !== opening.endDate ||
+		endTime.value !== opening.endTime,
+	),
+)
+
+// Set once the event exists: the form is no longer worth keeping, and the redirect that
+// follows must not be challenged.
+const created = ref(false)
+
+// Nothing here autosaves, so leaving with a draft in hand has to be deliberate.
+const LEAVE_WARNING = "You have unsaved changes. Leave without saving?"
+
+function warnOnUnload(unload: BeforeUnloadEvent) {
+	if (isDirty.value && !created.value) unload.preventDefault()
+}
+
+onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
+onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
+onBeforeRouteLeave(() => !isDirty.value || created.value || window.confirm(LEAVE_WARNING))
+
+// Nothing is marked wrong until the organiser has asked to save; before that the
+// checklist reads as a plan, not as four errors about work they have not started.
+const saveAttempted = ref(false)
+
+const missingItems = computed(() => checklist.value.filter((item) => !item.done))
+
+// Combobox draws its own error region, so Where says what it is missing in place.
+const locationError = computed(() =>
+	saveAttempted.value && !venue.value && !zoomMeeting.value
+		? "Pick a venue or an online meeting"
+		: "",
+)
+
+// "a, b, and c" — the toast has to name the fields, since the checklist may be scrolled
+// out of view and never reaches assistive tech on its own.
+const listFormat = new Intl.ListFormat("en", { style: "long", type: "conjunction" })
+
+// The checklist is a summary; the fields themselves have to show which one is meant.
+function focusFirstMissing() {
+	const target = document.getElementById(missingItems.value[0]?.field ?? "")
+	target?.scrollIntoView({ behavior: "smooth", block: "center" })
+	const focusable = target?.matches("input") ? target : target?.querySelector("input, button")
+	;(focusable as HTMLElement | null)?.focus({ preventScroll: true })
+}
+
+// The button stays live and the checklist says what is still missing, rather than
+// leaving the organiser to guess what would enable it.
 async function save() {
-	if (!canSave.value) return
+	if (!canCreate.value) return
+	saveAttempted.value = true
+	if (!isDraftComplete(draft.value)) {
+		// Labels are sentence-cased for the list, which reads as one sentence.
+		const names = missingItems.value.map((item) => item.label.toLowerCase())
+		toast.error(`Add ${listFormat.format(names)}`)
+		focusFirstMissing()
+		return
+	}
 
 	await createEvent.submit({
 		event: {
@@ -83,6 +151,7 @@ async function save() {
 	})
 	if (createEvent.error) return
 
+	created.value = true
 	toast.success(`${createEvent.data?.title} created`)
 	router.push({ name: "event-details", params: { eventId: createEvent.data?.name } })
 }
@@ -118,11 +187,14 @@ async function save() {
 
 				<div class="flex items-center justify-between gap-4">
 					<h1 class="text-2xl font-semibold text-ink-gray-9">Create event</h1>
+					<!-- Enabled even when incomplete, so the click can say what is missing. No
+					 aria-disabled: that reads as disabled to assistive tech and blocks the very
+					 click that explains the state. The checklist is named instead. -->
 					<Button
 						variant="solid"
 						label="Create event"
-						:disabled="!canSave"
 						:loading="createEvent.loading"
+						aria-describedby="event-requirements"
 						@click="save"
 					/>
 				</div>
@@ -142,11 +214,13 @@ async function save() {
 
 			<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
 			<input
+				id="event-title"
 				v-model="title"
 				aria-label="Event title"
 				placeholder="Name your event"
 				:disabled="!canCreate"
-				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5"
+				:aria-invalid="saveAttempted && !title.trim()"
+				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5 aria-invalid:placeholder:text-ink-red-4"
 			/>
 
 			<div class="grid gap-8 md:grid-cols-5">
@@ -171,6 +245,7 @@ async function save() {
 
 				<div class="space-y-8 md:col-span-2">
 					<EventSchedule
+						id="event-schedule"
 						:disabled="!canCreate"
 						v-model:start-date="startDate"
 						v-model:start-time="startTime"
@@ -179,19 +254,48 @@ async function save() {
 						v-model:time-zone="timeZone"
 					/>
 
-					<section class="space-y-8">
-						<label class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
-							Where
-						</label>
+					<section id="event-location" class="space-y-3">
+						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
 						<EventLocation
 							v-model:venue="venue"
 							v-model:zoom-meeting="zoomMeeting"
 							:team="currentTeam?.name ?? ''"
 							:disabled="!canCreate"
+							:error="locationError"
 						/>
 					</section>
 				</div>
 			</div>
+			<!-- The colour rides on the icon alone: the label stays at full contrast, so the
+			 row still reads when the two hues do not. -->
+			<section id="event-requirements" class="space-y-3 rounded-6 bg-surface-gray-1/90 p-4">
+				<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
+					{{ missingItems.length ? "Still needed" : "Ready to create" }}
+				</h2>
+
+				<ul class="space-y-2" aria-live="polite">
+					<li
+						v-for="item in checklist"
+						:key="item.label"
+						class="flex items-center gap-2 text-base text-ink-gray-8"
+					>
+						<span
+							class="size-4 shrink-0"
+							:class="[
+								item.done ? 'lucide-check' : 'lucide-x',
+								item.done
+									? 'text-ink-green-7'
+									: saveAttempted
+										? 'text-ink-red-7'
+										: 'text-ink-gray-6',
+							]"
+							aria-hidden="true"
+						/>
+						<span>{{ item.label }}</span>
+						<span class="sr-only">{{ item.done ? "done" : "missing" }}</span>
+					</li>
+				</ul>
+			</section>
 		</div>
 	</Transition>
 </template>

--- a/dashboard/src/utils/eventDates.ts
+++ b/dashboard/src/utils/eventDates.ts
@@ -47,3 +47,29 @@ export function isEndBeforeStart(
 	if (endDate && endDate !== startDate) return false
 	return normalizedTime(endTime) <= normalizedTime(startTime)
 }
+
+const pad = (value: number) => String(value).padStart(2, "0")
+
+const localDate = (at: Date) => `${at.getFullYear()}-${pad(at.getMonth() + 1)}-${pad(at.getDate())}`
+
+const localTime = (at: Date) => `${pad(at.getHours())}:00:00`
+
+/**
+ * The schedule a new event opens with: the next full hour, running for an hour.
+ *
+ * An organiser creating an event now is almost always scheduling one soon, so the form
+ * starts from a plausible slot rather than from nothing. Reads in local time, which is
+ * the same zone the form pre-selects.
+ */
+export function defaultSchedule(now: Date = new Date()) {
+	const start = new Date(now)
+	start.setMinutes(0, 0, 0)
+	start.setHours(start.getHours() + 1)
+	const end = new Date(start.getTime() + 60 * 60 * 1000)
+	return {
+		startDate: localDate(start),
+		startTime: localTime(start),
+		endDate: localDate(end),
+		endTime: localTime(end),
+	}
+}

--- a/dashboard/src/utils/eventDates.ts
+++ b/dashboard/src/utils/eventDates.ts
@@ -65,7 +65,10 @@ export function defaultSchedule(now: Date = new Date()) {
 	const start = new Date(now)
 	start.setMinutes(0, 0, 0)
 	start.setHours(start.getHours() + 1)
-	const end = new Date(start.getTime() + 60 * 60 * 1000)
+	// Wall clock, not elapsed milliseconds: on a DST fall-back day the hour after 01:00
+	// is 01:00 again, which would leave the event ending exactly when it starts.
+	const end = new Date(start)
+	end.setHours(end.getHours() + 1)
 	return {
 		startDate: localDate(start),
 		startTime: localTime(start),

--- a/dashboard/src/utils/eventValidation.ts
+++ b/dashboard/src/utils/eventValidation.ts
@@ -36,18 +36,14 @@ export function eventDraftChecklist(draft: EventDraft): ChecklistItem[] {
 		{
 			label: "Start date and time",
 			done: Boolean(draft.startDate && draft.startTime),
-			field: "event-schedule",
+			field: "event-schedule-start",
 		},
-		{ label: "End time", done: Boolean(draft.endTime), field: "event-schedule" },
-		{
-			label: "Venue or online meeting",
-			done: Boolean(draft.venue || draft.zoomMeeting),
-			field: "event-location",
-		},
+		{ label: "End time", done: Boolean(draft.endTime), field: "event-schedule-end" },
+		{ label: "Venue", done: Boolean(draft.venue || draft.zoomMeeting), field: "event-location" },
 		// A schedule nobody has filled in yet cannot run backwards, so this only earns a row
 		// once it can actually fail.
 		...(endsBeforeItStarts
-			? [{ label: "Ends after it starts", done: false, field: "event-schedule" }]
+			? [{ label: "Ends after it starts", done: false, field: "event-schedule-end" }]
 			: []),
 	]
 }

--- a/dashboard/src/utils/eventValidation.ts
+++ b/dashboard/src/utils/eventValidation.ts
@@ -1,0 +1,57 @@
+import { isEndBeforeStart } from "./eventDates.ts"
+
+export interface EventDraft {
+	title: string
+	startDate: string
+	startTime: string
+	endDate: string
+	endTime: string
+	venue: string
+	zoomMeeting: boolean
+}
+
+export interface ChecklistItem {
+	label: string
+	done: boolean
+	/** Element id the save handler focuses when this is what is missing. */
+	field: string
+}
+
+/**
+ * What an event needs before it can be created, and what the draft already has.
+ *
+ * Shown as a live checklist rather than enforced by a disabled button, so the organiser
+ * can see which field is holding the save back. About and the banner are optional: an
+ * event needs a name, when it runs, and where.
+ */
+export function eventDraftChecklist(draft: EventDraft): ChecklistItem[] {
+	const endsBeforeItStarts = isEndBeforeStart(
+		draft.startDate,
+		draft.endDate,
+		draft.startTime,
+		draft.endTime,
+	)
+	return [
+		{ label: "Name", done: Boolean(draft.title.trim()), field: "event-title" },
+		{
+			label: "Start date and time",
+			done: Boolean(draft.startDate && draft.startTime),
+			field: "event-schedule",
+		},
+		{ label: "End time", done: Boolean(draft.endTime), field: "event-schedule" },
+		{
+			label: "Venue or online meeting",
+			done: Boolean(draft.venue || draft.zoomMeeting),
+			field: "event-location",
+		},
+		// A schedule nobody has filled in yet cannot run backwards, so this only earns a row
+		// once it can actually fail.
+		...(endsBeforeItStarts
+			? [{ label: "Ends after it starts", done: false, field: "event-schedule" }]
+			: []),
+	]
+}
+
+export function isDraftComplete(draft: EventDraft): boolean {
+	return eventDraftChecklist(draft).every((item) => item.done)
+}

--- a/e2e/tests/create-event.spec.ts
+++ b/e2e/tests/create-event.spec.ts
@@ -11,7 +11,11 @@ test.describe("Create event", () => {
 		await expect(page).toHaveURL(/\/b\/manage\/team\/events\/new$/, { timeout: 15000 })
 		await expect(page.getByRole("button", { name: "Add a banner" })).toBeVisible()
 		await expect(page.getByRole("textbox", { name: "Event title" })).toBeVisible()
-		// Nothing is filled in yet, so the page must not offer to create anything.
-		await expect(page.getByRole("button", { name: "Create event" })).toBeDisabled()
+		// Nothing is filled in yet, so the button stays live and says what is missing
+		// rather than leaving the organiser guessing what would enable it.
+		const create = page.getByRole("button", { name: "Create event" })
+		await expect(create).toBeEnabled()
+		await create.click()
+		await expect(page.getByText("Add name, start date and time")).toBeVisible()
 	})
 })

--- a/e2e/tests/create-event.spec.ts
+++ b/e2e/tests/create-event.spec.ts
@@ -13,9 +13,10 @@ test.describe("Create event", () => {
 		await expect(page.getByRole("textbox", { name: "Event title" })).toBeVisible()
 		// Nothing is filled in yet, so the button stays live and says what is missing
 		// rather than leaving the organiser guessing what would enable it.
-		const create = page.getByRole("button", { name: "Create event" })
+		const create = page.getByRole("button", { name: "Create", exact: true })
 		await expect(create).toBeEnabled()
 		await create.click()
-		await expect(page.getByText("Add name, start date and time")).toBeVisible()
+		// The schedule is pre-filled, so only the name and the venue are outstanding.
+		await expect(page.getByText("Add name and venue")).toBeVisible()
 	})
 })


### PR DESCRIPTION
Closes #428.

## What changed

- **Create event is always enabled.** It was disabled until the form validated, so nothing said which field would enable it.
- **Clicking it while incomplete** names the missing fields in a toast — "Add name and venue" — then scrolls to the first one and focuses it. The scroll respects `prefers-reduced-motion`.
- **A "Still needed" checklist** tracks the four requirements and flips to "Ready to create" once met. Rows stay neutral until the first save attempt, so an untouched form does not open with four errors.
- **Colour rides on the icon alone**, labels stay `text-ink-gray-8`. The first cut coloured whole rows `ink-red-5` / `ink-green-5` — 2.69–4.24:1 light, 3.10–3.44:1 dark, both fail AA. The `-7` icons measure 4.72:1 or better in both themes.
- **Accessibility:** Where gets an inline error via Combobox's `error` prop, the title input gets `aria-invalid`, and the checklist is an `aria-live` region the button points at with `aria-describedby`. No `aria-disabled` — it reads as disabled to assistive tech and blocks the click that explains the state.
- **The schedule opens on the next full hour**, running for an hour, so two of the four requirements start met. Rolls day/month/year over correctly and uses wall-clock arithmetic so a DST fall-back hour does not end where it starts.
- **Leaving with an unsaved draft asks first**, reusing the guard already on EventDetails.

## Demo

Arrival — schedule pre-filled, nothing marked wrong yet:

![Arrival](https://raw.githubusercontent.com/bwhtech/buzz/ba7a47d2002a5bc9371e67d2564cbe7a8b6039c5/pr-screenshots/01-arrival.png)

After clicking Create event with fields missing:

![Missing fields](https://raw.githubusercontent.com/bwhtech/buzz/ba7a47d2002a5bc9371e67d2564cbe7a8b6039c5/pr-screenshots/02-missing-fields.png)

Complete draft:

![Complete](https://raw.githubusercontent.com/bwhtech/buzz/ba7a47d2002a5bc9371e67d2564cbe7a8b6039c5/pr-screenshots/03-complete.png)

Dark theme:

![Dark](https://raw.githubusercontent.com/bwhtech/buzz/ba7a47d2002a5bc9371e67d2564cbe7a8b6039c5/pr-screenshots/04-dark.png)

Screenshots live on the `assets/create-event-checklist` branch, not in this diff.

## Testing

- `e2e/tests/create-event.spec.ts` updated — it asserted `toBeDisabled()`, now asserts the button is enabled and that clicking it surfaces the toast. Passes locally.
- `yarn test:unit` (128 pass), `vue-tsc --noEmit` clean, oxlint + oxfmt clean.
- Manual: default schedule at 17:0x renders "7 Sep, 18:00" / "7 Sep, 19:00"; the dirty guard prompts on Back with a title typed and stays silent on an untouched form; contrast ratios above measured in-page against the composited background, light and dark.
