### PR TITLE
feat(events): publish new events with an opaque route

### DIFF
--- a/buzz/events/doctype/buzz_event/buzz_event.json
+++ b/buzz/events/doctype/buzz_event/buzz_event.json
@@ -213,7 +213,7 @@
    "label": "Banner Image"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_published",
    "fieldtype": "Check",
    "label": "Is Published?"
@@ -644,7 +644,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-09-08 12:00:00.000000",
+ "modified": "2026-09-10 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Buzz Event",

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -98,6 +98,11 @@ class BuzzEvent(Document):
 		venue: DF.Link | None
 	# end: auto-generated types
 
+	def before_insert(self):
+		# Opaque, not a title slug: a new event is published immediately.
+		if not self.route:
+			self.route = frappe.generate_hash(length=8)
+
 	def validate(self):
 		self.validate_dates()
 		self.validate_schedule()

--- a/buzz/events/doctype/buzz_event/test_buzz_event.py
+++ b/buzz/events/doctype/buzz_event/test_buzz_event.py
@@ -98,7 +98,7 @@ class TestBuzzEvent(FrappeTestCase):
 
 	# ==================== Reserved Route Tests ====================
 
-	def _make_event_with_route(self, route):
+	def _make_event_with_route(self, route=None, **overrides):
 		return frappe.get_doc(
 			{
 				"doctype": "Buzz Event",
@@ -109,6 +109,7 @@ class TestBuzzEvent(FrappeTestCase):
 				"start_time": "09:00:00",
 				"end_time": "18:00:00",
 				"route": route,
+				**overrides,
 			}
 		)
 
@@ -154,6 +155,27 @@ class TestBuzzEvent(FrappeTestCase):
 		event = self._make_event_with_route("my-conference-2026")
 		event.insert()
 		self.assertEqual(event.route, "my-conference-2026")
+
+	def test_new_event_is_published_with_a_hashed_route(self):
+		"""A new event is shareable on insert, on a route that is not its title."""
+		event = self._make_event_with_route()
+		event.insert()
+		self.assertTrue(event.is_published)
+		self.assertRegex(event.route, r"^[0-9a-f]{8}$")
+
+	def test_generated_routes_are_unique(self):
+		"""route is a unique column, so two events must not land on one hash."""
+		first = self._make_event_with_route()
+		first.insert()
+		second = self._make_event_with_route()
+		second.insert()
+		self.assertNotEqual(first.route, second.route)
+
+	def test_explicitly_unpublished_event_stays_a_draft(self):
+		"""The publish default must not override a caller asking for a draft."""
+		event = self._make_event_with_route(is_published=0)
+		event.insert()
+		self.assertFalse(event.is_published)
 
 	# ==================== Venue Tests ====================
 


### PR DESCRIPTION
## What changed

- New events default to published; `before_insert` sets an 8-char `frappe.generate_hash` route when none is given.
- Hash, not a title slug: no leaking the name of an unfinished event, no fight with the unique constraint or reserved segments.
- `is_published` default lives on the field, not the hook — `_set_defaults()` runs first, so a hook cannot tell unset from an explicit `is_published=0`.

## Demo

No dashboard changes — server-side defaults only.

## Testing

`bench --site testbuzz.localhost run-tests` on `test_buzz_event` (57), `api.events` (88), `test_permissions` (55), `api.booking` (42), `api.forms` (48) — all pass. `buzz.localhost` fails 24 in that module with and without this change (pre-existing `team` mandatory errors).