### PR TITLE
feat(dashboard): create an event inside the manager shell

### DIFF
--- a/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
+++ b/dashboard/src/components/dashboard/ManagerSidebarHeader.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { Avatar, Tooltip, sidebarCollapsedKey } from "frappe-ui"
 import { computed, inject } from "vue"
-import { useRouter } from "vue-router"
+import { useRoute, useRouter } from "vue-router"
 
 const props = defineProps<{ eventId?: string; eventTitle?: string }>()
 
+const route = useRoute()
 const router = useRouter()
 const isCollapsed = inject(
 	sidebarCollapsedKey,
@@ -14,12 +15,38 @@ const isCollapsed = inject(
 // Never falls back to the id: swapping a hash for the title reads as a glitch.
 const name = computed(() => props.eventTitle ?? "")
 
-const goBack = () => router.push("/manage/events")
+const isCreatingEvent = computed(() => route.name === "create-event")
+
+const goToEvents = () => router.push("/manage/events")
+
+// Deep links have nothing to go back to, so the events list stands in.
+const goBack = () => (window.history.state?.back ? router.back() : goToEvents())
 </script>
 
 <template>
+	<Tooltip
+		v-if="isCreatingEvent"
+		class="w-full"
+		text="Go back"
+		side="right"
+		:disabled="!isCollapsed"
+	>
+		<button
+			aria-label="Go back"
+			class="group flex h-12 w-full items-center gap-1.5 rounded-4 px-1 transition duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"
+			@click="goBack"
+		>
+			<span
+				class="lucide-chevron-left size-4 shrink-0 text-ink-gray-5 transition duration-150 ease-out group-hover:-translate-x-0.5 group-hover:text-ink-gray-8"
+			/>
+			<span v-if="!isCollapsed" class="truncate text-base font-medium text-ink-gray-8">
+				Go back
+			</span>
+		</button>
+	</Tooltip>
+
 	<!-- Identity and the way home; the account menu sits in the sidebar footer. -->
-	<Tooltip v-if="!eventId" class="w-full" text="Buzz" side="right" :disabled="!isCollapsed">
+	<Tooltip v-else-if="!eventId" class="w-full" text="Buzz" side="right" :disabled="!isCollapsed">
 		<router-link
 			to="/manage"
 			class="flex h-12 w-full items-center gap-2 rounded-4 px-1.5 transition-[background-color,transform] duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"
@@ -40,7 +67,7 @@ const goBack = () => router.push("/manage/events")
 		<button
 			aria-label="Back to events"
 			class="group flex h-12 w-full items-center gap-1.5 rounded-4 px-1 transition duration-150 ease-out hover:bg-surface-gray-2 active:scale-[0.98] focus-visible:outline-none focus-visible:focus-ring"
-			@click="goBack"
+			@click="goToEvents"
 		>
 			<span
 				class="lucide-chevron-left size-4 shrink-0 text-ink-gray-5 transition duration-150 ease-out group-hover:-translate-x-0.5 group-hover:text-ink-gray-8"

--- a/dashboard/src/composables/useTeamAccess.ts
+++ b/dashboard/src/composables/useTeamAccess.ts
@@ -8,8 +8,7 @@ export type TeamAccess = "pending" | "granted" | "denied"
  * Whether the session user belongs to any team.
  *
  * Tri-state so a caller can hold its 404 back until the answer is in, rather than
- * flashing one while the teams load. Shared because pages outside the manager shell
- * need the same guard the shell applies.
+ * flashing one while the teams load.
  */
 export function useTeamAccess(): Ref<TeamAccess> {
 	const access = ref<TeamAccess>("pending")

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -42,10 +42,16 @@ const mainItems = computed(() => {
 // An event opens into the same shell with its own destinations.
 const eventId = computed(() => route.params.eventId as string | undefined)
 
-// Entering an event pushes the sidebar left, leaving it pulls back right.
+// The header swaps between the brand mark, an event, and the create-event way out.
+const headerKey = computed(() => {
+	if (route.name === "create-event") return "create"
+	return eventId.value ? "event" : "root"
+})
+
+// Leaving the root pushes the sidebar left, returning to it pulls back right.
 const direction = ref<"forward" | "back">("forward")
-watch(eventId, (id, previous) => {
-	direction.value = id && !previous ? "forward" : "back"
+watch(headerKey, (key, previous) => {
+	direction.value = previous === "root" && key !== "root" ? "forward" : "back"
 })
 
 const eventTitle = ref("")
@@ -69,6 +75,8 @@ usePageMeta(() => {
 })
 
 const items = computed(() => {
+	// Creating an event is a page of its own; the sidebar holds only the way out of it.
+	if (headerKey.value === "create") return []
 	if (!eventId.value) return mainItems.value
 	const event = `/manage/events/${eventId.value}`
 	return [
@@ -87,14 +95,11 @@ const items = computed(() => {
 	<DesktopShell v-else-if="access === 'granted'" :scroll="false">
 		<template #sidebar>
 			<Sidebar>
-				<!-- px-1: puts the header mark on the item-icon centerline, in both states.
-				     h-14 holds the height while both states overlap mid-transition. -->
+				<!-- px-1: puts the header mark on the item-icon centerline, in every state.
+				     h-14 holds the height while two states overlap mid-transition. -->
 				<div class="nav-stage relative h-14 shrink-0">
 					<Transition :name="`nav-${direction}`">
-						<div
-							:key="eventId ? 'event' : 'root'"
-							class="absolute inset-x-1 top-2 flex items-center"
-						>
+						<div :key="headerKey" class="absolute inset-x-1 top-2 flex items-center">
 							<ManagerSidebarHeader :event-id="eventId" :event-title="eventTitle" />
 						</div>
 					</Transition>
@@ -105,7 +110,7 @@ const items = computed(() => {
 				     padding box, so padding here would lift it out of line. -->
 				<div class="nav-stage relative mx-2 my-2">
 					<Transition :name="`nav-${direction}`">
-						<div :key="eventId ? 'event' : 'root'" class="nav-list flex flex-col gap-0.5">
+						<div :key="headerKey" class="nav-list flex flex-col gap-0.5">
 							<SidebarItem
 								v-for="item in items"
 								:key="item.label"

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Alert, Button, ErrorMessage, resolvedColorScheme, toast, useColorScheme } from "frappe-ui"
+import { Alert, Button, ErrorMessage, toast } from "frappe-ui"
 import { Editor, EditorContent, RichTextKit } from "frappe-ui/editor"
 import { computed, onBeforeUnmount, onMounted, ref } from "vue"
 import { onBeforeRouteLeave, useRouter } from "vue-router"
@@ -7,10 +7,8 @@ import { onBeforeRouteLeave, useRouter } from "vue-router"
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
 import EventLocation from "@/components/dashboard/events/EventLocation.vue"
 import EventSchedule from "@/components/dashboard/events/EventSchedule.vue"
-import { useTeamAccess } from "@/composables/useTeamAccess"
 import { createEvent } from "@/data/events"
 import { currentTeam } from "@/data/teams"
-import NotFound from "@/pages/NotFound.vue"
 import type { FrappeError } from "@/types"
 import { defaultSchedule } from "@/utils/eventDates"
 import type { ChecklistItem } from "@/utils/eventValidation"
@@ -22,19 +20,9 @@ const MANAGER_REQUIRED = "Ask an admin to make you a Manager to create events."
 
 const router = useRouter()
 
-const access = useTeamAccess()
-
 // The server refuses anything below Manager, so the form is shown read-only rather than
 // letting someone fill it in and lose the work to a 403 on save.
 const canCreate = computed(() => canCreateEvents(currentTeam.value?.team_role))
-
-const { colorScheme, setColorScheme } = useColorScheme()
-// `system` resolves against the OS, so the icon shows what is on screen rather than
-// what was picked — and the toggle sets the opposite outright instead of stepping
-// through `system`, which would look like a no-op when the OS is already dark.
-const isDark = computed(
-	() => (colorScheme.value === "system" ? resolvedColorScheme() : colorScheme.value) === "dark",
-)
 
 const title = ref("")
 const about = ref("")
@@ -173,137 +161,111 @@ async function save() {
 </script>
 
 <template>
-	<NotFound v-if="access === 'denied'" />
-
-	<!-- Nothing renders until the team resolves, so the page would otherwise pop in. -->
-	<Transition
-		v-else
-		enter-active-class="transition-opacity duration-150 ease-out motion-reduce:transition-none"
-		enter-from-class="opacity-0"
-	>
-		<div v-if="access === 'granted'" class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
-			<header class="space-y-4">
-				<div class="flex items-center justify-between">
-					<Button
-						variant="ghost"
-						icon-left="lucide-arrow-left"
-						label="Back"
-						class="-ml-2"
-						:route="{ name: 'events' }"
-					/>
-
-					<Button
-						variant="ghost"
-						:icon="isDark ? 'lucide-sun' : 'lucide-moon'"
-						:label="isDark ? 'Switch to light theme' : 'Switch to dark theme'"
-						@click="setColorScheme(isDark ? 'light' : 'dark')"
-					/>
-				</div>
-
-				<div class="flex items-center justify-between gap-4">
-					<h1 class="text-2xl font-semibold text-ink-gray-9">Create event</h1>
-					<!-- Enabled even when incomplete, so the click can say what is missing. No
-					 aria-disabled: that reads as disabled to assistive tech and blocks the very
-					 click that explains the state. The checklist is named instead. -->
-					<Button
-						variant="solid"
-						label="Create"
-						:loading="createEvent.loading"
-						aria-describedby="event-requirements"
-						@click="save"
-					/>
-				</div>
-
-				<ErrorMessage v-if="errorMessage" :message="errorMessage" />
-			</header>
-
-			<Alert
-				v-if="!canCreate"
-				theme="amber"
-				title="You cannot create events"
-				:description="MANAGER_REQUIRED"
-				:dismissible="false"
-			/>
-
-			<EventBanner v-model="bannerImage" :seed="title" :disabled="!canCreate" />
-
-			<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
-			<input
-				id="event-title"
-				v-model="title"
-				aria-label="Event title"
-				placeholder="Name your event"
-				:disabled="!canCreate"
-				:aria-invalid="saveAttempted && !title.trim()"
-				class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5 aria-invalid:placeholder:text-ink-red-4"
-			/>
-
-			<div class="grid gap-8 md:grid-cols-5">
-				<section class="space-y-3 md:col-span-3">
-					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
-					<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
-					 itself: the height and scrolling land on the editable area rather than on a
-					 wrapper, and the whole box takes a click. -->
-					<div class="rounded-6 border border-outline-gray-2 p-3">
-						<Editor
-							v-model="about"
-							:extensions="[RichTextKit]"
-							placeholder="What is this event about?"
-							:editable="canCreate"
-						>
-							<EditorContent
-								class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
-							/>
-						</Editor>
-					</div>
-				</section>
-
-				<div class="space-y-8 md:col-span-2">
-					<EventSchedule
-						:disabled="!canCreate"
-						v-model:start-date="startDate"
-						v-model:start-time="startTime"
-						v-model:end-date="endDate"
-						v-model:end-time="endTime"
-						v-model:time-zone="timeZone"
-					/>
-
-					<section id="event-location" class="space-y-3">
-						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
-						<EventLocation
-							v-model:venue="venue"
-							v-model:zoom-meeting="zoomMeeting"
-							:team="currentTeam?.name ?? ''"
-							:disabled="!canCreate"
-							:error="locationError"
-						/>
-					</section>
-				</div>
+	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
+		<header class="space-y-4">
+			<div class="flex items-center justify-between gap-4">
+				<h1 class="text-2xl font-semibold text-ink-gray-9">Create event</h1>
+				<!-- Enabled even when incomplete, so the click can say what is missing. No
+				 aria-disabled: that reads as disabled to assistive tech and blocks the very
+				 click that explains the state. The checklist is named instead. -->
+				<Button
+					variant="solid"
+					label="Create"
+					:loading="createEvent.loading"
+					aria-describedby="event-requirements"
+					@click="save"
+				/>
 			</div>
-			<!-- The colour rides on the icon alone: the label stays at full contrast, so the
-			 row still reads when the two hues do not. -->
-			<section id="event-requirements" class="space-y-3 rounded-6 bg-surface-gray-1/90 p-4">
-				<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
-					{{ missingItems.length ? "Still needed" : "Ready to create" }}
-				</h2>
 
-				<ul class="space-y-2" aria-live="polite">
-					<li
-						v-for="item in checklist"
-						:key="item.label"
-						class="flex items-center gap-2 text-base text-ink-gray-8"
+			<ErrorMessage v-if="errorMessage" :message="errorMessage" />
+		</header>
+
+		<Alert
+			v-if="!canCreate"
+			theme="amber"
+			title="You cannot create events"
+			:description="MANAGER_REQUIRED"
+			:dismissible="false"
+		/>
+
+		<EventBanner v-model="bannerImage" :seed="title" :disabled="!canCreate" />
+
+		<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
+		<input
+			id="event-title"
+			v-model="title"
+			aria-label="Event title"
+			placeholder="Name your event"
+			:disabled="!canCreate"
+			:aria-invalid="saveAttempted && !title.trim()"
+			class="w-full bg-transparent text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5 aria-invalid:placeholder:text-ink-red-4"
+		/>
+
+		<div class="grid gap-8 md:grid-cols-5">
+			<section class="space-y-3 md:col-span-3">
+				<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
+				<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
+				 itself: the height and scrolling land on the editable area rather than on a
+				 wrapper, and the whole box takes a click. -->
+				<div class="rounded-6 border border-outline-gray-2 p-3">
+					<Editor
+						v-model="about"
+						:extensions="[RichTextKit]"
+						placeholder="What is this event about?"
+						:editable="canCreate"
 					>
-						<!-- A row turning green is the only reward in this flow; a hard cut spends it. -->
-						<span
-							class="size-4 shrink-0 transition-colors duration-150 ease-out motion-reduce:transition-none"
-							:class="[item.done ? 'lucide-check' : 'lucide-x', iconColor(item)]"
-							aria-hidden="true"
+						<EditorContent
+							class="prose-sm h-48 max-w-none overflow-y-auto text-ink-gray-8 focus:outline-none"
 						/>
-						<span>{{ item.label }}</span>
-						<span class="sr-only">{{ item.done ? "done" : "missing" }}</span>
-					</li>
-				</ul>
+					</Editor>
+				</div>
 			</section>
+
+			<div class="space-y-8 md:col-span-2">
+				<EventSchedule
+					:disabled="!canCreate"
+					v-model:start-date="startDate"
+					v-model:start-time="startTime"
+					v-model:end-date="endDate"
+					v-model:end-time="endTime"
+					v-model:time-zone="timeZone"
+				/>
+
+				<section id="event-location" class="space-y-3">
+					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
+					<EventLocation
+						v-model:venue="venue"
+						v-model:zoom-meeting="zoomMeeting"
+						:team="currentTeam?.name ?? ''"
+						:disabled="!canCreate"
+						:error="locationError"
+					/>
+				</section>
+			</div>
 		</div>
-	</Transition>
+		<!-- The colour rides on the icon alone: the label stays at full contrast, so the
+		 row still reads when the two hues do not. -->
+		<section id="event-requirements" class="space-y-3 rounded-6 bg-surface-gray-1/90 p-4">
+			<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
+				{{ missingItems.length ? "Still needed" : "Ready to create" }}
+			</h2>
+
+			<ul class="space-y-2" aria-live="polite">
+				<li
+					v-for="item in checklist"
+					:key="item.label"
+					class="flex items-center gap-2 text-base text-ink-gray-8"
+				>
+					<!-- A row turning green is the only reward in this flow; a hard cut spends it. -->
+					<span
+						class="size-4 shrink-0 transition-colors duration-150 ease-out motion-reduce:transition-none"
+						:class="[item.done ? 'lucide-check' : 'lucide-x', iconColor(item)]"
+						aria-hidden="true"
+					/>
+					<span>{{ item.label }}</span>
+					<span class="sr-only">{{ item.done ? "done" : "missing" }}</span>
+				</li>
+			</ul>
+		</section>
+	</div>
 </template>

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -15,14 +15,6 @@ const routes: RouteRecordRaw[] = [
 			name: (await isTeamMember()) ? "manage" : "bookings-tab",
 		}),
 	},
-	// Declared before /manage: this one opts out of the manager shell, so it cannot be a
-	// child of the route that renders it.
-	{
-		path: "/manage/team/events/new",
-		name: "create-event",
-		meta: { fullBleed: true, title: "Create New Event" },
-		component: () => import("@/pages/manage/events/CreateEvent.vue"),
-	},
 	{
 		path: "/manage",
 		meta: { fullBleed: true },
@@ -70,6 +62,12 @@ const routes: RouteRecordRaw[] = [
 			{
 				path: "events/:eventId/:section",
 				component: () => import("@/pages/manage/WorkInProgress.vue"),
+			},
+			{
+				path: "team/events/new",
+				name: "create-event",
+				meta: { title: "Create New Event" },
+				component: () => import("@/pages/manage/events/CreateEvent.vue"),
 			},
 			{
 				path: "proposals",


### PR DESCRIPTION
## What changed

The create-event form was the last manager page outside `ManagerLayout`, so it carried its own back button and theme toggle and had no account menu. Now a child of `/manage` — URL and route name unchanged. The sidebar header gains a third state, a "Go back" button, and the destinations are hidden: mid-draft they are only ways to lose unsaved work. Also drops the page's duplicate `useTeamAccess` gate, which the layout already applies.

## Demo
<img width="5088" height="3598" alt="image" src="https://github.com/user-attachments/assets/5a8cbc5c-acc4-42cb-abba-d659b80a51ed" />

## Testing

`vue-tsc` clean in `src/`, oxlint and oxfmt pass. `e2e/tests/create-event.spec.ts` asserts the same URL and controls, so it covers the move; left to CI.
