### PR TITLE
fix(dashboard): point event links at /events/&lt;route&gt;

### DIFF
--- a/dashboard/src/components/dashboard/events/EventDrawer.vue
+++ b/dashboard/src/components/dashboard/events/EventDrawer.vue
@@ -15,7 +15,7 @@ import EventMyTickets from "@/components/dashboard/events/EventMyTickets.vue"
 import type { MyEvent } from "@/types"
 import { timeLabel12Hour } from "@/utils/dateLabels"
 import { bannerPattern } from "@/utils/eventBanner"
-import { copyEventUrl, eventUrl } from "@/utils/eventUrl"
+import { copyEventUrl, openEventPage } from "@/utils/eventUrl"
 
 const props = defineProps<{ event: MyEvent | null }>()
 
@@ -89,7 +89,7 @@ const endsAt = computed(() => {
 							size="sm"
 							label="Event Page"
 							icon-right="lucide-arrow-up-right"
-							:link="eventUrl(event.route)"
+							@click="openEventPage(event.route)"
 						/>
 					</template>
 				</div>

--- a/dashboard/src/components/dashboard/events/EventRoute.vue
+++ b/dashboard/src/components/dashboard/events/EventRoute.vue
@@ -4,6 +4,7 @@ import { computed, ref, watch } from "vue"
 
 import { useCopyToClipboard } from "@/composables/useCopyToClipboard"
 import { checkEventRoute } from "@/data/events"
+import { eventPath, eventUrl, openEventPage } from "@/utils/eventUrl"
 
 // The route the event already answers to, which is the one that opens and copies —
 // an edit in the field is not a live address until it is saved.
@@ -15,8 +16,8 @@ const taken = defineModel<boolean>("taken", { default: false })
 
 // The host the dashboard is being used on, so the field reads as the address it will be.
 const hostname = window.location.hostname
-// Events are served under the dashboard's own base, not off the bare host.
-const publicPath = computed(() => `/b/register/${props.saved}`)
+// The public event page, which is served outside the dashboard's /b base.
+const publicPath = computed(() => eventPath(props.saved ?? ""))
 
 type Availability = { available: boolean; message: string }
 const availability = ref<Availability | null>(null)
@@ -42,9 +43,10 @@ watch(availability, (answer) => (taken.value = Boolean(answer) && !answer?.avail
 
 const copyToClipboard = useCopyToClipboard()
 
-// The path the link opens, not the shorthand the field reads.
-const copy = () =>
-	copyToClipboard(`${window.location.origin}${publicPath.value}`, "Event link copied")
+// The address the link opens, not the shorthand the field reads.
+const copy = () => copyToClipboard(eventUrl(props.saved ?? ""), "Event link copied")
+
+const open = () => openEventPage(props.saved ?? "")
 </script>
 
 <template>
@@ -55,10 +57,9 @@ const copy = () =>
 			<div v-if="saved" class="flex items-center gap-1">
 				<a
 					:href="publicPath"
-					target="_blank"
-					rel="noopener"
 					aria-label="Open event page"
 					class="rounded-4 p-1 text-ink-gray-5 transition-[color,transform] duration-150 ease-out hover:text-ink-gray-8 active:scale-95 motion-reduce:transition-none"
+					@click.prevent="open"
 				>
 					<span class="lucide-arrow-up-right block size-4" aria-hidden="true" />
 				</a>
@@ -79,7 +80,7 @@ const copy = () =>
 		<div
 			class="rounded-6 border border-outline-gray-2 px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:border-outline-gray-4 motion-reduce:transition-none"
 		>
-			<p class="text-xs leading-4 text-ink-gray-5">{{ hostname }}/</p>
+			<p class="text-xs leading-4 text-ink-gray-5">{{ hostname }}/events/</p>
 			<input
 				v-model="route"
 				aria-label="Event route"

--- a/dashboard/src/utils/eventUrl.test.ts
+++ b/dashboard/src/utils/eventUrl.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { eventUrl } from "./eventUrl.ts"
+import { eventPath, eventUrl } from "./eventUrl.ts"
 
 const withOrigin = (origin: string, run: () => void) => {
 	// The helper reads the live location; there is no browser under node --test.
@@ -15,12 +15,16 @@ const withOrigin = (origin: string, run: () => void) => {
 
 test("hangs the route off the current origin", () => {
 	withOrigin("https://buzz.example.com", () => {
-		assert.equal(eventUrl("frappeverse-2026"), "https://buzz.example.com/frappeverse-2026")
+		assert.equal(eventUrl("frappeverse-2026"), "https://buzz.example.com/events/frappeverse-2026")
 	})
 })
 
 test("keeps the port, which differs between the dashboard and the bench", () => {
 	withOrigin("http://buzz.localhost:8080", () => {
-		assert.equal(eventUrl("summit"), "http://buzz.localhost:8080/summit")
+		assert.equal(eventUrl("summit"), "http://buzz.localhost:8080/events/summit")
 	})
+})
+
+test("keeps the path off the dashboard's own base", () => {
+	assert.equal(eventPath("frappeverse-2026"), "/events/frappeverse-2026")
 })

--- a/dashboard/src/utils/eventUrl.ts
+++ b/dashboard/src/utils/eventUrl.ts
@@ -1,12 +1,25 @@
 /**
- * The public page for an event lives at the site root under the event's own route.
+ * The public page for an event lives under /events/<route>.
  *
  * Built from the current origin rather than a configured base URL: the dashboard and the
  * bench answer on different ports in development, so anything hardcoded is wrong in one
  * of the two places.
  */
 export function eventUrl(route: string): string {
-	return `${window.location.origin}/${route}`
+	return `${window.location.origin}${eventPath(route)}`
+}
+
+/** The origin-relative path of an event's public page. */
+export function eventPath(route: string): string {
+	return `/events/${route}`
+}
+
+/**
+ * Leaves the dashboard for the event's public page. A plain navigation, not a router
+ * one: the page is served outside the SPA's /b base.
+ */
+export function openEventPage(route: string): void {
+	window.open(eventUrl(route), "_blank", "noopener")
 }
 
 /** Puts an event's public link on the clipboard. Rejects if the browser refuses access. */

--- a/e2e/tests/manage-event.spec.ts
+++ b/e2e/tests/manage-event.spec.ts
@@ -45,8 +45,7 @@ test.describe("Event workspace", () => {
 		expect(route).not.toBe("")
 
 		const open = page.getByRole("link", { name: "Open event page" })
-		await expect(open).toHaveAttribute("href", `/b/register/${route}`)
-		await expect(open).toHaveAttribute("target", "_blank")
+		await expect(open).toHaveAttribute("href", `/events/${route}`)
 		await expect(page.getByRole("button", { name: "Copy" })).toBeVisible()
 	})
 


### PR DESCRIPTION
## What changed

The public event page lives at `/events/<event_route>`, but the dashboard built links to it two different (and both wrong) ways:

- `EventRoute.vue` — the Event URL field on Event Details pointed at `/b/register/<route>`.
- `eventUrl()` — hung the route straight off the origin, so the Event Drawer's **Event Page** button landed on `/<route>`.

Both now go through one helper:

- `eventUrl(route)` → `<origin>/events/<route>` (also what **Copy Link** puts on the clipboard).
- `eventPath(route)` → `/events/<route>`, used for the anchor's `href`.
- `openEventPage(route)` → opens the public page with `window.open`, a plain navigation rather than one the SPA router (based at `/b`) could claim. Used by the Event URL arrow link (`@click.prevent`) and the drawer's Event Page button.

The Event URL field prefix now reads `<host>/events/` so the field shows the address it actually is.

## Demo

No visual change beyond the field prefix now reading `<host>/events/` instead of `<host>/`; the fix is in where the links go.

## Testing

- `node --test dashboard/src/utils/eventUrl.test.ts` — updated for the new path, plus a case for `eventPath`. Passing.
- Updated the e2e assertion in `e2e/tests/manage-event.spec.ts` to expect `href="/events/<route>"`.
- Pre-existing unrelated failures in `timeZones.test.ts` / `timelineTabs.test.ts` are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdA87qK8nUEBfAxs9cGzjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdA87qK8nUEBfAxs9cGzjJ)_