### PR TITLE
chore(dashboard): upgrade frappe-ui to 1.0.0-beta.63

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -19,7 +19,7 @@
 		"@vueuse/router": "^14.4.0",
 		"canvas-confetti": "^1.9.3",
 		"feather-icons": "^4.29.2",
-		"frappe-ui": "1.0.0-beta.55",
+		"frappe-ui": "1.0.0-beta.63",
 		"reka-ui": "^2.10.1",
 		"socket.io-client": "^4.7.2",
 		"torph": "^0.1.3",

--- a/dashboard/src/components/BookingEventInfo.vue
+++ b/dashboard/src/components/BookingEventInfo.vue
@@ -3,7 +3,11 @@
 		<div class="mb-8 flex items-center justify-between">
 			<h3 class="text-lg-semibold text-ink-gray-9">{{ event.title }}</h3>
 
-			<Button :link="`/events/${event.route}`" icon-left="external-link" variant="subtle" size="sm"
+			<Button
+				:link="`/events/${event.route}`"
+				icon-left="lucide-external-link"
+				variant="subtle"
+				size="sm"
 				>{{ __("Visit Event Page") }}
 			</Button>
 		</div>

--- a/dashboard/src/components/Navbar.vue
+++ b/dashboard/src/components/Navbar.vue
@@ -19,13 +19,19 @@
 					v-if="session.isLoggedIn"
 					:loading="session.logout.loading"
 					@click="session.logout.submit"
-					icon-right="log-out"
+					icon-right="lucide-log-out"
 					variant="ghost"
 					size="md"
 				>
 					{{ __("Log Out") }}
 				</Button>
-				<Button v-else @click="openLoginDialog" icon-right="log-in" variant="ghost" size="md">
+				<Button
+					v-else
+					@click="openLoginDialog"
+					icon-right="lucide-log-in"
+					variant="ghost"
+					size="md"
+				>
 					{{ __("Log In") }}
 				</Button>
 			</div>

--- a/dashboard/src/components/QRScanner.vue
+++ b/dashboard/src/components/QRScanner.vue
@@ -34,7 +34,13 @@
 					</template>
 					Start Scanner
 				</Button>
-				<Button @click="stopScanner" v-else variant="outline" class="flex-1" icon-left="square">
+				<Button
+					@click="stopScanner"
+					v-else
+					variant="outline"
+					class="flex-1"
+					icon-left="lucide-square"
+				>
 					{{ __("Stop Scanner") }}
 				</Button>
 			</div>

--- a/dashboard/src/components/common/BackButton.vue
+++ b/dashboard/src/components/common/BackButton.vue
@@ -1,5 +1,10 @@
 <template>
-	<Button variant="ghost" icon-left="chevron-left" :route="to" @click="$emit('click', $event)">
+	<Button
+		variant="ghost"
+		icon-left="lucide-chevron-left"
+		:route="to"
+		@click="$emit('click', $event)"
+	>
 		{{ label }}
 	</Button>
 </template>

--- a/dashboard/src/components/dashboard/CreateEventHeader.vue
+++ b/dashboard/src/components/dashboard/CreateEventHeader.vue
@@ -7,7 +7,7 @@ import { Button, PageHeader } from "frappe-ui"
 		<Button
 			class="ml-auto"
 			variant="solid"
-			icon-left="plus"
+			icon-left="lucide-plus"
 			label="Create Event"
 			:route="{ name: 'create-event' }"
 		/>

--- a/dashboard/src/pages/SponsorshipDetails.vue
+++ b/dashboard/src/pages/SponsorshipDetails.vue
@@ -300,7 +300,7 @@
 		title="Withdraw Sponsorship Inquiry"
 		message="Are you sure you want to withdraw this sponsorship inquiry? This action cannot be undone."
 		size="lg"
-		:icon="{ name: 'triangle-alert', theme: 'amber' }"
+		:icon="{ name: 'lucide-triangle-alert', theme: 'amber' }"
 		:actions="[
 			{
 				label: 'Withdraw Inquiry',

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -1910,10 +1910,10 @@ fraction.js@^4.1.2:
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz"
   integrity sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==
 
-frappe-ui@1.0.0-beta.55:
-  version "1.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.55.tgz#405b8e569d456d8b6679f4dd3109068c3982dfcc"
-  integrity sha512-+G+5GDVIr31+QJ2ekDpM8FOXUWzTO4oBhh9rMjfDzJnFGzISbAy4U7V/XOF3hYOkQz4R/QqnrHTD55o+JRcOoA==
+frappe-ui@1.0.0-beta.63:
+  version "1.0.0-beta.63"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.63.tgz#4538261c9fd8bad4802d55b9b46c3f42548cb1bd"
+  integrity sha512-wUVIAFwpBGQTnmItSfWaDVu1/OxT885ENWMH7FUVb9j9NGDnSwcQDwaPAJyRUjGp+91jL4Be2xS0cBCzhXcpvA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
## What changed

- Bumps `frappe-ui` from `1.0.0-beta.55` to `1.0.0-beta.63` (the v1 RC).
- None of the RC's breaking changes reach us — `Rail`, `TabButtons`, `Toast`, `Calendar`, `ThemeSwitcher`, the input scale and `ListView` columns were each checked against our call sites.
- Prefixes seven icon names with `lucide-`. These already rendered nothing on `beta.55` — `FeatherIcon` back-compat went away in `1.0.0`.
- oxfmt rewrapped four templates because the longer icon names pushed those lines over the limit.

## Demo

`skip-demo` — the icon fixes restore icons that were already blank, no other visual change.

## Testing

- `yarn typecheck`, `yarn lint`, `yarn build` clean.
- Walked events, create event, event details, tickets, proposals, sponsorships and bookings in the browser as Administrator; no frappe-ui console warnings left.