### PR TITLE
feat(dashboard): crop images before uploading them

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -63,6 +63,8 @@ declare module 'vue' {
     FilterBar: typeof import('./src/components/common/filters/FilterBar.vue')['default']
     FormFieldSections: typeof import('./src/components/FormFieldSections.vue')['default']
     GuestInfoDrawer: typeof import('./src/components/dashboard/events/GuestInfoDrawer.vue')['default']
+    ImageCropper: typeof import('./src/components/common/ImageCropper.vue')['default']
+    ImageCropUploader: typeof import('./src/components/common/ImageCropUploader.vue')['default']
     LanguageSwitcher: typeof import('./src/components/LanguageSwitcher.vue')['default']
     LoginDialog: typeof import('./src/components/LoginDialog.vue')['default']
     LoginRequired: typeof import('./src/components/LoginRequired.vue')['default']

--- a/dashboard/src/components/ProfileView.vue
+++ b/dashboard/src/components/ProfileView.vue
@@ -1,8 +1,11 @@
 <template>
 	<div v-if="profile" class="flex w-full items-center justify-between mb-3 sm:mb-5">
-		<FileUploader
-			@success="(file: { file_url: string }) => updateImage(file.file_url)"
+		<ImageCropUploader
+			:aspect-ratio="1"
+			shape="circle"
+			:output-width="512"
 			:validateFile="validateIsImageFile"
+			@success="(file: { file_url: string }) => updateImage(file.file_url)"
 		>
 			<template #default="{ openFileSelector, error: _error }">
 				<div class="flex items-center gap-4">
@@ -53,15 +56,16 @@
 					</div>
 				</div>
 			</template>
-		</FileUploader>
+		</ImageCropUploader>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { Avatar, Dropdown, FileUploader, createResource, toast } from "frappe-ui"
+import { Avatar, Dropdown, createResource, toast } from "frappe-ui"
 import { onMounted, ref } from "vue"
 import LucideCamera from "~icons/lucide/camera"
 
+import ImageCropUploader from "@/components/common/ImageCropUploader.vue"
 import type { FrappeError, UserInfo } from "@/types"
 import { validateIsImageFile } from "@/utils"
 

--- a/dashboard/src/components/UserSettingsDialog.vue
+++ b/dashboard/src/components/UserSettingsDialog.vue
@@ -99,14 +99,18 @@ const isDirty = computed(() => {
 const fullName = computed(() => [form.first_name, form.last_name].filter(Boolean).join(" "))
 
 // A picture has no blur: an upload or a remove is the whole gesture, so it saves itself
-// rather than leaving the organiser to find the Save button. Reopening the dialog resets
-// the form back to what is stored, which the dirty check below absorbs.
-watch(() => form.user_image, save)
+// rather than leaving the organiser to find the Save button. It sends the picture alone,
+// so a half-typed name or bio stays a draft until Save is pressed. Reopening the dialog
+// resets the form back to what is stored, which the dirty check below absorbs.
+watch(
+	() => form.user_image,
+	() => save({ user_image: form.user_image }),
+)
 
-async function save() {
+async function save(fields: Partial<Profile> = { ...form }) {
 	if (!isDirty.value) return
 	// Resolves null on failure rather than throwing; setValue.error renders inline.
-	if (!(await user.setValue.submit({ ...form }))) return
+	if (!(await user.setValue.submit(fields))) return
 
 	// full_name is derived server-side.
 	await userResource.reload()
@@ -159,7 +163,7 @@ async function save() {
 								v-if="isDirty || user.setValue.loading"
 								variant="solid"
 								:loading="user.setValue.loading"
-								@click="save"
+								@click="() => save()"
 							>
 								{{ __("Save") }}
 							</Button>

--- a/dashboard/src/components/UserSettingsDialog.vue
+++ b/dashboard/src/components/UserSettingsDialog.vue
@@ -98,7 +98,13 @@ const isDirty = computed(() => {
 
 const fullName = computed(() => [form.first_name, form.last_name].filter(Boolean).join(" "))
 
+// A picture has no blur: an upload or a remove is the whole gesture, so it saves itself
+// rather than leaving the organiser to find the Save button. Reopening the dialog resets
+// the form back to what is stored, which the dirty check below absorbs.
+watch(() => form.user_image, save)
+
 async function save() {
+	if (!isDirty.value) return
 	// Resolves null on failure rather than throwing; setValue.error renders inline.
 	if (!(await user.setValue.submit({ ...form }))) return
 

--- a/dashboard/src/components/common/AvatarUploader.vue
+++ b/dashboard/src/components/common/AvatarUploader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ErrorMessage, FileUploader, Spinner } from "frappe-ui"
+import { ErrorMessage, Spinner } from "frappe-ui"
 
+import ImageCropUploader from "@/components/common/ImageCropUploader.vue"
 import { validateIsImageFile } from "@/utils"
 
 withDefaults(
@@ -17,7 +18,10 @@ const image = defineModel<string | null>({ required: true })
 </script>
 
 <template>
-	<FileUploader
+	<ImageCropUploader
+		:aspect-ratio="1"
+		:shape="shape === 'circle' ? 'circle' : 'rect'"
+		:output-width="512"
 		:validate-file="validateIsImageFile"
 		file-types="image/*"
 		@success="(file: { file_url: string }) => (image = file.file_url)"
@@ -70,5 +74,5 @@ const image = defineModel<string | null>({ required: true })
 				</div>
 			</div>
 		</template>
-	</FileUploader>
+	</ImageCropUploader>
 </template>

--- a/dashboard/src/components/common/ImageCropUploader.vue
+++ b/dashboard/src/components/common/ImageCropUploader.vue
@@ -11,7 +11,8 @@ import ImageCropper from "@/components/common/ImageCropper.vue"
  * `validateFile` props, same `success`/`failure` emits, same slot props — so a host that
  * wants a crop swaps the tag and keeps everything else. The difference is that nothing
  * is sent until the organiser presses Save: the file picker hands over a `File`, the
- * dialog hands back a re-encoded blob, and only that blob is uploaded.
+ * dialog hands back a re-encoded blob, and only that blob is uploaded. Cancel aborts a
+ * crop that is already uploading, so a slow request cannot land after it was dismissed.
  *
  * Public by default, unlike `FileUploader`. Every image this component uploads is read
  * without a session — a banner in a ticket email, an avatar on a public event page — and
@@ -48,6 +49,7 @@ const cropper = useTemplateRef<InstanceType<typeof ImageCropper>>("cropper")
 const selected = ref<File | null>(null)
 const isOpen = ref(false)
 const pickError = ref("")
+const pending = ref<AbortController | null>(null)
 
 const accept = computed(() =>
 	Array.isArray(props.fileTypes) ? props.fileTypes.join(",") : props.fileTypes || "image/*",
@@ -85,32 +87,51 @@ function selectFile(event: Event) {
 }
 
 async function save() {
-	const blob = await cropper.value?.getCroppedBlob()
-	if (!blob) {
-		pickError.value = __("Could not crop the image")
-		return
-	}
+	pickError.value = ""
+	const controller = new AbortController()
+	pending.value = controller
 
 	try {
-		const cropped = new File([blob], croppedName(selected.value), { type: "image/jpeg" })
+		// Cropping is inside the try because a canvas export can throw on an image the
+		// browser has not finished decoding, and that belongs in the dialog, not in an
+		// unhandled rejection.
+		const blob = await cropper.value?.getCroppedBlob()
+		if (!blob) {
+			pickError.value = __("Could not crop the image")
+			return
+		}
+
+		const cropped = new File([blob], croppedName(selected.value, blob.type), { type: blob.type })
 		const file = await upload.upload(cropped, {
 			private: props.private,
 			optimize: props.optimize,
+			signal: controller.signal,
 		})
 		isOpen.value = false
 		emit("success", file)
 	} catch (uploadError) {
+		// Cancel aborts the request rather than letting it land, so its rejection is the
+		// outcome the organiser asked for, not a failure to report.
+		if (controller.signal.aborted) return
 		emit("failure", uploadError)
+	} finally {
+		if (pending.value === controller) pending.value = null
 	}
 }
 
 /** Keeps the original name recognisable in the file list, with the new extension. */
-function croppedName(file: File | null) {
+function croppedName(file: File | null, type: string) {
 	const stem = file?.name.replace(/\.[^.]+$/, "")
-	return `${stem || "image"}-cropped.jpg`
+	return `${stem || "image"}-cropped.${type === "image/png" ? "png" : "jpg"}`
 }
 
+// Every way out of the dialog lands here — Cancel, Escape, the overlay — so this is the
+// one place an upload still in flight gets abandoned rather than left to land later. The
+// reset clears the "Upload cancelled" the abort leaves behind: the organiser asked for
+// that, and reporting it back to them as an error is just noise.
 function clearFile() {
+	pending.value?.abort()
+	upload.reset()
 	selected.value = null
 }
 </script>

--- a/dashboard/src/components/common/ImageCropUploader.vue
+++ b/dashboard/src/components/common/ImageCropUploader.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { Button, Dialog, ErrorMessage, useFileUpload } from "frappe-ui"
+import { computed, ref, useTemplateRef } from "vue"
+
+import ImageCropper from "@/components/common/ImageCropper.vue"
+
+/**
+ * Pick an image, crop it, then upload what was cropped.
+ *
+ * Shaped like frappe-ui's `FileUploader` on purpose — same `fileTypes` and
+ * `validateFile` props, same `success`/`failure` emits, same slot props — so a host that
+ * wants a crop swaps the tag and keeps everything else. The difference is that nothing
+ * is sent until the organiser presses Save: the file picker hands over a `File`, the
+ * dialog hands back a re-encoded blob, and only that blob is uploaded.
+ *
+ * Public by default, unlike `FileUploader`. Every image this component uploads is read
+ * without a session — a banner in a ticket email, an avatar on a public event page — and
+ * a private file there is a broken image, not a locked one.
+ */
+const props = withDefaults(
+	defineProps<{
+		aspectRatio: number
+		shape?: "circle" | "rect"
+		outputWidth?: number
+		fileTypes?: string | string[]
+		validateFile?: (file: File) => string | void
+		private?: boolean
+		optimize?: boolean
+	}>(),
+	{
+		shape: "rect",
+		outputWidth: 1024,
+		fileTypes: "image/*",
+		validateFile: undefined,
+		private: false,
+		optimize: true,
+	},
+)
+
+const emit = defineEmits<{
+	success: [file: { file_url: string }]
+	failure: [error: unknown]
+}>()
+
+const upload = useFileUpload()
+const input = useTemplateRef<HTMLInputElement>("input")
+const cropper = useTemplateRef<InstanceType<typeof ImageCropper>>("cropper")
+const selected = ref<File | null>(null)
+const isOpen = ref(false)
+const pickError = ref("")
+
+const accept = computed(() =>
+	Array.isArray(props.fileTypes) ? props.fileTypes.join(",") : props.fileTypes || "image/*",
+)
+const uploading = computed(() => upload.isUploading.value)
+const error = computed(() => pickError.value || errorText(upload.error.value))
+
+function errorText(reason: unknown): string {
+	if (!reason) return ""
+	if (reason instanceof Error) return reason.message
+	return String(reason)
+}
+
+function openFileSelector() {
+	pickError.value = ""
+	input.value?.click()
+}
+
+function selectFile(event: Event) {
+	const target = event.target as HTMLInputElement
+	const file = target.files?.[0]
+	// Cleared straight away, so choosing the same file twice in a row still fires.
+	target.value = ""
+	if (!file) return
+
+	const message = props.validateFile?.(file)
+	if (message) {
+		pickError.value = message
+		return
+	}
+
+	upload.reset()
+	selected.value = file
+	isOpen.value = true
+}
+
+async function save() {
+	const blob = await cropper.value?.getCroppedBlob()
+	if (!blob) {
+		pickError.value = __("Could not crop the image")
+		return
+	}
+
+	try {
+		const cropped = new File([blob], croppedName(selected.value), { type: "image/jpeg" })
+		const file = await upload.upload(cropped, {
+			private: props.private,
+			optimize: props.optimize,
+		})
+		isOpen.value = false
+		emit("success", file)
+	} catch (uploadError) {
+		emit("failure", uploadError)
+	}
+}
+
+/** Keeps the original name recognisable in the file list, with the new extension. */
+function croppedName(file: File | null) {
+	const stem = file?.name.replace(/\.[^.]+$/, "")
+	return `${stem || "image"}-cropped.jpg`
+}
+
+function clearFile() {
+	selected.value = null
+}
+</script>
+
+<template>
+	<input
+		ref="input"
+		type="file"
+		class="hidden"
+		:accept="accept"
+		aria-hidden="true"
+		tabindex="-1"
+		@change="selectFile"
+	/>
+
+	<slot v-bind="{ openFileSelector, uploading, progress: upload.progress.value, error }" />
+
+	<Dialog v-model="isOpen" :title="__('Crop image')" size="xl" @after-leave="clearFile">
+		<div v-if="selected" class="space-y-5">
+			<ImageCropper
+				ref="cropper"
+				:file="selected"
+				:aspect-ratio="aspectRatio"
+				:shape="shape"
+				:output-width="outputWidth"
+			/>
+
+			<ErrorMessage :message="error" />
+
+			<div class="flex items-center justify-between gap-3">
+				<Button variant="ghost" :label="__('Reset')" @click="cropper?.resetCrop()" />
+				<div class="flex items-center gap-2">
+					<Button :label="__('Cancel')" @click="isOpen = false" />
+					<Button variant="solid" :loading="uploading" :label="__('Save')" @click="save" />
+				</div>
+			</div>
+		</div>
+	</Dialog>
+</template>

--- a/dashboard/src/components/common/ImageCropper.vue
+++ b/dashboard/src/components/common/ImageCropper.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { useElementSize } from "@vueuse/core"
 import { Button, Slider } from "frappe-ui"
-import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from "vue"
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from "vue"
 
 import { clampOffset, coverScale, rotatedSize, type Point } from "@/utils/imageCrop"
 
@@ -32,10 +33,13 @@ const dragStart = ref<Point>({ x: 0, y: 0 })
 const dragOrigin = ref<Point>({ x: 0, y: 0 })
 
 const zoom = computed(() => zoomPercent.value[0] / 100)
-const frameSize = computed(() => {
-	const width = frame.value?.getBoundingClientRect().width || 0
-	return { width, height: width / props.aspectRatio }
-})
+// Observed rather than measured once: the dialog scales as it opens, and a plain
+// getBoundingClientRect would freeze the width mid-animation and again on every resize.
+const { width: frameWidth } = useElementSize(frame)
+const frameSize = computed(() => ({
+	width: frameWidth.value,
+	height: frameWidth.value / props.aspectRatio,
+}))
 const turnedSize = computed(() =>
 	imageSize.value ? rotatedSize(imageSize.value, rotation.value) : null,
 )
@@ -48,6 +52,11 @@ const renderedSize = computed(() => {
 	const scale = baseScale.value * zoom.value
 	return { width: turnedSize.value.width * scale, height: turnedSize.value.height * scale }
 })
+
+// PNG survives as PNG so a logo keeps its transparent background — JPEG has none to
+// keep, and an unpainted canvas encodes as black. Everything else is a photograph,
+// where JPEG is far smaller for the same picture.
+const outputType = computed(() => (props.file.type === "image/png" ? "image/png" : "image/jpeg"))
 
 const wrapStyle = computed(() => ({
 	transform: `translate(-50%, -50%) translate(${offset.value.x}px, ${offset.value.y}px)`,
@@ -70,14 +79,11 @@ watch(
 		imageUrl.value = URL.createObjectURL(file)
 		imageSize.value = await readImageSize(imageUrl.value)
 		resetCrop()
-		// The frame has no width until it is laid out, and every bound is measured off it.
-		await nextTick()
-		constrain()
 	},
 	{ immediate: true },
 )
 
-watch([zoomPercent, rotation], constrain)
+watch([zoomPercent, rotation, frameWidth], constrain)
 
 onBeforeUnmount(() => {
 	releaseImageUrl()
@@ -110,7 +116,7 @@ function startDrag(event: PointerEvent) {
 }
 
 function drag(event: PointerEvent) {
-	if (dragPointer.value === null) return
+	if (event.pointerId !== dragPointer.value) return
 	offset.value = bound({
 		x: dragOrigin.value.x + event.clientX - dragStart.value.x,
 		y: dragOrigin.value.y + event.clientY - dragStart.value.y,
@@ -139,7 +145,7 @@ function bound(point: Point) {
 }
 
 /**
- * The crop, as a JPEG.
+ * The crop, re-encoded.
  *
  * The canvas replays exactly what is on screen, scaled up from the frame's rendered
  * width to the export width — so what the organiser lined up is what gets stored, and
@@ -167,7 +173,7 @@ async function getCroppedBlob(): Promise<Blob | null> {
 	context.scale(scale, scale)
 	context.drawImage(source, -size.width / 2, -size.height / 2)
 
-	return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.92))
+	return new Promise((resolve) => canvas.toBlob(resolve, outputType.value, 0.92))
 }
 
 function releaseImageUrl() {
@@ -217,11 +223,13 @@ defineExpose({ getCroppedBlob, resetCrop })
 			</div>
 
 			<!-- The mask is the crop's own outline: everything outside it is what the
-				 frame will cut off. A ring rather than a fill, so the picture underneath
+				 frame will cut off. Edge to edge, because that is the circle the avatar
+				 renderers clip with — an inset ring would promise a tighter crop than the
+				 export delivers. A ring rather than a fill, so the picture underneath
 				 stays visible while it is being placed. -->
 			<div
 				v-if="shape === 'circle'"
-				class="pointer-events-none absolute inset-[7%] rounded-full border-2 border-white shadow-[0_0_0_999px_rgba(0,0,0,0.28)]"
+				class="pointer-events-none absolute inset-0 rounded-full border-2 border-white shadow-[0_0_0_999px_rgba(0,0,0,0.28)]"
 			/>
 
 			<Button

--- a/dashboard/src/components/common/ImageCropper.vue
+++ b/dashboard/src/components/common/ImageCropper.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+import { Button, Slider } from "frappe-ui"
+import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from "vue"
+
+import { clampOffset, coverScale, rotatedSize, type Point } from "@/utils/imageCrop"
+
+const MIN_ZOOM = 100
+const MAX_ZOOM = 300
+
+const props = withDefaults(
+	defineProps<{
+		file: File
+		/** Width over height of the crop, matching the frame the image will end up in. */
+		aspectRatio: number
+		shape?: "circle" | "rect"
+		/** Long edge of the exported image; the short one follows from the ratio. */
+		outputWidth?: number
+	}>(),
+	{ shape: "rect", outputWidth: 1024 },
+)
+
+const frame = useTemplateRef<HTMLElement>("frame")
+const image = useTemplateRef<HTMLImageElement>("image")
+const imageUrl = ref("")
+const imageSize = ref<{ width: number; height: number } | null>(null)
+const offset = ref<Point>({ x: 0, y: 0 })
+const rotation = ref(0)
+// Slider works in arrays, and in whole percent so its steps land somewhere predictable.
+const zoomPercent = ref([MIN_ZOOM])
+const dragPointer = ref<number | null>(null)
+const dragStart = ref<Point>({ x: 0, y: 0 })
+const dragOrigin = ref<Point>({ x: 0, y: 0 })
+
+const zoom = computed(() => zoomPercent.value[0] / 100)
+const frameSize = computed(() => {
+	const width = frame.value?.getBoundingClientRect().width || 0
+	return { width, height: width / props.aspectRatio }
+})
+const turnedSize = computed(() =>
+	imageSize.value ? rotatedSize(imageSize.value, rotation.value) : null,
+)
+// The scale that covers the frame before the organiser zooms past it.
+const baseScale = computed(() =>
+	turnedSize.value ? coverScale(turnedSize.value, frameSize.value) : 1,
+)
+const renderedSize = computed(() => {
+	if (!turnedSize.value) return null
+	const scale = baseScale.value * zoom.value
+	return { width: turnedSize.value.width * scale, height: turnedSize.value.height * scale }
+})
+
+const wrapStyle = computed(() => ({
+	transform: `translate(-50%, -50%) translate(${offset.value.x}px, ${offset.value.y}px)`,
+}))
+// Rotation and zoom ride on the element's own transform, so the wrapper above is left
+// holding nothing but the pan — which is the only thing a drag has to change.
+const imageStyle = computed(() => {
+	if (!imageSize.value) return {}
+	return {
+		width: `${imageSize.value.width * baseScale.value}px`,
+		height: `${imageSize.value.height * baseScale.value}px`,
+		transform: `rotate(${rotation.value}deg) scale(${zoom.value})`,
+	}
+})
+
+watch(
+	() => props.file,
+	async (file) => {
+		releaseImageUrl()
+		imageUrl.value = URL.createObjectURL(file)
+		imageSize.value = await readImageSize(imageUrl.value)
+		resetCrop()
+		// The frame has no width until it is laid out, and every bound is measured off it.
+		await nextTick()
+		constrain()
+	},
+	{ immediate: true },
+)
+
+watch([zoomPercent, rotation], constrain)
+
+onBeforeUnmount(() => {
+	releaseImageUrl()
+	stopListening()
+})
+
+function resetCrop() {
+	offset.value = { x: 0, y: 0 }
+	rotation.value = 0
+	zoomPercent.value = [MIN_ZOOM]
+}
+
+function rotate() {
+	rotation.value = (rotation.value + 90) % 360
+}
+
+function nudgeZoom(delta: number) {
+	zoomPercent.value = [Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoomPercent.value[0] + delta))]
+}
+
+function startDrag(event: PointerEvent) {
+	if (!frame.value) return
+	frame.value.setPointerCapture(event.pointerId)
+	dragPointer.value = event.pointerId
+	dragStart.value = { x: event.clientX, y: event.clientY }
+	dragOrigin.value = { ...offset.value }
+	window.addEventListener("pointermove", drag)
+	window.addEventListener("pointerup", stopDrag)
+	window.addEventListener("pointercancel", stopDrag)
+}
+
+function drag(event: PointerEvent) {
+	if (dragPointer.value === null) return
+	offset.value = bound({
+		x: dragOrigin.value.x + event.clientX - dragStart.value.x,
+		y: dragOrigin.value.y + event.clientY - dragStart.value.y,
+	})
+}
+
+function stopDrag(event: PointerEvent) {
+	if (dragPointer.value !== event.pointerId) return
+	dragPointer.value = null
+	stopListening()
+}
+
+function stopListening() {
+	window.removeEventListener("pointermove", drag)
+	window.removeEventListener("pointerup", stopDrag)
+	window.removeEventListener("pointercancel", stopDrag)
+}
+
+function constrain() {
+	offset.value = bound(offset.value)
+}
+
+function bound(point: Point) {
+	if (!renderedSize.value || !frameSize.value.width) return point
+	return clampOffset(point, renderedSize.value, frameSize.value)
+}
+
+/**
+ * The crop, as a JPEG.
+ *
+ * The canvas replays exactly what is on screen, scaled up from the frame's rendered
+ * width to the export width — so what the organiser lined up is what gets stored, and
+ * nothing downstream has to know a crop happened.
+ */
+async function getCroppedBlob(): Promise<Blob | null> {
+	const source = image.value
+	const size = imageSize.value
+	const width = frameSize.value.width
+	if (!source || !size || !width) return null
+
+	const canvas = document.createElement("canvas")
+	canvas.width = props.outputWidth
+	canvas.height = Math.round(props.outputWidth / props.aspectRatio)
+	const context = canvas.getContext("2d")
+	if (!context) return null
+
+	const exportRatio = props.outputWidth / width
+	const scale = baseScale.value * zoom.value * exportRatio
+	context.translate(
+		canvas.width / 2 + offset.value.x * exportRatio,
+		canvas.height / 2 + offset.value.y * exportRatio,
+	)
+	context.rotate((rotation.value * Math.PI) / 180)
+	context.scale(scale, scale)
+	context.drawImage(source, -size.width / 2, -size.height / 2)
+
+	return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.92))
+}
+
+function releaseImageUrl() {
+	if (imageUrl.value) URL.revokeObjectURL(imageUrl.value)
+	imageUrl.value = ""
+}
+
+function readImageSize(url: string) {
+	return new Promise<{ width: number; height: number } | null>((resolve) => {
+		const probe = new Image()
+		probe.addEventListener(
+			"load",
+			() => resolve({ width: probe.naturalWidth, height: probe.naturalHeight }),
+			{ once: true },
+		)
+		probe.addEventListener("error", () => resolve(null), { once: true })
+		probe.src = url
+	})
+}
+
+defineExpose({ getCroppedBlob, resetCrop })
+</script>
+
+<template>
+	<div class="space-y-4">
+		<div
+			ref="frame"
+			class="relative w-full select-none overflow-hidden rounded-6 bg-surface-gray-3 touch-none"
+			:class="dragPointer === null ? 'cursor-grab' : 'cursor-grabbing'"
+			:style="{ aspectRatio: String(aspectRatio) }"
+			@pointerdown="startDrag"
+			@wheel.prevent="nudgeZoom($event.deltaY > 0 ? -8 : 8)"
+		>
+			<div
+				v-if="imageUrl && imageSize"
+				class="absolute left-1/2 top-1/2 will-change-transform"
+				:style="wrapStyle"
+			>
+				<img
+					ref="image"
+					:src="imageUrl"
+					alt=""
+					draggable="false"
+					class="max-w-none select-none"
+					:style="imageStyle"
+				/>
+			</div>
+
+			<!-- The mask is the crop's own outline: everything outside it is what the
+				 frame will cut off. A ring rather than a fill, so the picture underneath
+				 stays visible while it is being placed. -->
+			<div
+				v-if="shape === 'circle'"
+				class="pointer-events-none absolute inset-[7%] rounded-full border-2 border-white shadow-[0_0_0_999px_rgba(0,0,0,0.28)]"
+			/>
+
+			<Button
+				class="absolute right-3 top-3"
+				icon="lucide-rotate-cw"
+				:label="__('Rotate')"
+				@pointerdown.stop
+				@click.stop="rotate"
+			/>
+		</div>
+
+		<div class="flex items-center gap-3">
+			<Button variant="ghost" icon="lucide-minus" :label="__('Zoom out')" @click="nudgeZoom(-10)" />
+			<Slider v-model="zoomPercent" class="min-w-0 flex-1" :min="MIN_ZOOM" :max="MAX_ZOOM" />
+			<Button variant="ghost" icon="lucide-plus" :label="__('Zoom in')" @click="nudgeZoom(10)" />
+		</div>
+	</div>
+</template>

--- a/dashboard/src/components/dashboard/events/EventBanner.vue
+++ b/dashboard/src/components/dashboard/events/EventBanner.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { refDebounced } from "@vueuse/core"
-import { Button, ErrorMessage, FileUploader } from "frappe-ui"
+import { Button, ErrorMessage } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 
+import ImageCropUploader from "@/components/common/ImageCropUploader.vue"
 import { bannerPattern } from "@/utils/eventBanner"
 
 // The picker is filtered to these, and the file that comes back is checked against the
@@ -49,7 +50,12 @@ watch(image, () => {
 </script>
 
 <template>
-	<FileUploader
+	<!-- 3:1 because that is the frame below; the crop is baked into the uploaded file, so
+		 every other place the banner appears keeps its own object-cover with no extra
+		 field to carry a position. -->
+	<ImageCropUploader
+		:aspect-ratio="3"
+		:output-width="1500"
 		:file-types="IMAGE_TYPES"
 		:validate-file="validateImage"
 		@success="(file: { file_url: string }) => (image = file.file_url)"
@@ -111,5 +117,5 @@ watch(image, () => {
 			<!-- The slot types its error as {}, so the message needs narrowing. -->
 			<ErrorMessage v-if="uploadError" class="mt-2" :message="String(uploadError)" />
 		</template>
-	</FileUploader>
+	</ImageCropUploader>
 </template>

--- a/dashboard/src/pages/SponsorshipDetails.vue
+++ b/dashboard/src/pages/SponsorshipDetails.vue
@@ -147,7 +147,8 @@
 						<FileUploader
 							@success="(file: { file_url: string }) => updateLogo(file.file_url)"
 							:validateFile="validateIsImageFile"
-							:uploadArgs="logoUploadArgs"
+							:private="false"
+							folder="Home/Attachments"
 						>
 							<template #default="{ openFileSelector, error: uploadError, uploading, progress }">
 								<div class="space-y-2">
@@ -437,14 +438,6 @@ const companyName = computed(() => {
 		return sponsorDetails.value.company_name
 	}
 	return enquiryDetails.data?.enquiry?.company_name || ""
-})
-
-// Upload arguments for file uploader
-const logoUploadArgs = computed(() => {
-	return {
-		private: false,
-		folder: "Home/Attachments",
-	}
 })
 
 const getStatusTheme = (status: string) => {

--- a/dashboard/src/utils/imageCrop.test.ts
+++ b/dashboard/src/utils/imageCrop.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { clampOffset, coverScale, rotatedSize } from "./imageCrop.ts"
+
+test("a half turn leaves the footprint alone", () => {
+	assert.deepEqual(rotatedSize({ width: 400, height: 300 }, 180), { width: 400, height: 300 })
+})
+
+test("a quarter turn swaps the axes", () => {
+	assert.deepEqual(rotatedSize({ width: 400, height: 300 }, 90), { width: 300, height: 400 })
+})
+
+test("a negative quarter turn swaps them the same way", () => {
+	assert.deepEqual(rotatedSize({ width: 400, height: 300 }, -90), { width: 300, height: 400 })
+})
+
+test("a landscape image covering a 3:1 frame is scaled by its width", () => {
+	// 600x400 into 300x100: fitting the height would need 0.25 and leave the width short.
+	assert.equal(coverScale({ width: 600, height: 400 }, { width: 300, height: 100 }), 0.5)
+})
+
+test("a wide image covering a square frame is scaled by its height", () => {
+	assert.equal(coverScale({ width: 800, height: 200 }, { width: 300, height: 300 }), 1.5)
+})
+
+test("an image with no dimensions yet falls back to unscaled", () => {
+	assert.equal(coverScale({ width: 0, height: 0 }, { width: 300, height: 100 }), 1)
+})
+
+test("a pan inside the overflow is left where it was put", () => {
+	const frame = { width: 300, height: 100 }
+	const rendered = { width: 500, height: 300 }
+	assert.deepEqual(clampOffset({ x: 40, y: -30 }, rendered, frame), { x: 40, y: -30 })
+})
+
+test("a pan past an edge stops at half the overflow", () => {
+	const frame = { width: 300, height: 100 }
+	const rendered = { width: 500, height: 300 }
+	assert.deepEqual(clampOffset({ x: 999, y: -999 }, rendered, frame), { x: 100, y: -100 })
+})
+
+test("an image no bigger than its frame cannot be panned", () => {
+	const frame = { width: 300, height: 100 }
+	assert.deepEqual(clampOffset({ x: 50, y: 50 }, { width: 300, height: 100 }, frame), {
+		x: 0,
+		y: 0,
+	})
+})

--- a/dashboard/src/utils/imageCrop.ts
+++ b/dashboard/src/utils/imageCrop.ts
@@ -1,0 +1,47 @@
+// Geometry for the crop frame. Kept out of the component because a bad number here is
+// invisible until someone's face is half outside the circle, and a component cannot be
+// unit tested in this project.
+
+export interface Size {
+	width: number
+	height: number
+}
+
+export interface Point {
+	x: number
+	y: number
+}
+
+export function clamp(value: number, low: number, high: number): number {
+	return Math.min(high, Math.max(low, value))
+}
+
+/** The image's footprint once rotated: a quarter turn swaps the axes. */
+export function rotatedSize(size: Size, rotation: number): Size {
+	const turned = ((rotation % 360) + 360) % 360
+	if (turned % 180 === 0) return size
+	return { width: size.height, height: size.width }
+}
+
+/**
+ * The scale at which the image covers the frame with nothing left over — the larger of
+ * the two ratios, which is what makes the other axis overflow instead of leaving a gap.
+ */
+export function coverScale(size: Size, frame: Size): number {
+	if (!size.width || !size.height || !frame.width || !frame.height) return 1
+	return Math.max(frame.width / size.width, frame.height / size.height)
+}
+
+/**
+ * The pan, held inside the overflow. Dragging is free until an edge of the image would
+ * come into the frame; past that the offset stops, so no dead space can appear. An image
+ * that exactly fills the frame has no overflow and so cannot be panned at all.
+ */
+export function clampOffset(point: Point, rendered: Size, frame: Size): Point {
+	const limitX = Math.max(0, (rendered.width - frame.width) / 2)
+	const limitY = Math.max(0, (rendered.height - frame.height) / 2)
+	return {
+		x: clamp(point.x, -limitX, limitX),
+		y: clamp(point.y, -limitY, limitY),
+	}
+}


### PR DESCRIPTION
## What changed

Image fields uploaded whatever was picked and let `object-cover` decide what survived the frame. A portrait dropped into the banner's 3:1 box got centre-cropped with no say in it.

`ImageCropUploader` wraps a crop dialog around the pick — shaped like frappe-ui's `FileUploader` (same `fileTypes`/`validateFile` props, same `success`/`failure` emits, same slot props) so each host swaps one tag. Nothing uploads until Save. `ImageCropper` does the pan, zoom and rotate, then replays that transform onto a canvas; the geometry lives in `utils/imageCrop.ts` so it can be unit tested.

Hosts: `EventBanner` (3:1, 1500px), `AvatarUploader` (1:1, 512px), `ProfileView` (1:1 circle).

**Uploads on this path are public again.** beta.55 flipped `FileUploader`'s default to `private: true` in #394. `EventBanner` never passed the prop, so banners have been landing under `/private/files` — and `templates/emails/ticket.html` renders `banner_image` with no session, so every ticket email has had a broken banner since. `SponsorshipDetails` passed `:uploadArgs`, which beta.55 ignores; replaced with the flat `private` / `folder` props.

Review round: the circle guide was inset 7% while the export took the whole square; transparent PNGs were re-encoded as black-backed JPEG; Cancel left the upload running. Fixed, plus a profile picture saves itself now instead of leaving a second Save in the header.

Not here: no Unsplash, no stored reposition value. The crop is baked into the file, so every renderer keeps its `object-cover` and Buzz Event needs no new field.

## Demo

Circle guide. The dimmed band on the left is content the export kept anyway.

| Before | After |
| --- | --- |
| <img width="380" src="https://github.com/user-attachments/assets/a7a098f7-6742-4919-8df6-ed8569f19a60"> | <img width="380" src="https://github.com/user-attachments/assets/248924ea-d2b3-47c0-a34e-2ab269f2b61e"> |

A profile picture lands in one Save, no second one waiting in the header.

<img width="760" src="https://github.com/user-attachments/assets/ec08d009-1df2-4f35-9f92-3d88cbe515b4">

## Testing

`imageCrop.test.ts` covers the geometry — cover scale both orientations, the axis swap on a quarter turn, the pan clamped at each edge.

Driven in the browser: a 400×1200 portrait banner uploads as `"is_private":0, "file_url":"/files/portrait-cropped.jpg"` and renders the region chosen in the dialog; a transparent PNG comes back PNG, colour type 6, corners `(0,0,0,0)`; the mask rect and frame rect are the same 528×528 box; Cancel mid-upload gives `net::ERR_ABORTED` and leaves the avatar alone; a picture change fires one PUT and reopening the dialog fires none.

`yarn typecheck`, `yarn lint`, `yarn fmt:check`, `yarn test:unit` (133) clean. Team-logo call site not driven in a browser — same component as the avatar, which was.
