### PR TITLE
feat(dashboard): show what the save is doing while an event is created

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,6 +22,7 @@
 		"frappe-ui": "1.0.0-beta.55",
 		"reka-ui": "^2.10.1",
 		"socket.io-client": "^4.7.2",
+		"torph": "^0.1.3",
 		"vue": "^3.5.13",
 		"vue-router": "^4.5.0"
 	},

--- a/dashboard/src/components/dashboard/events/EventLocation.vue
+++ b/dashboard/src/components/dashboard/events/EventLocation.vue
@@ -42,8 +42,10 @@ const selected = computed({
 })
 
 // Nothing answers to what they typed, so Add Manually is the only move left: it is
-// pre-armed, and Enter takes it.
+// pre-armed, and Enter takes it. Not while the list is still loading: an empty list is
+// not an answer, and arming Enter on one adds a venue that already exists.
 const unmatched = computed(() => {
+	if (venues.loading) return false
 	const text = query.value.trim().toLowerCase()
 	return Boolean(text) && !(venues.data ?? []).some((row) => row.name.toLowerCase().includes(text))
 })
@@ -92,6 +94,7 @@ async function onVenueCreated(name: string) {
 		placeholder="Search venues, or add one"
 		empty-text=""
 		class="w-full"
+		:loading="venues.loading"
 		:disabled="disabled"
 		:error="error"
 		@keydown.enter.prevent="unmatched && addManually()"

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -71,11 +71,8 @@ const isDirty = computed(() =>
 	),
 )
 
-// Also releases the leave guard: the redirect that follows must not be challenged.
-const created = ref(false)
-
-// Held for the whole sequence, not just the request: the steps play on past the response,
-// and a flag that tracks the request alone drops the form back in mid-walk.
+// True from the first step until the redirect lands, so the steps play past the response
+// and the leave guard stays quiet for a redirect the page asked for.
 const submitting = ref(false)
 
 // Local to the sequence: the resource keeps its error for the form's message long after
@@ -92,7 +89,7 @@ const FINAL_STEP = "Opening event page"
 const FAILED_STEP = "Failed to create event"
 const STEP_DURATION = 600
 
-const step = ref(CREATION_STEPS[0])
+const step = ref("")
 
 function wait(milliseconds: number) {
 	return new Promise((resolve) => setTimeout(resolve, milliseconds))
@@ -101,23 +98,22 @@ function wait(milliseconds: number) {
 // Walks the steps at a fixed pace whatever the save is doing, so the panel reads as
 // progress rather than as a spinner with captions.
 async function walkSteps() {
-	for (const next of CREATION_STEPS.slice(1)) {
-		await wait(STEP_DURATION)
+	for (const next of CREATION_STEPS) {
 		if (createEvent.error) return
 		step.value = next
+		await wait(STEP_DURATION)
 	}
-	await wait(STEP_DURATION)
 }
 
 const LEAVE_WARNING = "You have unsaved changes. Leave without saving?"
 
 function warnOnUnload(unload: BeforeUnloadEvent) {
-	if (isDirty.value && !created.value) unload.preventDefault()
+	if (isDirty.value && !submitting.value) unload.preventDefault()
 }
 
 onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
 onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
-onBeforeRouteLeave(() => !isDirty.value || created.value || window.confirm(LEAVE_WARNING))
+onBeforeRouteLeave(() => !isDirty.value || submitting.value || window.confirm(LEAVE_WARNING))
 
 const saveAttempted = ref(false)
 
@@ -148,7 +144,7 @@ function focusFirstMissing() {
 
 async function save() {
 	// The button is disabled through both, but a keyboard repeat outruns the re-render.
-	if (submitting.value || created.value) return
+	if (submitting.value) return
 	if (!canCreate.value) {
 		toast.error(MANAGER_REQUIRED)
 		return
@@ -163,27 +159,25 @@ async function save() {
 
 	submitting.value = true
 	failed.value = false
-	step.value = CREATION_STEPS[0]
-	// Steps and save run together: whichever finishes first waits for the other. The
-	// rejection is swallowed because createResource records the error on itself.
-	await Promise.all([
-		createEvent
-			.submit({
-				event: {
-					team: currentTeam.value?.name,
-					title: title.value.trim(),
-					start_date: startDate.value,
-					start_time: startTime.value,
-					end_date: endDate.value || null,
-					end_time: endTime.value,
-					about: about.value || null,
-					banner_image: bannerImage.value || null,
-					time_zone: timeZone.value || null,
-					venue: venue.value || null,
-					zoom_meeting: zoomMeeting.value,
-				},
-			})
-			.catch(() => {}),
+	// Steps and save run together: whichever finishes first waits for the other. Settled,
+	// not all: createResource rejects as well as recording the error, and the record is
+	// what the panel reads.
+	await Promise.allSettled([
+		createEvent.submit({
+			event: {
+				team: currentTeam.value?.name,
+				title: title.value.trim(),
+				start_date: startDate.value,
+				start_time: startTime.value,
+				end_date: endDate.value || null,
+				end_time: endTime.value,
+				about: about.value || null,
+				banner_image: bannerImage.value || null,
+				time_zone: timeZone.value || null,
+				venue: venue.value || null,
+				zoom_meeting: zoomMeeting.value,
+			},
+		}),
 		walkSteps(),
 	])
 	if (createEvent.error) {
@@ -196,7 +190,6 @@ async function save() {
 		return
 	}
 
-	created.value = true
 	step.value = FINAL_STEP
 	toast.success(`${createEvent.data?.title} created`)
 	await wait(STEP_DURATION)
@@ -322,7 +315,7 @@ async function save() {
 				</section>
 			</div>
 
-			<div v-else class="flex m-auto items-center justify-center gap-3 py-24">
+			<div v-else class="flex items-center justify-center gap-3 py-24">
 				<span v-if="failed" class="lucide-circle-x size-6 text-ink-red-6" aria-hidden="true" />
 				<LoadingIndicator v-else class="size-6 text-ink-gray-7" />
 				<TextMorph

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from "@vueuse/core"
-import { Alert, Button, ErrorMessage, toast } from "frappe-ui"
+import { Alert, Button, ErrorMessage, LoadingIndicator, toast } from "frappe-ui"
 import { Editor, EditorContent, EditorFixedMenu } from "frappe-ui/editor"
+import { TextMorph } from "torph/vue"
 import { computed, onBeforeUnmount, onMounted, ref } from "vue"
 import { onBeforeRouteLeave, useRouter } from "vue-router"
 
@@ -22,13 +23,10 @@ const MANAGER_REQUIRED = "Ask an admin to make you a Manager to create events."
 
 const router = useRouter()
 
-// The server refuses anything below Manager, so the form is shown read-only rather than
-// letting someone fill it in and lose the work to a 403 on save.
 const canCreate = computed(() => canCreateEvents(currentTeam.value?.team_role))
 
 const title = ref("")
 
-// A title wraps rather than scrolling out of sight, so the box grows with it.
 const titleField = ref<HTMLTextAreaElement>()
 useTextareaAutosize({ element: titleField, watch: title })
 const about = ref("")
@@ -39,12 +37,9 @@ const startDate = ref(opening.startDate)
 const startTime = ref(opening.startTime)
 const endDate = ref(opening.endDate)
 const endTime = ref(opening.endTime)
-// The organiser's own zone is the safe opening guess; they change it if the event is
-// somewhere else.
 const timeZone = ref(currentTimeZone())
 
 const venue = ref("")
-// The Zoom meeting can only be booked once the event exists, so save has to act on this.
 const zoomMeeting = ref(false)
 
 const draft = computed(() => ({
@@ -62,8 +57,6 @@ const checklist = computed(() => eventDraftChecklist(draft.value))
 // createResource types its error as {}, so the message needs narrowing.
 const errorMessage = computed(() => (createEvent.error as FrappeError | null)?.messages?.join("\n"))
 
-// The time zone and the opening slot come pre-filled, so they say nothing about whether
-// the organiser has started — only a schedule moved off those defaults does.
 const isDirty = computed(() =>
 	Boolean(
 		title.value ||
@@ -78,11 +71,44 @@ const isDirty = computed(() =>
 	),
 )
 
-// Set once the event exists: the form is no longer worth keeping, and the redirect that
-// follows must not be challenged.
+// Also releases the leave guard: the redirect that follows must not be challenged.
 const created = ref(false)
 
-// Nothing here autosaves, so leaving with a draft in hand has to be deliberate.
+// Held for the whole sequence, not just the request: the steps play on past the response,
+// and a flag that tracks the request alone drops the form back in mid-walk.
+const submitting = ref(false)
+
+// Local to the sequence: the resource keeps its error for the form's message long after
+// the panel is done with it, and the panel has to start clean on every attempt.
+const failed = ref(false)
+
+const CREATION_STEPS = [
+	"Saving the details",
+	"Setting the schedule",
+	"Booking the venue",
+	"Opening the guest list",
+]
+const FINAL_STEP = "Opening event page"
+const FAILED_STEP = "Failed to create event"
+const STEP_DURATION = 600
+
+const step = ref(CREATION_STEPS[0])
+
+function wait(milliseconds: number) {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+// Walks the steps at a fixed pace whatever the save is doing, so the panel reads as
+// progress rather than as a spinner with captions.
+async function walkSteps() {
+	for (const next of CREATION_STEPS.slice(1)) {
+		await wait(STEP_DURATION)
+		if (createEvent.error) return
+		step.value = next
+	}
+	await wait(STEP_DURATION)
+}
+
 const LEAVE_WARNING = "You have unsaved changes. Leave without saving?"
 
 function warnOnUnload(unload: BeforeUnloadEvent) {
@@ -93,8 +119,6 @@ onMounted(() => window.addEventListener("beforeunload", warnOnUnload))
 onBeforeUnmount(() => window.removeEventListener("beforeunload", warnOnUnload))
 onBeforeRouteLeave(() => !isDirty.value || created.value || window.confirm(LEAVE_WARNING))
 
-// Nothing is marked wrong until the organiser has asked to save; before that the
-// checklist reads as a plan, not as four errors about work they have not started.
 const saveAttempted = ref(false)
 
 const missingItems = computed(() => checklist.value.filter((item) => !item.done))
@@ -104,21 +128,16 @@ function iconColor(item: ChecklistItem) {
 	return saveAttempted.value ? "text-ink-red-7" : "text-ink-gray-6"
 }
 
-// Combobox draws its own error region, so Where says what it is missing in place.
 const locationError = computed(() =>
 	saveAttempted.value && !venue.value && !zoomMeeting.value
 		? "Pick a venue, or create a Zoom meeting"
 		: "",
 )
 
-// "a, b, and c" — the toast has to name the fields, since the checklist may be scrolled
-// out of view and never reaches assistive tech on its own.
 const listFormat = new Intl.ListFormat("en", { style: "long", type: "conjunction" })
 
-// The checklist is a summary; the fields themselves have to show which one is meant.
 function focusFirstMissing() {
 	const target = document.getElementById(missingItems.value[0]?.field ?? "")
-	// A full-page smooth scroll is exactly the motion a vestibular user turns off.
 	const smooth = !window.matchMedia("(prefers-reduced-motion: reduce)").matches
 	target?.scrollIntoView({ behavior: smooth ? "smooth" : "auto", block: "center" })
 	const focusable = target?.matches("input, button")
@@ -127,166 +146,191 @@ function focusFirstMissing() {
 	;(focusable as HTMLElement | null)?.focus({ preventScroll: true })
 }
 
-// The button stays live and the checklist says what is still missing, rather than
-// leaving the organiser to guess what would enable it.
 async function save() {
 	// The button is disabled through both, but a keyboard repeat outruns the re-render.
-	if (createEvent.loading || created.value) return
+	if (submitting.value || created.value) return
 	if (!canCreate.value) {
 		toast.error(MANAGER_REQUIRED)
 		return
 	}
 	saveAttempted.value = true
 	if (!isDraftComplete(draft.value)) {
-		// Labels are sentence-cased for the list, which reads as one sentence.
 		const names = missingItems.value.map((item) => item.label.toLowerCase())
 		toast.error(`Add ${listFormat.format(names)}`)
 		focusFirstMissing()
 		return
 	}
 
-	await createEvent.submit({
-		event: {
-			team: currentTeam.value?.name,
-			title: title.value.trim(),
-			start_date: startDate.value,
-			start_time: startTime.value,
-			end_date: endDate.value || null,
-			end_time: endTime.value,
-			about: about.value || null,
-			banner_image: bannerImage.value || null,
-			time_zone: timeZone.value || null,
-			venue: venue.value || null,
-			zoom_meeting: zoomMeeting.value,
-		},
-	})
-	if (createEvent.error) return
+	submitting.value = true
+	failed.value = false
+	step.value = CREATION_STEPS[0]
+	// Steps and save run together: whichever finishes first waits for the other. The
+	// rejection is swallowed because createResource records the error on itself.
+	await Promise.all([
+		createEvent
+			.submit({
+				event: {
+					team: currentTeam.value?.name,
+					title: title.value.trim(),
+					start_date: startDate.value,
+					start_time: startTime.value,
+					end_date: endDate.value || null,
+					end_time: endTime.value,
+					about: about.value || null,
+					banner_image: bannerImage.value || null,
+					time_zone: timeZone.value || null,
+					venue: venue.value || null,
+					zoom_meeting: zoomMeeting.value,
+				},
+			})
+			.catch(() => {}),
+		walkSteps(),
+	])
+	if (createEvent.error) {
+		// The panel says how it ended before it hands the form back with the message.
+		failed.value = true
+		step.value = FAILED_STEP
+		toast.error(errorMessage.value || FAILED_STEP)
+		await wait(STEP_DURATION * 2)
+		submitting.value = false
+		return
+	}
 
 	created.value = true
+	step.value = FINAL_STEP
 	toast.success(`${createEvent.data?.title} created`)
+	await wait(STEP_DURATION)
 	router.push({ name: "event-details", params: { eventId: createEvent.data?.name } })
 }
 </script>
 
 <template>
-	<div class="m-auto max-w-[800px] w-full py-8 px-4 space-y-8">
-		<header class="space-y-4">
-			<div class="flex items-center justify-between gap-4">
-				<h1 class="text-2xl font-semibold text-ink-gray-9">Create event</h1>
-				<!-- Enabled even when incomplete, so the click can say what is missing. No
-				 aria-disabled: that reads as disabled to assistive tech and blocks the very
-				 click that explains the state. The checklist is named instead. -->
-				<!-- Held busy past the response as well: the redirect waits on a session
-				 check and a lazy chunk, and a live button on the page it just saved
-				 creates the event a second time. -->
-				<Button
-					variant="solid"
-					size="lg"
-					label="Create"
-					:loading="createEvent.loading || created"
-					aria-describedby="event-requirements"
-					@click="save"
+	<div class="m-auto max-w-[800px] w-full py-8 px-4">
+		<Transition
+			mode="out-in"
+			enter-active-class="transition-opacity duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
+			leave-active-class="transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
+			enter-from-class="opacity-0"
+			leave-to-class="opacity-0"
+		>
+			<div v-if="!submitting" class="space-y-8">
+				<header class="space-y-4">
+					<div class="flex items-center justify-between gap-4">
+						<h1 class="text-2xl font-semibold text-ink-gray-9">Create event</h1>
+						<!-- Never disabled, and never aria-disabled: the click is what explains
+						 what is missing. Held busy past the response, or the page it just saved
+						 takes a second click. -->
+						<Button
+							variant="solid"
+							size="lg"
+							label="Create"
+							:loading="submitting"
+							aria-describedby="event-requirements"
+							@click="save"
+						/>
+					</div>
+
+					<ErrorMessage v-if="errorMessage" :message="errorMessage" />
+				</header>
+
+				<Alert
+					v-if="!canCreate"
+					theme="amber"
+					title="You cannot create events"
+					:description="MANAGER_REQUIRED"
+					:dismissible="false"
 				/>
-			</div>
 
-			<ErrorMessage v-if="errorMessage" :message="errorMessage" />
-		</header>
+				<EventBanner v-model="bannerImage" :seed="title" :disabled="!canCreate" />
 
-		<Alert
-			v-if="!canCreate"
-			theme="amber"
-			title="You cannot create events"
-			:description="MANAGER_REQUIRED"
-			:dismissible="false"
-		/>
-
-		<EventBanner v-model="bannerImage" :seed="title" :disabled="!canCreate" />
-
-		<!-- Plain input on purpose: this is the page's headline, not a labelled field. -->
-		<!-- A textarea rather than an input so a long name wraps; Enter is swallowed
-		 since a title has no second line of its own. -->
-		<textarea
-			id="event-title"
-			ref="titleField"
-			v-model="title"
-			rows="1"
-			aria-label="Event title"
-			placeholder="Name your event"
-			:disabled="!canCreate"
-			:aria-invalid="saveAttempted && !title.trim()"
-			class="w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5 aria-invalid:placeholder:text-ink-red-4"
-			@keydown.enter.prevent
-		/>
-
-		<div class="grid gap-8 md:grid-cols-5">
-			<section class="space-y-3 md:col-span-3">
-				<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
-				<!-- Editor is renderless, so EditorContent's root is the ProseMirror element
-				 itself: the height and scrolling land on the editable area rather than on a
-				 wrapper, and the whole box takes a click. -->
-				<div class="overflow-hidden rounded-6 border border-outline-gray-2">
-					<Editor
-						v-model="about"
-						:extensions="richTextExtensions"
-						placeholder="What is this event about?"
-						:editable="canCreate"
-					>
-						<EditorFixedMenu
-							:items="richTextToolbar"
-							class="overflow-x-auto border-b border-outline-gray-2 px-2 py-1"
-						/>
-						<EditorContent
-							class="prose-sm h-48 max-w-none overflow-y-auto p-3 text-ink-gray-8 focus:outline-none"
-						/>
-					</Editor>
-				</div>
-			</section>
-
-			<div class="space-y-8 md:col-span-2">
-				<EventSchedule
+				<textarea
+					id="event-title"
+					ref="titleField"
+					v-model="title"
+					rows="1"
+					aria-label="Event title"
+					placeholder="Name your event"
 					:disabled="!canCreate"
-					v-model:start-date="startDate"
-					v-model:start-time="startTime"
-					v-model:end-date="endDate"
-					v-model:end-time="endTime"
-					v-model:time-zone="timeZone"
+					:aria-invalid="saveAttempted && !title.trim()"
+					class="w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-4xl font-semibold text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none disabled:text-ink-gray-5 aria-invalid:placeholder:text-ink-red-4"
+					@keydown.enter.prevent
 				/>
 
-				<section id="event-location" class="space-y-1.5">
-					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
-					<EventLocation
-						v-model:venue="venue"
-						v-model:zoom-meeting="zoomMeeting"
-						:team="currentTeam?.name ?? ''"
-						:disabled="!canCreate"
-						:error="locationError"
-					/>
+				<div class="grid gap-8 md:grid-cols-5">
+					<section class="space-y-3 md:col-span-3">
+						<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">About</h2>
+						<div class="overflow-hidden rounded-6 border border-outline-gray-2">
+							<Editor
+								v-model="about"
+								:extensions="richTextExtensions"
+								placeholder="What is this event about?"
+								:editable="canCreate"
+							>
+								<EditorFixedMenu
+									:items="richTextToolbar"
+									class="overflow-x-auto border-b border-outline-gray-2 px-2 py-1"
+								/>
+								<EditorContent
+									class="prose-sm h-48 max-w-none overflow-y-auto p-3 text-ink-gray-8 focus:outline-none"
+								/>
+							</Editor>
+						</div>
+					</section>
+
+					<div class="space-y-8 md:col-span-2">
+						<EventSchedule
+							:disabled="!canCreate"
+							v-model:start-date="startDate"
+							v-model:start-time="startTime"
+							v-model:end-date="endDate"
+							v-model:end-time="endTime"
+							v-model:time-zone="timeZone"
+						/>
+
+						<section id="event-location" class="space-y-1.5">
+							<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">Where</h2>
+							<EventLocation
+								v-model:venue="venue"
+								v-model:zoom-meeting="zoomMeeting"
+								:team="currentTeam?.name ?? ''"
+								:disabled="!canCreate"
+								:error="locationError"
+							/>
+						</section>
+					</div>
+				</div>
+				<section id="event-requirements" class="space-y-3 rounded-6 bg-surface-gray-1/90 p-4">
+					<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
+						{{ missingItems.length ? "Still needed" : "Ready to create" }}
+					</h2>
+
+					<ul class="space-y-2" aria-live="polite">
+						<li
+							v-for="item in checklist"
+							:key="item.label"
+							class="flex items-center gap-2 text-base text-ink-gray-8"
+						>
+							<span
+								class="size-4 shrink-0 transition-colors duration-150 ease-out motion-reduce:transition-none"
+								:class="[item.done ? 'lucide-check' : 'lucide-x', iconColor(item)]"
+								aria-hidden="true"
+							/>
+							<span>{{ item.label }}</span>
+							<span class="sr-only">{{ item.done ? "done" : "missing" }}</span>
+						</li>
+					</ul>
 				</section>
 			</div>
-		</div>
-		<!-- The colour rides on the icon alone: the label stays at full contrast, so the
-		 row still reads when the two hues do not. -->
-		<section id="event-requirements" class="space-y-3 rounded-6 bg-surface-gray-1/90 p-4">
-			<h2 class="text-sm font-medium uppercase tracking-wide text-ink-gray-5">
-				{{ missingItems.length ? "Still needed" : "Ready to create" }}
-			</h2>
 
-			<ul class="space-y-2" aria-live="polite">
-				<li
-					v-for="item in checklist"
-					:key="item.label"
-					class="flex items-center gap-2 text-base text-ink-gray-8"
-				>
-					<!-- A row turning green is the only reward in this flow; a hard cut spends it. -->
-					<span
-						class="size-4 shrink-0 transition-colors duration-150 ease-out motion-reduce:transition-none"
-						:class="[item.done ? 'lucide-check' : 'lucide-x', iconColor(item)]"
-						aria-hidden="true"
-					/>
-					<span>{{ item.label }}</span>
-					<span class="sr-only">{{ item.done ? "done" : "missing" }}</span>
-				</li>
-			</ul>
-		</section>
+			<div v-else class="flex m-auto items-center justify-center gap-3 py-24">
+				<span v-if="failed" class="lucide-circle-x size-6 text-ink-red-6" aria-hidden="true" />
+				<LoadingIndicator v-else class="size-6 text-ink-gray-7" />
+				<TextMorph
+					:text="step"
+					class="text-base"
+					:class="failed ? 'text-ink-red-6' : 'text-ink-gray-7'"
+				/>
+			</div>
+		</Transition>
 	</div>
 </template>

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -130,6 +130,8 @@ function focusFirstMissing() {
 // The button stays live and the checklist says what is still missing, rather than
 // leaving the organiser to guess what would enable it.
 async function save() {
+	// The button is disabled through both, but a keyboard repeat outruns the re-render.
+	if (createEvent.loading || created.value) return
 	if (!canCreate.value) {
 		toast.error(MANAGER_REQUIRED)
 		return
@@ -174,10 +176,14 @@ async function save() {
 				<!-- Enabled even when incomplete, so the click can say what is missing. No
 				 aria-disabled: that reads as disabled to assistive tech and blocks the very
 				 click that explains the state. The checklist is named instead. -->
+				<!-- Held busy past the response as well: the redirect waits on a session
+				 check and a lazy chunk, and a live button on the page it just saved
+				 creates the event a second time. -->
 				<Button
 					variant="solid"
+					size="lg"
 					label="Create"
-					:loading="createEvent.loading"
+					:loading="createEvent.loading || created"
 					aria-describedby="event-requirements"
 					@click="save"
 				/>

--- a/dashboard/src/pages/manage/events/CreateEvent.vue
+++ b/dashboard/src/pages/manage/events/CreateEvent.vue
@@ -193,6 +193,8 @@ async function save() {
 	step.value = FINAL_STEP
 	toast.success(`${createEvent.data?.title} created`)
 	await wait(STEP_DURATION)
+	// Someone who walked off mid-save meant it; the toast already says the event exists.
+	if (router.currentRoute.value.name !== "create-event") return
 	router.push({ name: "event-details", params: { eventId: createEvent.data?.name } })
 }
 </script>

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -3257,6 +3257,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+torph@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/torph/-/torph-0.1.3.tgz#479b017319d6174f0ac821cd329d68fd48db1eeb"
+  integrity sha512-DOirbURFAedEZlK6Mx9jcAc7/gbDBUZNyXQwHUmQRXyUsbB3STYwb2PjiAy9iMc1eOWoQLfhm54DuPhWBPEibg==
+
 ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"


### PR DESCRIPTION
## What changed

- The create form is replaced by a progress panel while the save runs, instead of a spinning button over a form that still looks editable.
- Four steps play in order — details, schedule, venue, guest list — then "Opening event page" before the redirect.
- Steps and the request run under one `Promise.all`, putting a ~3s floor under the flow; the wait already existed, it just reads as work now.
- On failure the panel ends in place: red `lucide-circle-x`, "Failed to create event", toast with the server's message, then the form returns with the error in the header.
- That failure state is a local ref, not `createEvent.error` — the resource holds its error for the form's message long after the panel is done with it.
- Adds `torph` (MIT, no deps) for the per-character text morph; it keeps a plain-text copy of the line for assistive tech.

## Demo


https://github.com/user-attachments/assets/93c5b5e4-ee15-4274-a180-eb26cc2721fc



## Testing

Driven in Chromium against a local bench, with the create call delayed and forced to fail:

- Happy path: form → 4 steps → "Opening event page" → redirect to the new event.
- Failure: steps bail at the current one, panel goes red for 1.2s, form returns with the message; a retry starts clean and succeeds.
- `yarn typecheck`, `oxlint`, `oxfmt` pass. No new automated tests.

Note on the first commit: `torph` is 3 days old with a single maintainer. Read the dist before installing — no network calls, no `eval`, no process access. Pin it if that is too new for comfort.
