### PR TITLE
fix(dashboard): drop the ring and give the teams row more room

### DIFF
--- a/dashboard/src/components/common/UserGroup.vue
+++ b/dashboard/src/components/common/UserGroup.vue
@@ -24,15 +24,13 @@ const label = computed(() =>
 
 <template>
 	<div class="flex items-center gap-2">
-		<!-- Overlap needs a margin; the row's gap alone would spread the stack apart. -->
-		<div v-if="shown.length" class="flex shrink-0 -space-x-1.5" aria-hidden="true">
+		<div v-if="shown.length" class="flex shrink-0 gap-1" aria-hidden="true">
 			<Avatar
 				v-for="user in shown"
 				:key="user.user ?? user.full_name ?? ''"
 				size="sm"
 				:image="user.user_image ?? undefined"
 				:label="user.full_name ?? user.user ?? ''"
-				class="ring-2 ring-surface-white"
 			/>
 		</div>
 		<span class="truncate text-base text-ink-gray-6">{{ label }}</span>

--- a/dashboard/src/components/common/UserGroup.vue
+++ b/dashboard/src/components/common/UserGroup.vue
@@ -24,15 +24,13 @@ const label = computed(() =>
 
 <template>
 	<div class="flex items-center gap-2">
-		<!-- Overlap needs a margin; the row's gap alone would spread the stack apart. -->
-		<div v-if="shown.length" class="flex shrink-0 -space-x-1.5" aria-hidden="true">
+		<div v-if="shown.length" class="flex shrink-0 gap-1" aria-hidden="true">
 			<Avatar
 				v-for="user in shown"
 				:key="user.user ?? user.full_name ?? ''"
 				size="sm"
 				:image="user.user_image ?? undefined"
 				:label="user.full_name ?? user.user ?? ''"
-				class="ring-2 ring-[--surface-base] group-hover:ring-[--surface-gray-1]"
 			/>
 		</div>
 		<span class="truncate text-base text-ink-gray-6">{{ label }}</span>

--- a/dashboard/src/components/common/UserGroup.vue
+++ b/dashboard/src/components/common/UserGroup.vue
@@ -24,13 +24,15 @@ const label = computed(() =>
 
 <template>
 	<div class="flex items-center gap-2">
-		<div v-if="shown.length" class="flex shrink-0 gap-1" aria-hidden="true">
+		<!-- Overlap needs a margin; the row's gap alone would spread the stack apart. -->
+		<div v-if="shown.length" class="flex shrink-0 -space-x-1.5" aria-hidden="true">
 			<Avatar
 				v-for="user in shown"
 				:key="user.user ?? user.full_name ?? ''"
 				size="sm"
 				:image="user.user_image ?? undefined"
 				:label="user.full_name ?? user.user ?? ''"
+				class="ring-2 ring-[--surface-base] group-hover:ring-[--surface-gray-1]"
 			/>
 		</div>
 		<span class="truncate text-base text-ink-gray-6">{{ label }}</span>

--- a/dashboard/src/components/common/UserGroup.vue
+++ b/dashboard/src/components/common/UserGroup.vue
@@ -24,7 +24,7 @@ const label = computed(() =>
 
 <template>
 	<div class="flex items-center gap-2">
-		<div v-if="shown.length" class="flex shrink-0 gap-1" aria-hidden="true">
+		<div v-if="shown.length" class="flex shrink-0 -space-x-1.5" aria-hidden="true">
 			<Avatar
 				v-for="user in shown"
 				:key="user.user ?? user.full_name ?? ''"
@@ -33,6 +33,6 @@ const label = computed(() =>
 				:label="user.full_name ?? user.user ?? ''"
 			/>
 		</div>
-		<span class="truncate text-base text-ink-gray-6">{{ label }}</span>
+		<span class="truncate text-sm text-ink-gray-6">{{ label }}</span>
 	</div>
 </template>

--- a/dashboard/src/components/dashboard/teams/TeamsPanel.vue
+++ b/dashboard/src/components/dashboard/teams/TeamsPanel.vue
@@ -8,7 +8,7 @@ import ManageTeamPanel from "@/components/dashboard/teams/ManageTeamPanel.vue"
 import { teams } from "@/data/teams"
 import type { TeamOption } from "@/types"
 
-const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_1.5rem] items-center gap-4"
+const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,1.4fr)_1.5rem] items-center gap-4 pl-3"
 
 const search = ref("")
 const managing = ref<TeamOption | null>(null)


### PR DESCRIPTION
- `UserGroup`'s `ring-2 ring-surface-white` never compiled — frappe-ui's Tailwind plugin extends `ringColor` with only `outline`/`outline-alpha` (`tailwind/plugin.js:281`) and its palette has no `surface-*` keys, so the class emitted nothing.
- Removed it rather than recolouring it: the `-space-x-1.5` overlap reads fine with no edge, and the stack now carries no surface colour to mismatch `TeamsPanel.vue`'s `hover:bg-surface-gray-1` row or dark surfaces.
- Member count drops to `text-sm`, the members column widens to `minmax(0,1.4fr)`, and `pl-3` on the shared `COLUMNS` grid indents header and rows together so the team logo isn't flush to the panel edge.
- Props, `max`-slicing, the "N members" label and `aria-hidden` are unchanged; `yarn lint`, `typecheck` and `fmt:check` pass.

Closes #431


<img width="1649" height="261" alt="image" src="https://github.com/user-attachments/assets/7329ce46-d3c7-44c5-961b-601ee459195c" />
