### PR TITLE
feat(dashboard): keep unsaved event details across tab switches

### DIFF
--- a/dashboard/src/composables/useFormDraft.ts
+++ b/dashboard/src/composables/useFormDraft.ts
@@ -1,4 +1,4 @@
-import { useLocalStorage } from "@vueuse/core"
+import { StorageSerializers, useLocalStorage } from "@vueuse/core"
 import { type Ref, watch } from "vue"
 
 import { type DraftOutcome, type StoredDraft, matches, restoredDraft } from "@/utils/formDraft"
@@ -12,7 +12,12 @@ import { type DraftOutcome, type StoredDraft, matches, restoredDraft } from "@/u
  * @param baseline - the clean document the form is compared against
  */
 export function useFormDraft<T extends object>(key: string, form: T, baseline: Ref<T>) {
-	const stored = useLocalStorage<Partial<StoredDraft<T>>>(key, {})
+	// Null rather than an empty object once the form is clean: vueuse only drops the key
+	// on null, and a browser that opens many documents should not keep one entry each. A
+	// null default leaves it guessing the serializer, and it guesses String.
+	const stored = useLocalStorage<Partial<StoredDraft<T>> | null>(key, null, {
+		serializer: StorageSerializers.object,
+	})
 	// Read once, up front: the page's own load rewrites the form, and the watcher below
 	// would drop the draft as clean before anyone asked for it back.
 	let onOpen: Partial<StoredDraft<T>> = { ...stored.value }
@@ -22,7 +27,7 @@ export function useFormDraft<T extends object>(key: string, form: T, baseline: R
 		() => {
 			const edited = { ...form }
 			const clean = { ...baseline.value }
-			stored.value = matches(edited, clean) ? {} : { baseline: clean, form: edited }
+			stored.value = matches(edited, clean) ? null : { baseline: clean, form: edited }
 		},
 		{ deep: true },
 	)
@@ -35,7 +40,7 @@ export function useFormDraft<T extends object>(key: string, form: T, baseline: R
 	function restore(): DraftOutcome<T>["status"] {
 		const outcome = restoredDraft(onOpen, baseline.value)
 		onOpen = {}
-		if (outcome.status === "restored") Object.assign(form, outcome.form)
+		if (outcome.status !== "none") Object.assign(form, outcome.form)
 		return outcome.status
 	}
 

--- a/dashboard/src/composables/useFormDraft.ts
+++ b/dashboard/src/composables/useFormDraft.ts
@@ -1,0 +1,43 @@
+import { useLocalStorage } from "@vueuse/core"
+import { type Ref, watch } from "vue"
+
+import { type DraftOutcome, type StoredDraft, matches, restoredDraft } from "@/utils/formDraft"
+
+/**
+ * Keeps a form's unsaved edits in localStorage, so leaving the page for another tab —
+ * or reloading — does not eat them.
+ *
+ * @param key - storage key; scope it to the user and the document it edits
+ * @param form - the reactive form the page edits
+ * @param baseline - the clean document the form is compared against
+ */
+export function useFormDraft<T extends object>(key: string, form: T, baseline: Ref<T>) {
+	const stored = useLocalStorage<Partial<StoredDraft<T>>>(key, {})
+	// Read once, up front: the page's own load rewrites the form, and the watcher below
+	// would drop the draft as clean before anyone asked for it back.
+	let onOpen: Partial<StoredDraft<T>> = { ...stored.value }
+
+	watch(
+		[form, baseline],
+		() => {
+			const edited = { ...form }
+			const clean = { ...baseline.value }
+			stored.value = matches(edited, clean) ? {} : { baseline: clean, form: edited }
+		},
+		{ deep: true },
+	)
+
+	/**
+	 * Applies the draft this page opened with, and reports what became of it. Spent on
+	 * the first call: a later reload of the document — a save, or a discard — is the page
+	 * deliberately leaving those edits behind.
+	 */
+	function restore(): DraftOutcome<T>["status"] {
+		const outcome = restoredDraft(onOpen, baseline.value)
+		onOpen = {}
+		if (outcome.status === "restored") Object.assign(form, outcome.form)
+		return outcome.status
+	}
+
+	return { restore }
+}

--- a/dashboard/src/composables/useFormDraft.ts
+++ b/dashboard/src/composables/useFormDraft.ts
@@ -1,4 +1,4 @@
-import { StorageSerializers, useLocalStorage } from "@vueuse/core"
+import { StorageSerializers, useEventListener, useLocalStorage } from "@vueuse/core"
 import { type Ref, watch } from "vue"
 
 import { type DraftOutcome, type StoredDraft, matches, restoredDraft } from "@/utils/formDraft"
@@ -31,6 +31,14 @@ export function useFormDraft<T extends object>(key: string, form: T, baseline: R
 		},
 		{ deep: true },
 	)
+
+	// Leaving the site is the one exit the page warns about, so taking it means the draft
+	// goes too — a reload that put the text back would make the warning a lie. Written
+	// straight through: the reactive write is queued, and the document is already going.
+	// A page held for the back button is not leaving, so it keeps its draft.
+	useEventListener(window, "pagehide", (leaving: PageTransitionEvent) => {
+		if (!leaving.persisted) localStorage.removeItem(key)
+	})
 
 	/**
 	 * Applies the draft this page opened with, and reports what became of it. Spent on

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -2,7 +2,7 @@
 import { useEventListener } from "@vueuse/core"
 import { Button, ErrorMessage, Textarea, toast } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue"
+import { computed, nextTick, reactive, ref, watch } from "vue"
 import { useRoute } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
@@ -89,12 +89,12 @@ watch(
 	(detail) => detail && !isDirty.value && fill(detail),
 )
 
-// The draft is the user's own text: whether it came back or had to be let go, they are
-// told which.
+// The draft is the user's own text and always comes back; a stale one says so, because
+// it now sits on top of a change made somewhere else.
 function announceDraft(outcome: ReturnType<typeof draft.restore>) {
 	if (outcome === "restored") toast.info("Restored your unsaved changes")
 	if (outcome === "stale")
-		toast.warning("The event changed elsewhere, so your unsaved changes were dropped")
+		toast.warning("The event changed elsewhere — check your restored changes before saving")
 }
 
 const isDirty = computed(() => !matches({ ...form }, saved.value))
@@ -108,15 +108,7 @@ const canSave = computed(
 		!isEndBeforeStart(form.start_date, form.end_date, form.start_time, form.end_time),
 )
 
-// The draft only reaches this browser, so closing the site with edits in hand is still
-// worth a word — moving between the event's own sections is not.
-function warnOnUnload(unload: BeforeUnloadEvent) {
-	if (!isDirty.value) return
-	unload.preventDefault()
-}
-
-onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
-onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
+// No unload warning: edits survive a reload now, so a dialog would guard nothing.
 
 // The page's own save takes the shortcut the browser would otherwise spend on saving the
 // document — swallowed even with nothing to commit, so it never surprises mid-edit.

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -3,7 +3,7 @@ import { useEventListener } from "@vueuse/core"
 import { Button, ErrorMessage, Textarea, toast } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue"
-import { onBeforeRouteLeave, useRoute } from "vue-router"
+import { useRoute } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
 import EventDetailsSkeleton from "@/components/dashboard/events/EventDetailsSkeleton.vue"
@@ -11,18 +11,32 @@ import EventMedium from "@/components/dashboard/events/EventMedium.vue"
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
 import EventRoute from "@/components/dashboard/events/EventRoute.vue"
 import EventSchedule from "@/components/dashboard/events/EventSchedule.vue"
+import { useFormDraft } from "@/composables/useFormDraft"
 import { eventDetail, updateEvent } from "@/data/events"
+import { session } from "@/data/session"
 import type { EventDetail, FrappeError } from "@/types"
 import { isEndBeforeStart } from "@/utils/eventDates"
+import { matches } from "@/utils/formDraft"
 
 const route = useRoute()
 const eventId = route.params.eventId as string
 
 const event = eventDetail(eventId)
 
+type EventForm = ReturnType<typeof blank>
+
 // The form the page edits, and the copy it is compared against to know it is dirty.
 const form = reactive(blank())
-const saved = ref(JSON.stringify(blank()))
+const saved = ref<EventForm>(blank())
+
+// Unsaved edits outlive the page: the section tabs unmount it, and losing a half-written
+// description to a look at the guest list is not a fair trade.
+const draft = useFormDraft(
+	// Keyed by user too: a shared browser must not hand one account's edits to the next.
+	`buzz:event-details-draft:${session.user}:${eventId}`,
+	form,
+	saved,
+)
 
 function blank() {
 	return {
@@ -62,7 +76,10 @@ function fill(detail: EventDetail) {
 	})
 	// The editor rewrites its own HTML once it mounts, so the baseline is taken after
 	// that settles — otherwise the page loads already dirty.
-	nextTick().then(() => (saved.value = JSON.stringify(form)))
+	nextTick().then(() => {
+		saved.value = { ...form }
+		announceDraft(draft.restore())
+	})
 }
 
 // A dirty form outranks the fetched document: the refetch after a save would otherwise
@@ -72,7 +89,15 @@ watch(
 	(detail) => detail && !isDirty.value && fill(detail),
 )
 
-const isDirty = computed(() => JSON.stringify(form) !== saved.value)
+// The draft is the user's own text: whether it came back or had to be let go, they are
+// told which.
+function announceDraft(outcome: ReturnType<typeof draft.restore>) {
+	if (outcome === "restored") toast.info("Restored your unsaved changes")
+	if (outcome === "stale")
+		toast.warning("The event changed elsewhere, so your unsaved changes were dropped")
+}
+
+const isDirty = computed(() => !matches({ ...form }, saved.value))
 
 // The server refuses both of these, so the page should not spend a round trip finding out.
 const routeTaken = ref(false)
@@ -83,9 +108,8 @@ const canSave = computed(
 		!isEndBeforeStart(form.start_date, form.end_date, form.start_time, form.end_time),
 )
 
-// Nothing here autosaves, so leaving with edits in hand has to be deliberate.
-const LEAVE_WARNING = "You have unsaved changes. Leave without saving?"
-
+// The draft only reaches this browser, so closing the site with edits in hand is still
+// worth a word — moving between the event's own sections is not.
 function warnOnUnload(unload: BeforeUnloadEvent) {
 	if (!isDirty.value) return
 	unload.preventDefault()
@@ -93,7 +117,6 @@ function warnOnUnload(unload: BeforeUnloadEvent) {
 
 onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
 onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
-onBeforeRouteLeave(() => !isDirty.value || window.confirm(LEAVE_WARNING))
 
 // The page's own save takes the shortcut the browser would otherwise spend on saving the
 // document — swallowed even with nothing to commit, so it never surprises mid-edit.
@@ -117,7 +140,7 @@ async function save() {
 	const fieldname = Object.fromEntries(
 		Object.entries(form).map(([field, value]) => [field, value === "" ? null : value]),
 	)
-	const submitted = JSON.stringify(form)
+	const submitted = { ...form }
 
 	await updateEvent.submit({ doctype: "Buzz Event", name: eventId, fieldname })
 	if (updateEvent.error) return

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -2,7 +2,7 @@
 import { useEventListener } from "@vueuse/core"
 import { Button, ErrorMessage, Textarea, toast } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
-import { computed, nextTick, reactive, ref, watch } from "vue"
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue"
 import { useRoute } from "vue-router"
 
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
@@ -108,7 +108,16 @@ const canSave = computed(
 		!isEndBeforeStart(form.start_date, form.end_date, form.start_time, form.end_time),
 )
 
-// No unload warning: edits survive a reload now, so a dialog would guard nothing.
+// Moving between the event's own sections keeps the edits, so it passes without a word.
+// Leaving the site is the deliberate exit: it is worth a warning, and taking it drops the
+// draft, so the warning is the last chance to keep the text.
+function warnOnUnload(unload: BeforeUnloadEvent) {
+	if (!isDirty.value) return
+	unload.preventDefault()
+}
+
+onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
+onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
 
 // The page's own save takes the shortcut the browser would otherwise spend on saving the
 // document — swallowed even with nothing to commit, so it never surprises mid-edit.

--- a/dashboard/src/utils/formDraft.test.ts
+++ b/dashboard/src/utils/formDraft.test.ts
@@ -31,9 +31,16 @@ test("a draft matching the document is not an edit", () => {
 	})
 })
 
-test("a draft typed against an older document reads as stale", () => {
+test("a draft typed against an older document comes back flagged stale", () => {
 	const moved = { title: "Frappe Fest", venue: "Bengaluru" }
-	assert.deepEqual(restoredDraft({ baseline, form: edited }, moved), { status: "stale" })
+	assert.deepEqual(restoredDraft({ baseline, form: edited }, moved), {
+		status: "stale",
+		form: edited,
+	})
+})
+
+test("a stale draft the document caught up with is not an edit", () => {
+	assert.deepEqual(restoredDraft({ baseline, form: edited }, edited), { status: "none" })
 })
 
 test("a half-written entry without its baseline is dropped", () => {

--- a/dashboard/src/utils/formDraft.test.ts
+++ b/dashboard/src/utils/formDraft.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { matches, restoredDraft } from "./formDraft.ts"
+
+const baseline = { title: "Frappe Fest", venue: "" }
+const edited = { title: "Frappe Fest 2026", venue: "" }
+
+test("two snapshots of the same values match", () => {
+	assert.equal(matches(baseline, { title: "Frappe Fest", venue: "" }), true)
+})
+
+test("a changed field breaks the match", () => {
+	assert.equal(matches(baseline, edited), false)
+})
+
+test("nothing stored means nothing to restore", () => {
+	assert.deepEqual(restoredDraft({}, baseline), { status: "none" })
+})
+
+test("edits typed against this document come back", () => {
+	assert.deepEqual(restoredDraft({ baseline, form: edited }, baseline), {
+		status: "restored",
+		form: edited,
+	})
+})
+
+test("a draft matching the document is not an edit", () => {
+	assert.deepEqual(restoredDraft({ baseline, form: { ...baseline } }, baseline), {
+		status: "none",
+	})
+})
+
+test("a draft typed against an older document reads as stale", () => {
+	const moved = { title: "Frappe Fest", venue: "Bengaluru" }
+	assert.deepEqual(restoredDraft({ baseline, form: edited }, moved), { status: "stale" })
+})
+
+test("a half-written entry without its baseline is dropped", () => {
+	assert.deepEqual(restoredDraft({ form: edited }, baseline), { status: "none" })
+})

--- a/dashboard/src/utils/formDraft.ts
+++ b/dashboard/src/utils/formDraft.ts
@@ -10,8 +10,13 @@ export interface StoredDraft<T> {
 /** What a stored draft turned out to be worth. */
 export type DraftOutcome<T> =
 	| { status: "restored"; form: T }
-	/** Typed against an older copy of the document, so replaying it would undo the change. */
-	| { status: "stale" }
+	/**
+	 * Typed against an older copy of the document, so replaying it lands on top of
+	 * someone else's change. The edits still come back — a save already writes the whole
+	 * form, so restoring adds no risk the form did not carry anyway, and throwing away
+	 * text the user wrote is the worse trade.
+	 */
+	| { status: "stale"; form: T }
 	| { status: "none" }
 
 /** Value equality for two snapshots of the same form shape. */
@@ -23,6 +28,6 @@ export function matches<T>(one: T, other: T): boolean {
 export function restoredDraft<T>(stored: Partial<StoredDraft<T>>, baseline: T): DraftOutcome<T> {
 	const { baseline: typedAgainst, form } = stored
 	if (!typedAgainst || !form) return { status: "none" }
-	if (!matches(typedAgainst, baseline)) return { status: "stale" }
-	return matches(form, baseline) ? { status: "none" } : { status: "restored", form }
+	if (matches(form, baseline)) return { status: "none" }
+	return { status: matches(typedAgainst, baseline) ? "restored" : "stale", form }
 }

--- a/dashboard/src/utils/formDraft.ts
+++ b/dashboard/src/utils/formDraft.ts
@@ -1,0 +1,28 @@
+// Unsaved form edits, kept against the document they were typed on top of.
+
+export interface StoredDraft<T> {
+	/** The clean document the edits were made against. */
+	baseline: T
+	/** The form as it was last left. */
+	form: T
+}
+
+/** What a stored draft turned out to be worth. */
+export type DraftOutcome<T> =
+	| { status: "restored"; form: T }
+	/** Typed against an older copy of the document, so replaying it would undo the change. */
+	| { status: "stale" }
+	| { status: "none" }
+
+/** Value equality for two snapshots of the same form shape. */
+export function matches<T>(one: T, other: T): boolean {
+	return JSON.stringify(one) === JSON.stringify(other)
+}
+
+/** Reads a stored draft against the document as it now stands. */
+export function restoredDraft<T>(stored: Partial<StoredDraft<T>>, baseline: T): DraftOutcome<T> {
+	const { baseline: typedAgainst, form } = stored
+	if (!typedAgainst || !form) return { status: "none" }
+	if (!matches(typedAgainst, baseline)) return { status: "stale" }
+	return matches(form, baseline) ? { status: "none" } : { status: "restored", form }
+}

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -285,3 +285,75 @@ test.describe("Guest list", () => {
 		await expect(rows).toHaveCount(GUESTS.length)
 	})
 })
+
+// The details form holds edits in memory, so moving between sections used to drop them.
+// They are kept in localStorage now; this block seeds its own event rather than leaving
+// the shared one dirty for the specs above.
+test.describe("Unsaved details", () => {
+	let eventId: string
+
+	test.beforeEach(async ({ page, request }) => {
+		const team = await ensureTestTeam(request)
+		const event = await callMethod<{ name: string }>(request, "buzz.api.events.create_event", {
+			event: {
+				team,
+				title: `Draft Event ${Date.now()}`,
+				start_date: "2030-01-01",
+				start_time: "09:00:00",
+				end_time: "17:00:00",
+			},
+		})
+		eventId = String(event.name)
+		await page.goto(`/b/manage/events/${eventId}/details`)
+	})
+
+	test("keeps edits through a trip to another section, and drops them on discard", async ({
+		page,
+	}) => {
+		const description = page.getByRole("textbox", { name: "Short description" })
+		await expect(description).toBeVisible({ timeout: 15000 })
+
+		const text = `Typed but not saved ${Date.now()}`
+		await description.fill(text)
+		// Save showing is the form registering the edit, so the trip below starts dirty.
+		await expect(page.getByRole("button", { name: "Save" })).toBeVisible()
+
+		await page.getByRole("link", { name: "Guests" }).click()
+		await expect(page).toHaveURL(new RegExp(`/b/manage/events/${eventId}/guests$`))
+		await page.getByRole("link", { name: "Details" }).click()
+
+		await expect(description).toHaveValue(text, { timeout: 15000 })
+		await expect(page.getByText("Restored your unsaved changes")).toBeVisible()
+		await expect(page.getByRole("button", { name: "Save" })).toBeVisible()
+
+		// Discard is the deliberate way out, and it has to take the stored draft with it.
+		await page.getByRole("button", { name: "Discard" }).click()
+		await expect(description).toHaveValue("")
+
+		await page.getByRole("link", { name: "Guests" }).click()
+		await expect(page).toHaveURL(new RegExp(`/b/manage/events/${eventId}/guests$`))
+		await page.getByRole("link", { name: "Details" }).click()
+
+		await expect(description).toHaveValue("", { timeout: 15000 })
+		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
+	})
+
+	test("drops the draft once the edits are saved", async ({ page }) => {
+		const description = page.getByRole("textbox", { name: "Short description" })
+		await expect(description).toBeVisible({ timeout: 15000 })
+
+		const text = `Saved after a detour ${Date.now()}`
+		await description.fill(text)
+		await page.getByRole("button", { name: "Save" }).click()
+		await expect(page.getByText("Event saved")).toBeVisible()
+
+		await page.getByRole("link", { name: "Guests" }).click()
+		await expect(page).toHaveURL(new RegExp(`/b/manage/events/${eventId}/guests$`))
+		await page.getByRole("link", { name: "Details" }).click()
+
+		// The value is the event's own now, so it arrives without a draft behind it.
+		await expect(description).toHaveValue(text, { timeout: 15000 })
+		await expect(page.getByText("Restored your unsaved changes")).toHaveCount(0)
+		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
+	})
+})

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test"
 
-import { callMethod, createDoc, ensureTestTeam, getDoc } from "../helpers/frappe"
+import { callMethod, createDoc, deleteDoc, ensureTestTeam, getDoc } from "../helpers/frappe"
 
 // Runs under the shared Administrator state, whose team hosts the event seeded by
 // event.setup.ts — the one card guaranteed to carry a Manage button.
@@ -305,6 +305,12 @@ test.describe("Unsaved details", () => {
 		})
 		eventId = String(event.name)
 		await page.goto(`/b/manage/events/${eventId}/details`)
+	})
+
+	// Each run seeds its own event, so each run takes it away again rather than leaving a
+	// trail of them on the shared site.
+	test.afterEach(async ({ request }) => {
+		await deleteDoc(request, "Buzz Event", eventId).catch(() => {})
 	})
 
 	test("keeps edits through a trip to another section, and drops them on discard", async ({

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -344,6 +344,28 @@ test.describe("Unsaved details", () => {
 		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
 	})
 
+	// Leaving the site warns first, and taking that exit means the edits go with it —
+	// otherwise the reload would hand back the text the warning offered to save.
+	test("warns on reload, and drops the draft once the warning is accepted", async ({ page }) => {
+		const description = page.getByRole("textbox", { name: "Short description" })
+		await expect(description).toBeVisible({ timeout: 15000 })
+
+		await description.fill(`Typed then reloaded ${Date.now()}`)
+		await expect(page.getByRole("button", { name: "Save" })).toBeVisible()
+
+		let warned = false
+		page.on("dialog", (dialog) => {
+			warned = dialog.type() === "beforeunload"
+			return dialog.accept()
+		})
+		await page.reload()
+
+		expect(warned).toBe(true)
+		await expect(description).toHaveValue("", { timeout: 15000 })
+		await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0)
+		await expect(page.getByText("Restored your unsaved changes")).toHaveCount(0)
+	})
+
 	test("drops the draft once the edits are saved", async ({ page }) => {
 		const description = page.getByRole("textbox", { name: "Short description" })
 		await expect(description).toBeVisible({ timeout: 15000 })


### PR DESCRIPTION
## What changed

Switching from **Details** to Guests / Talks / Announcements unmounts the details page, so anything typed and unsaved was lost. The only guard was a `window.confirm` on route leave — a nag that kept nothing.

Event details now persist to `localStorage`, user- and event-scoped so a shared browser cannot hand one account's edits to the next.

- `utils/formDraft.ts` — pure `matches()` / `restoredDraft()`. A draft carries the baseline it was typed against.
- `composables/useFormDraft.ts` — `useLocalStorage`, a watcher that persists while dirty and removes the key once clean, and a single-use `restore()`.
- `EventDetails.vue` — baseline is an object, not a JSON string; `fill()` restores once the baseline settles and announces the outcome.

Section switches pass without a word — the route-leave confirm is gone. Leaving the site still warns, and taking that exit drops the draft on `pagehide`, so the warning is the last chance to keep the text rather than a nag the reload undoes.

**Stale drafts are restored, not dropped.** A draft typed against an older copy of the event comes back with a warning toast rather than being discarded. `save()` writes the whole form either way, so replaying adds no risk the dirty form did not already carry, and losing the text is the worse trade.

## Demo

**Section switch keeps the edits.** Type on Details → leave for Guests → come back.

| 1. Typed, unsaved | 2. Away on Guests | 3. Back, restored |
|---|---|---|
| ![Typed](https://raw.githubusercontent.com/bwhtech/buzz/7c292169731be19a72fb5efeac587a9103236778/pr-screenshots-438/01-typed-unsaved.png) | ![Guests](https://raw.githubusercontent.com/bwhtech/buzz/7c292169731be19a72fb5efeac587a9103236778/pr-screenshots-438/02-another-section.png) | ![Restored](https://raw.githubusercontent.com/bwhtech/buzz/7c292169731be19a72fb5efeac587a9103236778/pr-screenshots-438/03-restored.png) |

**Reload warns, and drops them.** The `beforeunload` dialog is browser chrome, so it cannot be captured — accepting it lands here.

| 4. After the accepted reload |
|---|
| ![After reload](https://raw.githubusercontent.com/bwhtech/buzz/7c292169731be19a72fb5efeac587a9103236778/pr-screenshots-438/04-after-reload.png) |

## Testing

- `formDraft.test.ts` — 8 unit cases: value equality, nothing stored, edits replayed, draft equal to the document, stale draft returned with its form, stale draft the document caught up with, half-written entry with no baseline.
- `manage-event.spec.ts` — 3 Playwright cases on a seeded event, deleted in teardown: edits survive a trip to Guests and back and are announced, then Discard clears the draft; a reload warns and lands on an empty form; and a saved edit leaves nothing to restore.
- Full file green locally: **17 passed**. `vue-tsc` clean over `src/`, `yarn build` passes.
