### PR TITLE
feat(dashboard): name the page in the browser tab title

### DIFF
--- a/dashboard/src/components/BaseCustomEventForm.vue
+++ b/dashboard/src/components/BaseCustomEventForm.vue
@@ -198,7 +198,7 @@ const formData = ref<CustomFormData | null>(null)
 usePageMeta(() => {
 	const eventTitle = formData.value?.event?.title
 	const formTitle = formData.value?.form_title
-	return eventTitle && formTitle ? { title: `${eventTitle} - ${formTitle}` } : null
+	return eventTitle && formTitle ? { title: `${formTitle} | ${eventTitle}` } : null
 })
 
 const formValues = reactive<Record<string, any>>({})

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DesktopShell, PageHeaderTarget, Sidebar, SidebarItem } from "frappe-ui"
+import { DesktopShell, PageHeaderTarget, Sidebar, SidebarItem, usePageMeta } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 import { useRoute } from "vue-router"
 
@@ -61,6 +61,12 @@ watch(
 	},
 	{ immediate: true },
 )
+
+usePageMeta(() => {
+	const section = route.meta.title as string | undefined
+	if (!section || !eventTitle.value) return null
+	return { title: `${__(section)} | ${eventTitle.value}` }
+})
 
 const items = computed(() => {
 	if (!eventId.value) return mainItems.value

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -37,8 +37,9 @@ setConfig("resourceFetcher", frappeRequest)
 // Before the router runs and may redirect away from the query.
 applyLanguageFromQuery(router)
 
-app.use(router)
+// Before the router: its afterEach translates page titles through `__`.
 app.use(translationPlugin)
+app.use(router)
 app.use(resourcesPlugin)
 
 const socket = initSocket()

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -37,7 +37,7 @@ setConfig("resourceFetcher", frappeRequest)
 // Before the router runs and may redirect away from the query.
 applyLanguageFromQuery(router)
 
-// Before the router: its afterEach translates page titles through `__`.
+// Before the router, whose afterEach translates page titles through `__`.
 app.use(translationPlugin)
 app.use(router)
 app.use(resourcesPlugin)

--- a/dashboard/src/pages/BookTickets.vue
+++ b/dashboard/src/pages/BookTickets.vue
@@ -98,7 +98,7 @@ const isGuest = computed(() => !session.isLoggedIn)
 
 usePageMeta(() => {
 	const eventTitle = eventBookingData.eventDetails?.title
-	return eventTitle ? { title: `${eventTitle} - ${__("Register")}` } : null
+	return eventTitle ? { title: `${__("Register")} | ${eventTitle}` } : null
 })
 
 const goToHome = () => {

--- a/dashboard/src/pages/EventProposalForm.vue
+++ b/dashboard/src/pages/EventProposalForm.vue
@@ -104,7 +104,7 @@ const load_error = ref<string | null>(null)
 
 usePageMeta(() => {
 	const bannerTitle = form_data.value?.banner_title
-	return bannerTitle ? { title: bannerTitle } : null
+	return bannerTitle ? { title: `${bannerTitle} | Buzz` } : null
 })
 
 const rendered_success_message = computed(() => {

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -250,10 +250,10 @@ router.beforeEach(async (to, from, next) => {
 	next()
 })
 
-router.afterEach((to) => {
-	// Pages whose title needs loaded data (the event name, a form title) set it
-	// through usePageMeta. Those watchers flush after this hook, so the specific
-	// title always lands last and this one is what a route falls back to.
+router.afterEach((to, from) => {
+	// Skipped on a same-path navigation: a usePageMeta watcher built only on loaded
+	// data won't rerun, so overwriting here would strand the generic title.
+	if (to.path === from.path) return
 	const title = to.meta.title as string | undefined
 	document.title = title ? `${__(title)} | ${APP_NAME}` : APP_NAME
 })

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -3,6 +3,8 @@ import { type RouteRecordRaw, createRouter, createWebHistory } from "vue-router"
 import { isTeamMember } from "@/data/teams"
 import { userResource } from "@/data/user"
 
+const APP_NAME = "Buzz"
+
 const routes: RouteRecordRaw[] = [
 	{
 		path: "/",
@@ -18,7 +20,7 @@ const routes: RouteRecordRaw[] = [
 	{
 		path: "/manage/team/events/new",
 		name: "create-event",
-		meta: { fullBleed: true },
+		meta: { fullBleed: true, title: "Create New Event" },
 		component: () => import("@/pages/manage/events/CreateEvent.vue"),
 	},
 	{
@@ -34,6 +36,7 @@ const routes: RouteRecordRaw[] = [
 			{
 				path: "events",
 				name: "events",
+				meta: { title: "My Events" },
 				component: () => import("@/pages/manage/MyEvents.vue"),
 			},
 			{
@@ -43,21 +46,25 @@ const routes: RouteRecordRaw[] = [
 			{
 				path: "events/:eventId/details",
 				name: "event-details",
+				meta: { title: "Details" },
 				component: () => import("@/pages/manage/events/EventDetails.vue"),
 			},
 			{
 				path: "events/:eventId/guests",
 				name: "event-guests",
+				meta: { title: "Guests" },
 				component: () => import("@/pages/manage/events/EventGuests.vue"),
 			},
 			{
 				path: "events/:eventId/talks",
 				name: "event-talks",
+				meta: { title: "Talks" },
 				component: () => import("@/pages/manage/events/EventTalks.vue"),
 			},
 			{
 				path: "events/:eventId/communications",
 				name: "event-communications",
+				meta: { title: "Announcements" },
 				component: () => import("@/pages/manage/events/EventCommunications.vue"),
 			},
 			{
@@ -67,6 +74,7 @@ const routes: RouteRecordRaw[] = [
 			{
 				path: "proposals",
 				name: "proposals",
+				meta: { title: "My Proposals" },
 				component: () => import("@/pages/manage/MyProposals.vue"),
 			},
 			// Sidebar destinations that have no page yet. Unnamed on purpose: SidebarItem
@@ -89,6 +97,7 @@ const routes: RouteRecordRaw[] = [
 		path: "/check-in/:eventName?",
 		name: "check-in",
 		props: true,
+		meta: { title: "Check In" },
 		component: () => import("@/pages/CheckInScanner.vue"),
 	},
 	{
@@ -108,13 +117,14 @@ const routes: RouteRecordRaw[] = [
 		path: "/booking-success/:bookingId",
 		name: "booking-success",
 		props: true,
-		meta: { isPublic: true },
+		meta: { isPublic: true, title: "Booking Confirmed" },
 		component: () => import("@/pages/BookingSuccess.vue"),
 	},
 	{
 		path: "/register-interest/:campaign",
 		props: true,
 		name: "register-interest",
+		meta: { title: "Register Interest" },
 		component: () => import("@/pages/RegisterInterest.vue"),
 	},
 	// Back-compat: old in-app paths redirect to the shortened scheme.
@@ -157,45 +167,53 @@ const routes: RouteRecordRaw[] = [
 			{
 				path: "bookings",
 				name: "bookings-list",
+				meta: { title: "My Bookings" },
 				component: () => import("@/pages/BookingsList.vue"),
 			},
 			{
 				path: "bookings/:bookingId",
 				props: true,
 				name: "booking-details",
+				meta: { title: "Booking Details" },
 				component: () => import("@/pages/BookingDetails.vue"),
 			},
 			{
 				path: "tickets",
 				name: "tickets-list",
+				meta: { title: "My Tickets" },
 				component: () => import("@/pages/TicketsList.vue"),
 			},
 			{
 				path: "tickets/:ticketId",
 				props: true,
 				name: "ticket-details",
+				meta: { title: "Ticket Details" },
 				component: () => import("@/pages/TicketDetails.vue"),
 			},
 			{
 				path: "proposals",
 				name: "proposals-list",
+				meta: { title: "Talk Proposals" },
 				component: () => import("@/pages/ProposalsList.vue"),
 			},
 			{
 				path: "proposals/:proposalId",
 				props: true,
 				name: "proposal-details",
+				meta: { title: "Proposal Details" },
 				component: () => import("@/pages/ProposalDetails.vue"),
 			},
 			{
 				path: "sponsorships",
 				name: "sponsorships-list",
+				meta: { title: "Sponsorships" },
 				component: () => import("@/pages/SponsorshipsList.vue"),
 			},
 			{
 				path: "sponsorships/:enquiryId",
 				props: true,
 				name: "sponsorship-details",
+				meta: { title: "Sponsorship Details" },
 				component: () => import("@/pages/SponsorshipDetails.vue"),
 			},
 		],
@@ -213,7 +231,7 @@ const routes: RouteRecordRaw[] = [
 	{
 		path: "/:pathMatch(.*)*",
 		name: "not-found",
-		meta: { isPublic: true },
+		meta: { isPublic: true, title: "Not Found" },
 		component: () => import("@/pages/NotFound.vue"),
 	},
 ]
@@ -232,14 +250,12 @@ router.beforeEach(async (to, from, next) => {
 	next()
 })
 
-const defaultTitle = document.title
-
-router.afterEach((to, from) => {
-	// Pages set their own title via usePageMeta, which never restores it on
-	// unmount. Reset here so a page without one doesn't keep showing the
-	// previous page's title. Same-path navigation keeps the title: usePageMeta's
-	// watcher won't refire when its data is unchanged, so resetting would stick.
-	if (to.path !== from.path) document.title = defaultTitle
+router.afterEach((to) => {
+	// Pages whose title needs loaded data (the event name, a form title) set it
+	// through usePageMeta. Those watchers flush after this hook, so the specific
+	// title always lands last and this one is what a route falls back to.
+	const title = to.meta.title as string | undefined
+	document.title = title ? `${__(title)} | ${APP_NAME}` : APP_NAME
 })
 
 export default router

--- a/e2e/tests/page-titles.spec.ts
+++ b/e2e/tests/page-titles.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test"
+
+// The three levels that produce a title: the router's afterEach for static routes,
+// ManagerLayout for event-scoped ones, and a page's own usePageMeta for titles that
+// need loaded data.
+const EVENT_TITLE = "E2E Test Event"
+const EVENT_ROUTE = "test-event-e2e"
+
+test.describe("Page titles", () => {
+	test("names the page and falls back to the app for context", async ({ page }) => {
+		await page.goto("/b/manage/events")
+		await expect(page).toHaveTitle("My Events | Buzz")
+
+		await page.goto("/b/account/bookings")
+		await expect(page).toHaveTitle("My Bookings | Buzz")
+	})
+
+	test("uses the event as context inside an event", async ({ page }) => {
+		await page.goto("/b/manage/events")
+		await page.getByRole("link", { name: "Manage" }).first().click()
+
+		// Whichever event the first card opens — the title comes from the event, not
+		// from the route.
+		const field = page.getByRole("textbox", { name: "Event title" })
+		await expect(field).toBeVisible({ timeout: 15000 })
+		const title = await field.inputValue()
+
+		await expect(page).toHaveTitle(`Details | ${title}`)
+		await page.getByRole("link", { name: "Guests" }).click()
+		await expect(page).toHaveTitle(`Guests | ${title}`)
+	})
+
+	test("keeps a data-derived title, and drops it on the way out", async ({ page }) => {
+		await page.goto(`/b/register/${EVENT_ROUTE}`)
+		await expect(page).toHaveTitle(`Register | ${EVENT_TITLE}`, { timeout: 15000 })
+
+		// The stale-title case the afterEach exists for: usePageMeta never restores.
+		await page.goto("/b/account/tickets")
+		await expect(page).toHaveTitle("My Tickets | Buzz")
+	})
+})

--- a/e2e/tests/page-titles.spec.ts
+++ b/e2e/tests/page-titles.spec.ts
@@ -1,8 +1,5 @@
 import { expect, test } from "@playwright/test"
 
-// The three levels that produce a title: the router's afterEach for static routes,
-// ManagerLayout for event-scoped ones, and a page's own usePageMeta for titles that
-// need loaded data.
 const EVENT_TITLE = "E2E Test Event"
 const EVENT_ROUTE = "test-event-e2e"
 
@@ -19,8 +16,7 @@ test.describe("Page titles", () => {
 		await page.goto("/b/manage/events")
 		await page.getByRole("link", { name: "Manage" }).first().click()
 
-		// Whichever event the first card opens — the title comes from the event, not
-		// from the route.
+		// Whichever event the first card opens: the title follows the event, not the route.
 		const field = page.getByRole("textbox", { name: "Event title" })
 		await expect(field).toBeVisible({ timeout: 15000 })
 		const title = await field.inputValue()
@@ -34,7 +30,7 @@ test.describe("Page titles", () => {
 		await page.goto(`/b/register/${EVENT_ROUTE}`)
 		await expect(page).toHaveTitle(`Register | ${EVENT_TITLE}`, { timeout: 15000 })
 
-		// The stale-title case the afterEach exists for: usePageMeta never restores.
+		// usePageMeta never restores on unmount; the afterEach is what clears it.
 		await page.goto("/b/account/tickets")
 		await expect(page).toHaveTitle("My Tickets | Buzz")
 	})


### PR DESCRIPTION
Closes #433.

## What changed

Every route showed `Buzz Dashboard`, so open tabs all looked the same. Titles now read
`<Page> | <Context>` — `My Events | Buzz`, `Guests | Frappeverse 2026`. Naming follows the
thread on the issue.

- `router.ts` — each route gets a `meta.title`. The `afterEach` that used to reset
  `document.title` now renders it, covering every static route from one place.
- `ManagerLayout.vue` — adds the event name for the event sections, reusing the
  `eventTitle` its sidebar already loads. Nothing extra is fetched.
- The three pages that already set their own title just swap `-` for `|`.
- `main.ts` — the translation plugin now loads before the router, so `__` is ready when
  the first title is set.

Ordering takes care of itself: vue-router runs `afterEach` before watchers flush, so a
page's own title always wins over the fallback.

Left alone: `WorkInProgress` placeholders stay untitled and fall back to `Buzz`; no
favicon/emoji; no `RouteMeta` type augmentation, since route meta is already read loosely
here (`Boolean(route.meta?.fullBleed)`).

## Demo

`skip-demo` — a browser tab title is not something a page screenshot can show. The route
sweep under Testing is the visual.

## Testing

`e2e/tests/page-titles.spec.ts` adds three tests, one per title level: a static route, an
event-scoped route, and a data-derived one that also covers the stale-title case the
`afterEach` exists for. `--project=chromium page-titles` → 6 passed.

`vue-tsc` clean for app source; the errors that remain are pre-existing frappe-ui
`node_modules` noise. `pre-commit run --files` on the touched files passed.

Manual sweep against the dev server:

| Route | Title |
| --- | --- |
| `/b/manage/events/<id>/details` | `Details \| E2E Test Event` |
| `/b/manage/events/<id>/guests` | `Guests \| E2E Test Event` |
| `/b/manage/events/<id>/talks` | `Talks \| E2E Test Event` |
| `/b/manage/events/<id>/communications` | `Announcements \| E2E Test Event` |
| `/b/manage/events` | `My Events \| Buzz` |
| `/b/manage/proposals` | `My Proposals \| Buzz` |
| `/b/manage/team/events/new` | `Create New Event \| Buzz` |
| `/b/account/bookings` | `My Bookings \| Buzz` |
| `/b/account/tickets` | `My Tickets \| Buzz` |
| `/b/account/proposals` | `Talk Proposals \| Buzz` |
| `/b/account/sponsorships` | `Sponsorships \| Buzz` |
| `/b/register-interest/demo` | `Register Interest \| Buzz` |
| `/b/register/test-event-e2e` | `Register \| E2E Test Event` |
| `/b/manage/events/<id>/sponsors` | `Buzz` (WorkInProgress, as intended) |
| `/b/this-route-does-not-exist` | `Not Found \| Buzz` |

Not exercised in the browser: the four `*-details` account routes and the custom-form page,
which need seeded records. Both ride paths covered above.
