### PR TITLE
feat(events): archive an event from a new More space

### DIFF
--- a/buzz/api/events/__init__.py
+++ b/buzz/api/events/__init__.py
@@ -2,6 +2,7 @@ import frappe
 
 from buzz.api.events import services
 from buzz.api.events.schemas import (
+	ArchiveState,
 	CreatedEvent,
 	EventDetail,
 	EventGuestsResponse,
@@ -54,6 +55,12 @@ def get_event_guests(
 def set_registration_state(event: str, closed: bool) -> RegistrationState:
 	"""Open or close an event's registrations, answering with the state that results."""
 	return services.set_registration_state(event, closed)
+
+
+@frappe.whitelist(methods=["POST"])
+def archive_event(event: str) -> ArchiveState:
+	"""Take an event and the forms it serves off the public site."""
+	return services.archive_event(event)
 
 
 @frappe.whitelist()

--- a/buzz/api/events/__init__.py
+++ b/buzz/api/events/__init__.py
@@ -2,7 +2,6 @@ import frappe
 
 from buzz.api.events import services
 from buzz.api.events.schemas import (
-	ArchiveState,
 	CreatedEvent,
 	EventDetail,
 	EventGuestsResponse,
@@ -58,9 +57,9 @@ def set_registration_state(event: str, closed: bool) -> RegistrationState:
 
 
 @frappe.whitelist(methods=["POST"])
-def archive_event(event: str) -> ArchiveState:
+def archive_event(event: str) -> None:
 	"""Take an event and the forms it serves off the public site."""
-	return services.archive_event(event)
+	services.archive_event(event)
 
 
 @frappe.whitelist()

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -185,12 +185,6 @@ class RegistrationState(APIResponse):
 	registrations_closed: bool
 
 
-class ArchiveState(APIResponse):
-	"""Whether the event is off the public site, as the server reads it after a change."""
-
-	archived: bool
-
-
 class VerificationMethods(APIResponse):
 	"""Which guest verification methods this site is configured to deliver."""
 

--- a/buzz/api/events/schemas.py
+++ b/buzz/api/events/schemas.py
@@ -185,6 +185,12 @@ class RegistrationState(APIResponse):
 	registrations_closed: bool
 
 
+class ArchiveState(APIResponse):
+	"""Whether the event is off the public site, as the server reads it after a change."""
+
+	archived: bool
+
+
 class VerificationMethods(APIResponse):
 	"""Which guest verification methods this site is configured to deliver."""
 

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -13,7 +13,6 @@ from buzz.api.events.exceptions import (
 	ZoomNotAvailable,
 )
 from buzz.api.events.schemas import (
-	ArchiveState,
 	CreatedEvent,
 	DailyRegistrations,
 	EventDetail,
@@ -303,15 +302,9 @@ def set_registration_state(event: str, closed: bool) -> RegistrationState:
 	return RegistrationState(registrations_closed=are_registrations_closed(doc))
 
 
-def archive_event(event: str) -> ArchiveState:
-	"""Take the event and its forms off the public site, answering with the resulting state.
-
-	Unarchiving is the plain `is_published` write the dashboard already makes; it does not
-	republish the forms this closed.
-	"""
-	doc = manageable_event(event)
-	doc.archive_event()
-	return ArchiveState(archived=not doc.is_published)
+def archive_event(event: str) -> None:
+	"""Take the event and its forms off the public site."""
+	manageable_event(event).archive_event()
 
 
 def verification_methods() -> VerificationMethods:

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -13,6 +13,7 @@ from buzz.api.events.exceptions import (
 	ZoomNotAvailable,
 )
 from buzz.api.events.schemas import (
+	ArchiveState,
 	CreatedEvent,
 	DailyRegistrations,
 	EventDetail,
@@ -298,6 +299,17 @@ def set_registration_state(event: str, closed: bool) -> RegistrationState:
 	doc.registrations_close_at = get_datetime_in_timezone(timezone).replace(tzinfo=None) if closed else None
 	doc.save()
 	return RegistrationState(registrations_closed=are_registrations_closed(doc))
+
+
+def archive_event(event: str) -> ArchiveState:
+	"""Take the event and its forms off the public site, answering with the resulting state.
+
+	Unarchiving is the plain `is_published` write the dashboard already makes; it does not
+	republish the forms this closed.
+	"""
+	doc = manageable_event(event)
+	doc.archive_event()
+	return ArchiveState(archived=not doc.is_published)
 
 
 def verification_methods() -> VerificationMethods:

--- a/buzz/api/events/services.py
+++ b/buzz/api/events/services.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _
 from frappe.query_builder import Case
 from frappe.query_builder.functions import Count, Date
-from frappe.utils import add_days, get_datetime_in_timezone, get_system_timezone, getdate
+from frappe.utils import add_days, getdate
 
 from buzz.api.booking.guests import email_otp_available, phone_otp_available
 from buzz.api.booking.services import are_registrations_closed
@@ -295,8 +295,10 @@ def set_registration_state(event: str, closed: bool) -> RegistrationState:
 	which closes registrations on its own — hence the state rather than an acknowledgement.
 	"""
 	doc = manageable_event(event)
-	timezone = doc.time_zone or get_system_timezone()
-	doc.registrations_close_at = get_datetime_in_timezone(timezone).replace(tzinfo=None) if closed else None
+	if closed:
+		doc.close_registrations()
+	else:
+		doc.registrations_close_at = None
 	doc.save()
 	return RegistrationState(registrations_closed=are_registrations_closed(doc))
 

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -1142,7 +1142,7 @@ class TestArchiveEvent(IntegrationTestCase):
 		publish_forms(event)
 		frappe.set_user(self.owner)
 
-		self.assertTrue(archive_event(event).archived)
+		archive_event(event)
 
 		doc = frappe.get_doc("Buzz Event", event)
 		self.assertFalse(doc.is_published)
@@ -1158,10 +1158,13 @@ class TestArchiveEvent(IntegrationTestCase):
 		self.assertIsNotNone(frappe.db.get_value("Buzz Event", event, "registrations_close_at"))
 
 	def test_archiving_an_archived_event_is_a_no_op(self):
+		"""validate() runs on the way through, so a second archive must not throw."""
 		event = create_event("Already Archived Event", self.team, is_published=0)
 		frappe.set_user(self.owner)
 
-		self.assertTrue(archive_event(event).archived)
+		archive_event(event)
+
+		self.assertFalse(frappe.db.get_value("Buzz Event", event, "is_published"))
 
 	def test_someone_outside_the_team_cannot_archive(self):
 		event = create_event("Guarded Event", self.team, is_published=1)

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from buzz.api.events import (
 	add_co_host,
+	archive_event,
 	check_event_route,
 	get_event,
 	get_event_guests,
@@ -1114,3 +1115,50 @@ class TestVerificationMethods(IntegrationTestCase):
 		from frappe.email.doctype.email_account.email_account import EmailAccount
 
 		self.assertEqual(get_verification_methods().email, bool(EmailAccount.find_default_outgoing()))
+
+
+def publish_forms(event: str) -> None:
+	"""`publish` defaults to 0, so the rows have to be opened before a close means anything."""
+	doc = frappe.get_doc("Buzz Event", event)
+	for row in doc.custom_forms:
+		row.publish = 1
+	doc.save(ignore_permissions=True)
+
+
+class TestArchiveEvent(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = create_user("archive-owner@example.com", "Archive Owner")
+		cls.outsider = create_user("archive-outsider@example.com", "Archive Outsider")
+		cls.team = create_owned_team("Archive Team", cls.owner)
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def test_archiving_unpublishes_the_event_and_its_forms(self):
+		event = create_event("Archivable Event", self.team, is_published=1)
+		publish_forms(event)
+		frappe.set_user(self.owner)
+
+		self.assertTrue(archive_event(event).archived)
+
+		doc = frappe.get_doc("Buzz Event", event)
+		self.assertFalse(doc.is_published)
+		self.assertFalse(any(row.publish for row in doc.custom_forms))
+
+	def test_archiving_an_archived_event_is_a_no_op(self):
+		event = create_event("Already Archived Event", self.team, is_published=0)
+		frappe.set_user(self.owner)
+
+		self.assertTrue(archive_event(event).archived)
+
+	def test_someone_outside_the_team_cannot_archive(self):
+		event = create_event("Guarded Event", self.team, is_published=1)
+		frappe.set_user(self.outsider)
+
+		with self.assertRaises(CannotManageEvent):
+			archive_event(event)
+
+		self.assertTrue(frappe.db.get_value("Buzz Event", event, "is_published"))

--- a/buzz/api/events/test_events.py
+++ b/buzz/api/events/test_events.py
@@ -1148,6 +1148,15 @@ class TestArchiveEvent(IntegrationTestCase):
 		self.assertFalse(doc.is_published)
 		self.assertFalse(any(row.publish for row in doc.custom_forms))
 
+	def test_archiving_closes_registrations(self):
+		"""The booking gates stop at `is_published`, but the cutoff has to agree with them."""
+		event = create_event("Open Registrations Event", self.team, is_published=1)
+		frappe.set_user(self.owner)
+
+		archive_event(event)
+
+		self.assertIsNotNone(frappe.db.get_value("Buzz Event", event, "registrations_close_at"))
+
 	def test_archiving_an_archived_event_is_a_no_op(self):
 		event = create_event("Already Archived Event", self.team, is_published=0)
 		frappe.set_user(self.owner)

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -257,6 +257,18 @@ class BuzzEvent(Document):
 			self.append("custom_forms", form)
 		self.save(ignore_permissions=True)
 
+	def archive_event(self):
+		"""Take the event off the public site, along with every form it serves.
+
+		The public form page already refuses an unpublished event, so unpublishing the
+		rows is the stored state catching up with that gate: a row left published would
+		reopen its form the moment the event is published again.
+		"""
+		self.is_published = 0
+		for form in self.custom_forms:
+			form.publish = 0
+		self.save()
+
 	@frappe.whitelist()
 	@only_if_app_installed("zoom_integration", raise_exception=True)
 	def create_webinar_on_zoom(self):

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -259,11 +259,10 @@ class BuzzEvent(Document):
 		self.save(ignore_permissions=True)
 
 	def archive_event(self):
-		"""Take the event off the public site, along with every form it serves.
+		"""Take the event off the public site, along with the forms and registrations it takes.
 
-		The public form page already refuses an unpublished event, so unpublishing the
-		rows is the stored state catching up with that gate: a row left published would
-		reopen its form the moment the event is published again.
+		The booking and form gates already refuse an unpublished event; this is the stored
+		state catching up, so publishing again does not reopen everything with it.
 		"""
 		self.is_published = 0
 		self.close_registrations()

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
+from frappe.utils import get_datetime_in_timezone, get_system_timezone
 from frappe.utils.data import get_datetime, get_time, time_diff_in_seconds
 
 from buzz.api.forms.fields import validate_excluded_fields
@@ -265,9 +266,15 @@ class BuzzEvent(Document):
 		reopen its form the moment the event is published again.
 		"""
 		self.is_published = 0
+		self.close_registrations()
 		for form in self.custom_forms:
 			form.publish = 0
 		self.save()
+
+	def close_registrations(self):
+		"""Stop new registrations now, read on the event's own wall clock."""
+		timezone = self.time_zone or get_system_timezone()
+		self.registrations_close_at = get_datetime_in_timezone(timezone).replace(tzinfo=None)
 
 	@frappe.whitelist()
 	@only_if_app_installed("zoom_integration", raise_exception=True)

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -42,6 +42,7 @@ declare module 'vue' {
     DrawerContent: typeof import('./src/components/common/drawer/DrawerContent.vue')['default']
     EmailSettingsDialog: typeof import('./src/components/dashboard/communications/EmailSettingsDialog.vue')['default']
     EmptyState: typeof import('./src/components/common/EmptyState.vue')['default']
+    EventArchivedAlert: typeof import('./src/components/dashboard/events/EventArchivedAlert.vue')['default']
     EventBanner: typeof import('./src/components/dashboard/events/EventBanner.vue')['default']
     EventCard: typeof import('./src/components/dashboard/events/EventCard.vue')['default']
     EventCountdownPill: typeof import('./src/components/dashboard/events/EventCountdownPill.vue')['default']

--- a/dashboard/src/components/dashboard/events/EventArchivedAlert.vue
+++ b/dashboard/src/components/dashboard/events/EventArchivedAlert.vue
@@ -14,7 +14,12 @@ const archived = computed(() => Boolean(eventDoc.doc) && !eventDoc.doc?.is_publi
 </script>
 
 <template>
-	<Alert v-if="archived" theme="amber" :title="__('This event is archived')">
+	<Alert
+		v-if="archived"
+		theme="amber"
+		:title="__('This event is archived')"
+		class="dark:!bg-surface-gray-2"
+	>
 		<template #description>
 			{{ __("The event page is offline and its forms are no longer accepting responses.") }}
 			<RouterLink
@@ -23,7 +28,7 @@ const archived = computed(() => Boolean(eventDoc.doc) && !eventDoc.doc?.is_publi
 			>
 				{{ __("Unarchive the event") }}
 			</RouterLink>
-			{{ __("from More to bring it back online.") }}
+			{{ __("to make the event page live.") }}
 		</template>
 	</Alert>
 </template>

--- a/dashboard/src/components/dashboard/events/EventArchivedAlert.vue
+++ b/dashboard/src/components/dashboard/events/EventArchivedAlert.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { Alert } from "frappe-ui"
+import { computed } from "vue"
+
+import { useEventDoc } from "@/data/events"
+
+// Each space of an event carries this itself, and the way back sits in the notice: the
+// setting that undoes it lives on only one of them.
+const props = defineProps<{ event: string }>()
+
+const eventDoc = useEventDoc(() => props.event)
+
+const archived = computed(() => Boolean(eventDoc.doc) && !eventDoc.doc?.is_published)
+</script>
+
+<template>
+	<Alert v-if="archived" theme="amber" :title="__('This event is archived')">
+		<template #description>
+			{{ __("The event page is offline and its forms are no longer accepting responses.") }}
+			<RouterLink
+				:to="`/manage/events/${event}/more`"
+				class="font-medium underline underline-offset-2"
+			>
+				{{ __("Unarchive the event") }}
+			</RouterLink>
+			{{ __("from More to bring it back online.") }}
+		</template>
+	</Alert>
+</template>

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -93,6 +93,23 @@ export function useAddCoHost() {
 }
 
 /**
+ * Whether the session user may write to an event.
+ *
+ * Core's own check, so it runs through Buzz's `team_has_permission` hook and answers for
+ * an unrestricted user too — a System Manager holds no membership, so reading the role off
+ * the loaded teams list would deny them.
+ */
+export function useCanWriteEvent(event: string) {
+	return useCall<
+		{ has_permission: boolean },
+		{ doctype: string; docname: string; perm_type: string }
+	>({
+		url: "/api/v2/method/frappe.client.has_permission",
+		params: { doctype: "Buzz Event", docname: event, perm_type: "write" },
+	})
+}
+
+/**
  * Take an event and the forms it serves off the public site.
  *
  * Archiving is more than the `is_published` write its opposite is — the endpoint also

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -92,6 +92,21 @@ export function useAddCoHost() {
 	})
 }
 
+/**
+ * Take an event and the forms it serves off the public site.
+ *
+ * Archiving is more than the `is_published` write its opposite is — the endpoint also
+ * closes the event's forms — so it does not go through `setValue`. Reload the doc after
+ * it lands: the store has no idea the server moved.
+ */
+export function useArchiveEvent() {
+	return useCall<{ archived: boolean }, { event: string }>({
+		url: "/api/v2/method/buzz.api.events.archive_event",
+		method: "POST",
+		immediate: false,
+	})
+}
+
 /** Drop a co-host from the event. The Event Host record itself is left alone. */
 export function useRemoveCoHost() {
 	return useCall<null, { event: string; host: string }>({

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -1,4 +1,4 @@
-import { createResource, useCall } from "frappe-ui"
+import { createResource, useCall, useDoc } from "frappe-ui"
 
 import type {
 	EventDetail,
@@ -23,6 +23,21 @@ export function useMyEvents(filters?: () => Record<string, string>) {
 export const createEvent = createResource<{ name: string; title: string }>({
 	url: "buzz.api.events.create_event",
 })
+
+/** What the manage shell reads off the event itself: its title, and whether it is live. */
+type EventShellDoc = { name: string; title: string; is_published: 0 | 1 }
+
+/**
+ * The event document, shared by everything that reads or flips its publish state.
+ *
+ * useDoc keys into frappe-ui's document store, so the shell's archived banner and the
+ * setting that archives the event work off one reactive doc — a write through `setValue`
+ * lands in both without either knowing about the other.
+ */
+export function useEventDoc(event: () => string) {
+	// The empty string holds the initial fetch until the route param resolves.
+	return useDoc<EventShellDoc>({ doctype: "Buzz Event", name: () => event() || "" })
+}
 
 /** One event with everything its manage page edits. Per page, so it is not a singleton. */
 export function eventDetail(event: string) {

--- a/dashboard/src/data/events.ts
+++ b/dashboard/src/data/events.ts
@@ -100,7 +100,7 @@ export function useAddCoHost() {
  * it lands: the store has no idea the server moved.
  */
 export function useArchiveEvent() {
-	return useCall<{ archived: boolean }, { event: string }>({
+	return useCall<null, { event: string }>({
 		url: "/api/v2/method/buzz.api.events.archive_event",
 		method: "POST",
 		immediate: false,

--- a/dashboard/src/layouts/ManagerLayout.vue
+++ b/dashboard/src/layouts/ManagerLayout.vue
@@ -6,7 +6,7 @@ import { useRoute } from "vue-router"
 import ManagerSidebarHeader from "@/components/dashboard/ManagerSidebarHeader.vue"
 import UserMenu from "@/components/UserMenu.vue"
 import { useTeamAccess } from "@/composables/useTeamAccess"
-import { eventDetail } from "@/data/events"
+import { useEventDoc } from "@/data/events"
 import { useMySponsorships } from "@/data/sponsorships"
 import NotFound from "@/pages/NotFound.vue"
 
@@ -54,19 +54,12 @@ watch(headerKey, (key, previous) => {
 	direction.value = previous === "root" && key !== "root" ? "forward" : "back"
 })
 
-const eventTitle = ref("")
-watch(
-	eventId,
-	(id) => {
-		eventTitle.value = ""
-		if (!id) return
-		// Drops a late response for an event the user has already left.
-		eventDetail(id).promise?.then((event) => {
-			if (eventId.value === id) eventTitle.value = event?.title ?? ""
-		})
-	},
-	{ immediate: true },
-)
+// Keyed by the route param, so the doc follows the event the user is looking at. Shared
+// through frappe-ui's document store, so the spaces reading the same event pay for one
+// fetch between them.
+const eventDoc = useEventDoc(() => eventId.value ?? "")
+
+const eventTitle = computed(() => eventDoc.doc?.title ?? "")
 
 usePageMeta(() => {
 	const section = route.meta.title as string | undefined
@@ -84,6 +77,7 @@ const items = computed(() => {
 		{ label: "Guests", icon: "lucide-users-round", to: `${event}/guests` },
 		{ label: "Talks", icon: "lucide-presentation", to: `${event}/talks` },
 		{ label: "Announcements", icon: "lucide-megaphone", to: `${event}/communications` },
+		{ label: "More", icon: "lucide-ellipsis", to: `${event}/more` },
 	]
 })
 </script>

--- a/dashboard/src/pages/manage/events/EventCommunications.vue
+++ b/dashboard/src/pages/manage/events/EventCommunications.vue
@@ -8,6 +8,7 @@ import CommunicationActions from "@/components/dashboard/communications/Communic
 import CommunicationComposer from "@/components/dashboard/communications/CommunicationComposer.vue"
 import CommunicationDrawer from "@/components/dashboard/communications/CommunicationDrawer.vue"
 import CommunicationHistory from "@/components/dashboard/communications/CommunicationHistory.vue"
+import EventArchivedAlert from "@/components/dashboard/events/EventArchivedAlert.vue"
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
 import { useEventCommunications, useSendCommunication } from "@/data/communications"
 import { session } from "@/data/session"
@@ -97,6 +98,8 @@ const canWrite = computed(() => !!page.data?.can_write)
 	<EventPageHeader :title="page.data?.title" section="Announcements" />
 
 	<PageWithSidebar>
+		<EventArchivedAlert :event="eventId" />
+
 		<section class="space-y-3">
 			<h1 class="text-xl font-semibold text-ink-gray-9">Send an Announcement</h1>
 			<Skeleton v-if="page.loading && !page.data" class="h-40 w-full rounded-8" />

--- a/dashboard/src/pages/manage/events/EventDetails.vue
+++ b/dashboard/src/pages/manage/events/EventDetails.vue
@@ -5,6 +5,7 @@ import { Editor, EditorContent, EditorFixedMenu } from "frappe-ui/editor"
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue"
 import { useRoute } from "vue-router"
 
+import EventArchivedAlert from "@/components/dashboard/events/EventArchivedAlert.vue"
 import EventBanner from "@/components/dashboard/events/EventBanner.vue"
 import EventDetailsSkeleton from "@/components/dashboard/events/EventDetailsSkeleton.vue"
 import EventHosts from "@/components/dashboard/events/EventHosts.vue"
@@ -192,6 +193,8 @@ async function save() {
 		enter-from-class="opacity-0"
 	>
 		<div v-if="event.data" class="m-auto w-full max-w-[800px] space-y-8 px-4 py-8">
+			<EventArchivedAlert :event="eventId" />
+
 			<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
 			<EventBanner v-model="form.banner_image" :seed="form.title" />

--- a/dashboard/src/pages/manage/events/EventGuests.vue
+++ b/dashboard/src/pages/manage/events/EventGuests.vue
@@ -7,6 +7,7 @@ import { computed, ref } from "vue"
 import { useRoute } from "vue-router"
 
 import { FilterBar, type FilterGroup, type FilterValues } from "@/components/common/filters"
+import EventArchivedAlert from "@/components/dashboard/events/EventArchivedAlert.vue"
 import EventGuestActions from "@/components/dashboard/events/EventGuestActions.vue"
 import EventGuestItem from "@/components/dashboard/events/EventGuestItem.vue"
 import EventGuestSkeleton from "@/components/dashboard/events/EventGuestSkeleton.vue"
@@ -155,6 +156,8 @@ useIntersectionObserver(sentinel, ([entry]) => entry?.isIntersecting && loadMore
 	<EventPageHeader :title="page.data?.title" section="Guests" />
 
 	<PageWithSidebar>
+		<EventArchivedAlert :event="eventId" />
+
 		<section class="space-y-2">
 			<h1 class="text-xl font-semibold text-ink-gray-9">How it's going</h1>
 

--- a/dashboard/src/pages/manage/events/EventMore.vue
+++ b/dashboard/src/pages/manage/events/EventMore.vue
@@ -4,7 +4,7 @@ import { computed } from "vue"
 import { useRoute } from "vue-router"
 
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
-import { useArchiveEvent, useEventDoc } from "@/data/events"
+import { useArchiveEvent, useCanWriteEvent, useEventDoc } from "@/data/events"
 
 // A settings row and the group it belongs to. The page renders whatever this describes,
 // so a new setting is an entry here rather than another block of markup.
@@ -22,6 +22,11 @@ const eventId = route.params.eventId as string
 
 const event = useEventDoc(() => eventId)
 const archiveEvent = useArchiveEvent()
+
+// Viewers and Frontdesk reach this page — the shell only gates on team membership — but
+// the server refuses the write. Read-only sees the setting, greyed, rather than a button
+// that always fails.
+const canWrite = useCanWriteEvent(eventId)
 
 // Only read once the doc has landed, so a null doc never renders as "not archived".
 const archived = computed(() => !event.doc?.is_published)
@@ -120,6 +125,7 @@ async function unarchive() {
 								:label="setting.action.label"
 								:theme="setting.action.theme"
 								:loading="busy"
+								:disabled="!canWrite.data?.has_permission"
 								class="transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97] motion-reduce:active:scale-100"
 								@click="setting.action.onClick"
 							/>

--- a/dashboard/src/pages/manage/events/EventMore.vue
+++ b/dashboard/src/pages/manage/events/EventMore.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { Button, dialog, toast } from "frappe-ui"
+import { computed } from "vue"
+import { useRoute } from "vue-router"
+
+import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
+import { useEventDoc } from "@/data/events"
+import PageWithSidebar from "@/layouts/PageWithSidebar.vue"
+
+const route = useRoute()
+const eventId = route.params.eventId as string
+
+const event = useEventDoc(() => eventId)
+
+const archived = computed(() => Boolean(event.doc) && !event.doc?.is_published)
+
+// Archiving takes the event off the public site, so it is worth a confirmation. Coming
+// back online is not destructive and goes straight through.
+function confirmArchive() {
+	dialog.confirm({
+		title: __("Archive Event"),
+		message: __(
+			"The event page goes offline and its forms stop accepting responses. You can unarchive it from here at any time.",
+		),
+		theme: "red",
+		confirmLabel: __("Archive"),
+		onConfirm: async () => {
+			await publish(0)
+			// The call settles either way, so the failure has to be rethrown to reach the dialog.
+			if (event.setValue.error) throw event.setValue.error
+		},
+	})
+}
+
+async function publish(is_published: 0 | 1) {
+	await event.setValue.submit({ is_published })
+	if (event.setValue.error) {
+		// An event that never had a route cannot be published — the server says so.
+		toast.error(event.setValue.error.message || __("Could not save the event"))
+		return
+	}
+	toast.success(is_published ? __("Event is back online") : __("Event archived"))
+}
+</script>
+
+<template>
+	<EventPageHeader :title="event.doc?.title" section="More" />
+
+	<PageWithSidebar>
+		<section class="space-y-3">
+			<h1 class="text-xl font-semibold text-ink-gray-9">{{ __("Danger") }}</h1>
+
+			<!-- One row per setting, divided rather than boxed each: the card is the group. -->
+			<div class="divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1">
+				<div class="flex flex-wrap items-center justify-between gap-3 p-4">
+					<div class="space-y-1">
+						<h2 class="font-medium text-ink-gray-8">
+							{{ archived ? __("Unarchive event") : __("Archive event") }}
+						</h2>
+						<p class="text-p-sm text-ink-gray-6">
+							{{
+								archived
+									? __("Puts the event page back online and reopens its forms.")
+									: __("Takes the event page offline and stops its forms accepting responses.")
+							}}
+						</p>
+					</div>
+
+					<Button
+						v-if="archived"
+						:label="__('Unarchive')"
+						:loading="event.setValue.loading"
+						@click="publish(1)"
+					/>
+					<Button
+						v-else
+						theme="red"
+						variant="subtle"
+						:label="__('Archive')"
+						:loading="event.setValue.loading"
+						@click="confirmArchive"
+					/>
+				</div>
+			</div>
+		</section>
+	</PageWithSidebar>
+</template>

--- a/dashboard/src/pages/manage/events/EventMore.vue
+++ b/dashboard/src/pages/manage/events/EventMore.vue
@@ -1,34 +1,63 @@
 <script setup lang="ts">
-import { Button, dialog, toast } from "frappe-ui"
+import { Button, Skeleton, dialog, toast } from "frappe-ui"
 import { computed } from "vue"
 import { useRoute } from "vue-router"
 
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
 import { useEventDoc } from "@/data/events"
-import PageWithSidebar from "@/layouts/PageWithSidebar.vue"
+
+// A settings row and the group it belongs to. The page renders whatever this describes,
+// so a new setting is an entry here rather than another block of markup.
+type Setting = {
+	name: string
+	title: string
+	description: string
+	action: { label: string; theme?: "red"; onClick: () => void }
+}
+
+type SettingGroup = { name: string; title: string; settings: Setting[] }
 
 const route = useRoute()
 const eventId = route.params.eventId as string
 
 const event = useEventDoc(() => eventId)
 
-const archived = computed(() => Boolean(event.doc) && !event.doc?.is_published)
+// Only read once the doc has landed, so a null doc never renders as "not archived".
+const archived = computed(() => !event.doc?.is_published)
+
+const settingGroups = computed<SettingGroup[]>(() => [
+	{ name: "danger", title: __("Danger"), settings: [archiveSetting()] },
+])
+
+// One row, two directions: which one it offers depends on where the event stands.
+function archiveSetting(): Setting {
+	if (archived.value)
+		return {
+			name: "archive",
+			title: __("Unarchive event"),
+			description: __("Puts the event page back online."),
+			action: { label: __("Unarchive"), onClick: () => publish(1) },
+		}
+
+	return {
+		name: "archive",
+		title: __("Archive event"),
+		description: __("Takes the event page offline. Its forms will stop accepting responses."),
+		action: { label: __("Archive"), theme: "red", onClick: confirmArchive },
+	}
+}
 
 // Archiving takes the event off the public site, so it is worth a confirmation. Coming
 // back online is not destructive and goes straight through.
 function confirmArchive() {
 	dialog.confirm({
-		title: __("Archive Event"),
+		title: __("Archive Event?"),
 		message: __(
 			"The event page goes offline and its forms stop accepting responses. You can unarchive it from here at any time.",
 		),
 		theme: "red",
 		confirmLabel: __("Archive"),
-		onConfirm: async () => {
-			await publish(0)
-			// The call settles either way, so the failure has to be rethrown to reach the dialog.
-			if (event.setValue.error) throw event.setValue.error
-		},
+		onConfirm: () => publish(0),
 	})
 }
 
@@ -46,42 +75,42 @@ async function publish(is_published: 0 | 1) {
 <template>
 	<EventPageHeader :title="event.doc?.title" section="More" />
 
-	<PageWithSidebar>
-		<section class="space-y-3">
-			<h1 class="text-xl font-semibold text-ink-gray-9">{{ __("Danger") }}</h1>
+	<div class="m-auto w-full max-w-[800px] space-y-8 px-4 py-8">
+		<section v-for="group in settingGroups" :key="group.name" class="space-y-3">
+			<h2 class="text-lg font-semibold text-ink-gray-9">{{ group.title }}</h2>
 
 			<!-- One row per setting, divided rather than boxed each: the card is the group. -->
-			<div class="divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1">
-				<div class="flex flex-wrap items-center justify-between gap-3 p-4">
-					<div class="space-y-1">
-						<h2 class="font-medium text-ink-gray-8">
-							{{ archived ? __("Unarchive event") : __("Archive event") }}
-						</h2>
-						<p class="text-p-sm text-ink-gray-6">
-							{{
-								archived
-									? __("Puts the event page back online and reopens its forms.")
-									: __("Takes the event page offline and stops its forms accepting responses.")
-							}}
-						</p>
-					</div>
-
-					<Button
-						v-if="archived"
-						:label="__('Unarchive')"
-						:loading="event.setValue.loading"
-						@click="publish(1)"
-					/>
-					<Button
-						v-else
-						theme="red"
-						variant="subtle"
-						:label="__('Archive')"
-						:loading="event.setValue.loading"
-						@click="confirmArchive"
-					/>
+			<div class="overflow-hidden rounded-6 border border-outline-gray-2">
+				<div v-if="!event.doc" class="p-4">
+					<Skeleton class="h-11 w-full rounded-4" />
 				</div>
+
+				<Transition
+					enter-active-class="transition-opacity duration-200 ease-out motion-reduce:transition-none"
+					enter-from-class="opacity-0"
+				>
+					<div v-if="event.doc" class="divide-y divide-outline-gray-1">
+						<div
+							v-for="setting in group.settings"
+							:key="setting.name"
+							class="flex flex-wrap items-center justify-between gap-3 p-4"
+						>
+							<div class="space-y-1">
+								<h3 class="font-medium text-base text-ink-gray-8">{{ setting.title }}</h3>
+								<p class="text-p-sm text-ink-gray-6">{{ setting.description }}</p>
+							</div>
+
+							<Button
+								:label="setting.action.label"
+								:theme="setting.action.theme"
+								:loading="event.setValue.loading"
+								class="transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97] motion-reduce:active:scale-100"
+								@click="setting.action.onClick"
+							/>
+						</div>
+					</div>
+				</Transition>
 			</div>
 		</section>
-	</PageWithSidebar>
+	</div>
 </template>

--- a/dashboard/src/pages/manage/events/EventMore.vue
+++ b/dashboard/src/pages/manage/events/EventMore.vue
@@ -4,7 +4,7 @@ import { computed } from "vue"
 import { useRoute } from "vue-router"
 
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
-import { useEventDoc } from "@/data/events"
+import { useArchiveEvent, useEventDoc } from "@/data/events"
 
 // A settings row and the group it belongs to. The page renders whatever this describes,
 // so a new setting is an entry here rather than another block of markup.
@@ -21,9 +21,12 @@ const route = useRoute()
 const eventId = route.params.eventId as string
 
 const event = useEventDoc(() => eventId)
+const archiveEvent = useArchiveEvent()
 
 // Only read once the doc has landed, so a null doc never renders as "not archived".
 const archived = computed(() => !event.doc?.is_published)
+
+const busy = computed(() => event.setValue.loading || archiveEvent.loading)
 
 const settingGroups = computed<SettingGroup[]>(() => [
 	{ name: "danger", title: __("Danger"), settings: [archiveSetting()] },
@@ -36,7 +39,7 @@ function archiveSetting(): Setting {
 			name: "archive",
 			title: __("Unarchive event"),
 			description: __("Puts the event page back online."),
-			action: { label: __("Unarchive"), onClick: () => publish(1) },
+			action: { label: __("Unarchive"), onClick: unarchive },
 		}
 
 	return {
@@ -53,22 +56,35 @@ function confirmArchive() {
 	dialog.confirm({
 		title: __("Archive Event?"),
 		message: __(
-			"The event page goes offline and its forms stop accepting responses. You can unarchive it from here at any time.",
+			"The event page goes offline and its forms stop accepting responses. You can unarchive the event at any time, but its forms stay closed until you publish them again.",
 		),
 		theme: "red",
 		confirmLabel: __("Archive"),
-		onConfirm: () => publish(0),
+		onConfirm: archive,
 	})
 }
 
-async function publish(is_published: 0 | 1) {
-	await event.setValue.submit({ is_published })
+// Archiving closes the event's forms as well as the event, so it goes through the
+// endpoint that does both. The doc store never sees that write — hence the reload.
+async function archive() {
+	await archiveEvent.submit({ event: eventId })
+	if (archiveEvent.error) {
+		toast.error(archiveEvent.error.message || __("Could not archive the event"))
+		return
+	}
+	await event.reload()
+	toast.success(__("Event archived"))
+}
+
+// Publishing is the plain write its opposite is not: the forms this closed stay closed.
+async function unarchive() {
+	await event.setValue.submit({ is_published: 1 })
 	if (event.setValue.error) {
 		// An event that never had a route cannot be published — the server says so.
 		toast.error(event.setValue.error.message || __("Could not save the event"))
 		return
 	}
-	toast.success(is_published ? __("Event is back online") : __("Event archived"))
+	toast.success(__("Event is back online"))
 }
 </script>
 
@@ -103,7 +119,7 @@ async function publish(is_published: 0 | 1) {
 							<Button
 								:label="setting.action.label"
 								:theme="setting.action.theme"
-								:loading="event.setValue.loading"
+								:loading="busy"
 								class="transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97] motion-reduce:active:scale-100"
 								@click="setting.action.onClick"
 							/>

--- a/dashboard/src/pages/manage/events/EventMore.vue
+++ b/dashboard/src/pages/manage/events/EventMore.vue
@@ -56,7 +56,7 @@ function confirmArchive() {
 	dialog.confirm({
 		title: __("Archive Event?"),
 		message: __(
-			"The event page goes offline and its forms stop accepting responses. You can unarchive the event at any time, but its forms stay closed until you publish them again.",
+			"The event page goes offline, and its forms and registrations stop accepting responses. You can unarchive the event at any time, but its forms and registrations stay closed until you reopen them.",
 		),
 		theme: "red",
 		confirmLabel: __("Archive"),

--- a/dashboard/src/pages/manage/events/EventTalks.vue
+++ b/dashboard/src/pages/manage/events/EventTalks.vue
@@ -7,6 +7,7 @@ import { computed, ref } from "vue"
 import { useRoute } from "vue-router"
 
 import { FilterBar, type FilterGroup, type FilterValues } from "@/components/common/filters"
+import EventArchivedAlert from "@/components/dashboard/events/EventArchivedAlert.vue"
 import EventPageHeader from "@/components/dashboard/events/EventPageHeader.vue"
 import EventTalkActions from "@/components/dashboard/proposals/EventTalkActions.vue"
 import EventTalkProposalDrawer from "@/components/dashboard/proposals/EventTalkProposalDrawer.vue"
@@ -140,6 +141,8 @@ useIntersectionObserver(sentinel, ([entry]) => entry?.isIntersecting && loadMore
 	<EventPageHeader :title="page.data?.title" section="Talks" />
 
 	<PageWithSidebar>
+		<EventArchivedAlert :event="eventId" />
+
 		<section class="space-y-2">
 			<h1 class="text-xl font-semibold text-ink-gray-9">How it's going</h1>
 

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -60,6 +60,12 @@ const routes: RouteRecordRaw[] = [
 				component: () => import("@/pages/manage/events/EventCommunications.vue"),
 			},
 			{
+				path: "events/:eventId/more",
+				name: "event-more",
+				meta: { title: "More" },
+				component: () => import("@/pages/manage/events/EventMore.vue"),
+			},
+			{
 				path: "events/:eventId/:section",
 				component: () => import("@/pages/manage/WorkInProgress.vue"),
 			},


### PR DESCRIPTION
## What changed

- New **More** space per event, with a Danger group holding the archive setting
- Page renders from a `settingGroups` list, so a new setting is an entry rather than markup
- `BuzzEvent.archive_event` unpublishes the event, its custom form rows, and closes registrations
- `buzz.api.events.archive_event` — POST, behind the same team write check as every manage write
- `close_registrations` now owns the timezone write; `set_registration_state` delegates to it
- Unarchive stays a plain `is_published` write — forms and registrations stay closed until reopened
- Archived alert had no background in dark mode: `surface-gray-1` resolves to the page surface
- Card border was `outline-gray-1`, within 0.02 lightness of the dark page — now `outline-gray-2`
- Skeleton until the event doc lands, so the destructive button never paints the wrong action
- A failed archive raised the same error twice, as a toast and into the confirm dialog

## Demo

https://cap.so/s/ahqrh5wcq9mb3j3

## Testing

- `bench --site buzz.localhost run-tests --module buzz.api.events.test_events` — 92 pass
- 4 new tests: forms closed, registrations closed, second archive is a no-op, non-team member refused
- `oxfmt` / `oxlint` / `ruff` / `vue-tsc` clean
- Not opened in a browser this session