### PR TITLE
fix(permissions): return SQL text from permission query hooks

### DIFF
--- a/buzz/permissions.py
+++ b/buzz/permissions.py
@@ -21,6 +21,18 @@ def is_unrestricted(user: str) -> bool:
 	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
 
 
+def as_sql(criterion: Criterion | None) -> str | None:
+	"""Render a criterion the way the query engine itself does.
+
+	A permission query hook hands back SQL text: whatever it returns is stringified,
+	and pypika defaults to ANSI double quotes, which MariaDB reads as string literals.
+	"""
+	if criterion is None:
+		return None
+	quote_char = "`" if frappe.db.db_type == "mariadb" else '"'
+	return criterion.get_sql(with_namespace=True, quote_char=quote_char)
+
+
 def my_teams(user: str) -> QueryBuilder:
 	membership = frappe.qb.DocType("Buzz Team Membership")
 	return (
@@ -118,7 +130,7 @@ def has_team_access(team: str | None, ptype: str, user: str) -> bool:
 	return bool(team_role) and role_allows(team_role, ptype)
 
 
-def team_query_conditions(user: str | None = None, doctype: str | None = None, **kwargs) -> Criterion | None:
+def team_query_conditions(user: str | None = None, doctype: str | None = None, **kwargs) -> str | None:
 	user = user or frappe.session.user
 	if is_unrestricted(user):
 		return None
@@ -127,15 +139,12 @@ def team_query_conditions(user: str | None = None, doctype: str | None = None, *
 	if doctype == "Buzz Event":
 		if user == "Guest":
 			return None
-		return table.team.isin(my_teams(user)) | (table.is_published == 1)
+		return as_sql(table.team.isin(my_teams(user)) | (table.is_published == 1))
 
-	return table.team.isin(my_teams(user))
+	return as_sql(table.team.isin(my_teams(user)))
 
 
-def derived_query_conditions(
-	user: str | None = None, doctype: str | None = None, **kwargs
-) -> Criterion | None:
-	user = user or frappe.session.user
+def derived_criterion(user: str, doctype: str | None) -> Criterion | None:
 	if is_unrestricted(user):
 		return None
 
@@ -155,18 +164,22 @@ def derived_query_conditions(
 	return criterion
 
 
-def team_doc_query_conditions(user: str | None = None, **kwargs) -> Criterion | None:
+def derived_query_conditions(user: str | None = None, doctype: str | None = None, **kwargs) -> str | None:
+	return as_sql(derived_criterion(user or frappe.session.user, doctype))
+
+
+def team_doc_query_conditions(user: str | None = None, **kwargs) -> str | None:
 	user = user or frappe.session.user
 	if is_unrestricted(user):
 		return None
-	return frappe.qb.DocType("Buzz Team").name.isin(my_teams(user))
+	return as_sql(frappe.qb.DocType("Buzz Team").name.isin(my_teams(user)))
 
 
-def membership_query_conditions(user: str | None = None, **kwargs) -> Criterion | None:
+def membership_query_conditions(user: str | None = None, **kwargs) -> str | None:
 	user = user or frappe.session.user
 	if is_unrestricted(user):
 		return None
-	return frappe.qb.DocType("Buzz Team Membership").team.isin(my_teams(user))
+	return as_sql(frappe.qb.DocType("Buzz Team Membership").team.isin(my_teams(user)))
 
 
 def team_has_permission(doc, ptype: str = "read", user: str | None = None, **kwargs) -> bool:

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.py
@@ -8,7 +8,7 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder import Criterion
 from frappe.utils import cstr, getdate
 
-from buzz.permissions import derived_has_permission, derived_query_conditions
+from buzz.permissions import as_sql, derived_criterion, derived_has_permission
 
 
 def get_speaker_query_conditions(user: str) -> Criterion:
@@ -24,13 +24,13 @@ def get_speaker_query_conditions(user: str) -> Criterion:
 	return (proposal.submitted_by == user) | (proposal.owner == user) | proposal.name.isin(speaker_rows)
 
 
-def get_permission_query_conditions(user: str | None = None, doctype: str | None = None) -> Criterion | None:
+def get_permission_query_conditions(user: str | None = None, doctype: str | None = None) -> str | None:
 	user = user or frappe.session.user
-	team_conditions = derived_query_conditions(user=user, doctype="Talk Proposal")
+	team_conditions = derived_criterion(user, "Talk Proposal")
 	if team_conditions is None:
 		return None
 
-	return get_speaker_query_conditions(user) | team_conditions
+	return as_sql(get_speaker_query_conditions(user) | team_conditions)
 
 
 def is_speaker_on(doc, user: str) -> bool:

--- a/buzz/test_permissions.py
+++ b/buzz/test_permissions.py
@@ -171,6 +171,18 @@ class TestCrossTeamIsolation(TeamPermissionTestCase):
 				self.assertTrue(query_conditions.get(doctype))
 				self.assertTrue(has_permission.get(doctype))
 
+	def test_every_query_condition_is_valid_sql(self):
+		# Whatever these hooks return is stringified into the WHERE clause, so a
+		# criterion rendered in pypika's default dialect reaches the database as-is.
+		hooks = frappe.get_hooks("permission_query_conditions", app_name="buzz")
+
+		for doctype, methods in hooks.items():
+			for method in methods:
+				with self.subTest(doctype=doctype):
+					condition = frappe.call(frappe.get_attr(method), self.alice, doctype=doctype)
+					self.assertIsInstance(condition, str)
+					frappe.db.sql(f"SELECT `name` FROM `tab{doctype}` WHERE {condition} LIMIT 1")
+
 	def test_opening_another_teams_event_is_denied(self):
 		self.as_user(self.alice)
 


### PR DESCRIPTION
## What changed

Every `permission_query_conditions` hook returned a pypika criterion. On
`frappe/version-16` — what production runs — the query engine stringifies
whatever a hook returns (`query.py:1630`, `RawCriterion(f"({c})")`), and pypika's
default rendering quotes identifiers ANSI-style. MariaDB reads those as string
literals:

```
"team" IN (SELECT "team" FROM "tabBuzz Team Membership" WHERE "user"='...' AND "enabled"=1)
```

Syntax error 1064. Every list read by a user who is not Administrator or System
Manager was broken on prod — all 24 registered doctypes, not just the Event
Venue dropdown where it surfaced.

`frappe/develop` guards that call with `isinstance(c, str)` and passes criterions
through untouched, so local benches and CI (which take develop) are green.
`pyproject.toml` claims `frappe = ">=16.0.0,<18.0.0"`; we only ever test the one
point in that range where the bug is invisible.

Hooks now render to SQL text at the boundary via `as_sql`, picking the quote char
the way the query engine does. Talk Proposal ORs the team scope with its speaker
carve-out before rendering, so the shared body moved to `derived_criterion` and
the hook keeps the rendering.

Not changed: no CI matrix entry for version-16. That gap is real and stays open.

Trade-off: the string contract inlines values instead of parameterising them.
Inputs are `frappe.session.user` and generated team names, and Frappe's own
`build_match_conditions` renders the same way, but it is a downgrade from the
`%(param1)s` we get today.

## Demo

No UI change.

## Testing

`test_every_query_condition_is_valid_sql` calls every registered hook as a
non-privileged user and runs the returned fragment against MariaDB, so a
criterion leaking through fails loudly. Reverting `as_sql` to return its
argument fails it 25 times, once per doctype.

`bench run-tests --module buzz.test_permissions` — 55 passed.
`bench run-tests --module buzz.proposals.doctype.talk_proposal.test_talk_proposal` — 24 passed.

Also confirmed against the live local site: the old rendering reproduces the
exact 1064 from prod; the new rendering returns the same three venues as
`frappe.get_list` does today.
