### PR TITLE
perf(dashboard): fetch user info once per app load

### DIFF
--- a/buzz/api/account/__init__.py
+++ b/buzz/api/account/__init__.py
@@ -27,7 +27,7 @@ def get_user_info() -> UserInfoResponse | GuestInfoResponse:
 		user_image=user.user_image,
 		bio=user.bio,
 		roles=user.roles,
-		brand_image=frappe.get_single_value("Website Settings", "banner_image"),
+		brand_image=frappe.get_cached_value("Website Settings", "Website Settings", "banner_image"),
 		language=user.language,
 		time_zone=user.time_zone,
 	)

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -419,7 +419,7 @@ import LucideX from "~icons/lucide/x"
 import BillingDetails from "@/components/BillingDetails.vue"
 import { useBookingFormStorage } from "@/composables/useBookingFormStorage"
 import { useLoginDialog } from "@/composables/useLoginDialog"
-import { userResource } from "@/data/user"
+import { loadUser, userResource } from "@/data/user"
 import type {
 	AvailableAddOn,
 	AvailableTicketType,
@@ -575,9 +575,8 @@ onUnmounted(() => {
 	clearInterval(resendCooldownTimer)
 })
 
-// Ensure user data is loaded (only if not in guest mode)
-if (!props.isGuestMode && !userResource.data) {
-	userResource.fetch()
+if (!props.isGuestMode) {
+	loadUser()
 }
 
 // --- HELPERS / DERIVED STATE ---

--- a/dashboard/src/data/user.ts
+++ b/dashboard/src/data/user.ts
@@ -6,3 +6,12 @@ export const userResource = createResource<UserInfo>({
 	url: "buzz.api.account.get_user_info",
 	cache: "User",
 })
+
+let pending: Promise<unknown> | null = null
+
+// Session info doesn't change between navigations, so it is fetched once per app load.
+// Anything that changes it (login, profile and preference saves) calls reload() itself.
+export function loadUser() {
+	pending ??= userResource.fetch().catch(() => null)
+	return pending
+}

--- a/dashboard/src/data/user.ts
+++ b/dashboard/src/data/user.ts
@@ -11,7 +11,11 @@ let pending: Promise<unknown> | null = null
 
 // Session info doesn't change between navigations, so it is fetched once per app load.
 // Anything that changes it (login, profile and preference saves) calls reload() itself.
+// A failed fetch clears the memo so the next navigation retries.
 export function loadUser() {
-	pending ??= userResource.fetch().catch(() => null)
+	pending ??= userResource.fetch().catch(() => {
+		pending = null
+		return null
+	})
 	return pending
 }

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -1,7 +1,7 @@
 import { type RouteRecordRaw, createRouter, createWebHistory } from "vue-router"
 
 import { isTeamMember } from "@/data/teams"
-import { userResource } from "@/data/user"
+import { loadUser } from "@/data/user"
 
 const APP_NAME = "Buzz"
 
@@ -240,11 +240,7 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to, from, next) => {
-	try {
-		await userResource.fetch()
-	} catch {
-		// user is not logged in — Layout will show LoginRequired for protected routes
-	}
+	await loadUser()
 	next()
 })
 


### PR DESCRIPTION
## What changed

- The router guard awaited `userResource.fetch()` per navigation; `createResource` has no dedupe or TTL, so every link click cost a blocking `get_user_info` round trip.
- `loadUser()` memoizes the first fetch and clears the memo on failure so a transient error still retries; the guard and `BookingForm` both use it.
- `reload()` after login, profile save and preference save bypasses the memo, so invalidation is unchanged.
- `get_user_info` now uses `get_cached_value` for `banner_image` in the logged-in branch, matching the guest branch above it.

## Demo

`skip-demo` — no visual change; one `get_user_info` per session instead of one per navigation.

## Testing

- `vue-tsc --noEmit` clean on `src/`; no unit test, since the dashboard suite is `node:test` over pure functions with no module mocking.
