### PR TITLE
feat(teams): search and multi-select the members list in settings

### DIFF
--- a/buzz/api/teams/__init__.py
+++ b/buzz/api/teams/__init__.py
@@ -32,13 +32,13 @@ def get_team_overview(team: str) -> TeamOverview:
 
 
 @frappe.whitelist(methods=["POST"])
-def remove_member(team: str, user: str) -> None:
-	services.remove_member(team, user)
+def remove_members(team: str, users: list[str]) -> None:
+	services.remove_members(team, users)
 
 
 @frappe.whitelist(methods=["POST"])
-def change_role(team: str, user: str, team_role: str) -> None:
-	services.change_role(team, user, team_role)
+def change_roles(team: str, users: list[str], team_role: str) -> None:
+	services.change_roles(team, users, team_role)
 
 
 @frappe.whitelist(methods=["POST"])

--- a/buzz/api/teams/services.py
+++ b/buzz/api/teams/services.py
@@ -128,6 +128,22 @@ def change_role(team: str, user: str, team_role: str) -> None:
 	membership.save(ignore_permissions=True)
 
 
+def remove_members(team: str, users: list[str]) -> None:
+	"""Take several members off a team at once.
+
+	One request is one transaction, so a refusal on any of them takes the whole batch
+	back out — the roster is never left half-changed.
+	"""
+	for user in users:
+		remove_member(team, user)
+
+
+def change_roles(team: str, users: list[str], team_role: str) -> None:
+	"""Move several members to the same role, all-or-nothing like `remove_members`."""
+	for user in users:
+		change_role(team, user, team_role)
+
+
 def update_team(team: str, team_name: str, logo: str | None) -> None:
 	"""Rename a team or change its logo.
 

--- a/buzz/api/teams/test_teams.py
+++ b/buzz/api/teams/test_teams.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from buzz.api.teams import change_role, get_my_teams, get_team_overview, remove_member, update_team
+from buzz.api.teams import change_roles, get_my_teams, get_team_overview, remove_members, update_team
 from buzz.api.teams.exceptions import (
 	CannotEditTeam,
 	CannotGrantOwnership,
@@ -160,7 +160,7 @@ class TestRemoveMember(IntegrationTestCase):
 		upsert_membership(team, member, "Manager")
 
 		frappe.set_user(admin)
-		remove_member(team, member)
+		remove_members(team, [member])
 
 		self.assertEqual(self.membership(team, member).enabled, 0)
 
@@ -173,7 +173,7 @@ class TestRemoveMember(IntegrationTestCase):
 
 		frappe.set_user(manager)
 		with self.assertRaises(CannotManageMembers):
-			remove_member(team, member)
+			remove_members(team, [member])
 
 	def test_an_outsider_cannot_remove_anyone(self):
 		outsider = create_user("remove-outsider@example.com", "Outsider")
@@ -182,7 +182,7 @@ class TestRemoveMember(IntegrationTestCase):
 
 		frappe.set_user(outsider)
 		with self.assertRaises(CannotManageMembers):
-			remove_member(team, owner)
+			remove_members(team, [owner])
 
 	def test_the_owner_cannot_be_removed(self):
 		owner = create_user("remove-locked-owner@example.com", "Owner")
@@ -192,7 +192,7 @@ class TestRemoveMember(IntegrationTestCase):
 
 		frappe.set_user(admin)
 		with self.assertRaises(frappe.ValidationError):
-			remove_member(team, owner)
+			remove_members(team, [owner])
 
 	def test_refuses_a_user_who_is_not_on_the_team(self):
 		owner = create_user("remove-stranger-owner@example.com", "Owner")
@@ -201,7 +201,7 @@ class TestRemoveMember(IntegrationTestCase):
 
 		frappe.set_user(owner)
 		with self.assertRaises(NotATeamMember):
-			remove_member(team, stranger)
+			remove_members(team, [stranger])
 
 	def test_removing_the_same_member_twice_is_refused(self):
 		owner = create_user("remove-twice-owner@example.com", "Owner")
@@ -210,10 +210,10 @@ class TestRemoveMember(IntegrationTestCase):
 		upsert_membership(team, member, "Manager")
 
 		frappe.set_user(owner)
-		remove_member(team, member)
+		remove_members(team, [member])
 
 		with self.assertRaises(NotATeamMember):
-			remove_member(team, member)
+			remove_members(team, [member])
 
 	def test_the_desk_role_survives_while_another_team_still_earns_it(self):
 		owner = create_user("remove-roles-owner@example.com", "Owner")
@@ -224,11 +224,25 @@ class TestRemoveMember(IntegrationTestCase):
 		upsert_membership(second, member, "Manager")
 
 		frappe.set_user(owner)
-		remove_member(first, member)
+		remove_members(first, [member])
 		self.assertIn("Event Manager", frappe.get_roles(member))
 
-		remove_member(second, member)
+		remove_members(second, [member])
 		self.assertNotIn("Event Manager", frappe.get_roles(member))
+
+	def test_an_admin_removes_several_members_at_once(self):
+		owner = create_user("remove-batch-owner@example.com", "Owner")
+		first = create_user("remove-batch-first@example.com", "First")
+		second = create_user("remove-batch-second@example.com", "Second")
+		team = create_owned_team("Remove Batch", owner)
+		upsert_membership(team, first, "Manager")
+		upsert_membership(team, second, "Viewer")
+
+		frappe.set_user(owner)
+		remove_members(team, [first, second])
+
+		self.assertEqual(self.membership(team, first).enabled, 0)
+		self.assertEqual(self.membership(team, second).enabled, 0)
 
 
 class TestChangeRole(IntegrationTestCase):
@@ -249,7 +263,7 @@ class TestChangeRole(IntegrationTestCase):
 		upsert_membership(team, member, "Manager")
 
 		frappe.set_user(admin)
-		change_role(team, member, "Admin")
+		change_roles(team, [member], "Admin")
 
 		self.assertEqual(self.role(team, member), "Admin")
 
@@ -261,7 +275,7 @@ class TestChangeRole(IntegrationTestCase):
 		self.assertIn("Event Manager", frappe.get_roles(member))
 
 		frappe.set_user(owner)
-		change_role(team, member, "Viewer")
+		change_roles(team, [member], "Viewer")
 
 		self.assertNotIn("Event Manager", frappe.get_roles(member))
 
@@ -274,7 +288,7 @@ class TestChangeRole(IntegrationTestCase):
 		upsert_membership(team, peer, "Admin")
 
 		frappe.set_user(admin)
-		change_role(team, peer, "Viewer")
+		change_roles(team, [peer], "Viewer")
 
 		self.assertEqual(self.role(team, peer), "Viewer")
 
@@ -288,7 +302,7 @@ class TestChangeRole(IntegrationTestCase):
 
 		frappe.set_user(manager)
 		with self.assertRaises(CannotManageMembers):
-			change_role(team, member, "Manager")
+			change_roles(team, [member], "Manager")
 
 	def test_an_outsider_cannot_change_anyone(self):
 		owner = create_user("role-outsider-owner@example.com", "Owner")
@@ -299,7 +313,7 @@ class TestChangeRole(IntegrationTestCase):
 
 		frappe.set_user(outsider)
 		with self.assertRaises(CannotManageMembers):
-			change_role(team, member, "Manager")
+			change_roles(team, [member], "Manager")
 
 	def test_the_owner_cannot_be_given_another_role(self):
 		owner = create_user("role-locked-owner@example.com", "Owner")
@@ -309,7 +323,7 @@ class TestChangeRole(IntegrationTestCase):
 
 		frappe.set_user(admin)
 		with self.assertRaises(frappe.ValidationError):
-			change_role(team, owner, "Viewer")
+			change_roles(team, [owner], "Viewer")
 
 	def test_ownership_cannot_be_granted(self):
 		owner = create_user("role-grant-owner@example.com", "Owner")
@@ -319,7 +333,7 @@ class TestChangeRole(IntegrationTestCase):
 
 		frappe.set_user(owner)
 		with self.assertRaises(CannotGrantOwnership):
-			change_role(team, member, "Owner")
+			change_roles(team, [member], "Owner")
 
 	def test_an_unknown_role_is_refused(self):
 		owner = create_user("role-unknown-owner@example.com", "Owner")
@@ -329,7 +343,7 @@ class TestChangeRole(IntegrationTestCase):
 
 		frappe.set_user(owner)
 		with self.assertRaises(UnknownTeamRole):
-			change_role(team, member, "Overlord")
+			change_roles(team, [member], "Overlord")
 
 	def test_refuses_a_user_who_is_not_on_the_team(self):
 		owner = create_user("role-stranger-owner@example.com", "Owner")
@@ -338,7 +352,7 @@ class TestChangeRole(IntegrationTestCase):
 
 		frappe.set_user(owner)
 		with self.assertRaises(NotATeamMember):
-			change_role(team, stranger, "Manager")
+			change_roles(team, [stranger], "Manager")
 
 	def test_refuses_a_member_whose_membership_is_disabled(self):
 		owner = create_user("role-disabled-owner@example.com", "Owner")
@@ -347,10 +361,24 @@ class TestChangeRole(IntegrationTestCase):
 		upsert_membership(team, member, "Manager")
 
 		frappe.set_user(owner)
-		remove_member(team, member)
+		remove_members(team, [member])
 
 		with self.assertRaises(NotATeamMember):
-			change_role(team, member, "Viewer")
+			change_roles(team, [member], "Viewer")
+
+	def test_an_admin_re_roles_several_members_at_once(self):
+		owner = create_user("role-batch-owner@example.com", "Owner")
+		first = create_user("role-batch-first@example.com", "First")
+		second = create_user("role-batch-second@example.com", "Second")
+		team = create_owned_team("Role Batch", owner)
+		upsert_membership(team, first, "Manager")
+		upsert_membership(team, second, "Frontdesk")
+
+		frappe.set_user(owner)
+		change_roles(team, [first, second], "Viewer")
+
+		self.assertEqual(self.role(team, first), "Viewer")
+		self.assertEqual(self.role(team, second), "Viewer")
 
 
 class TestUpdateTeam(IntegrationTestCase):

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -92,6 +92,7 @@ declare module 'vue' {
     RestrictionNotices: typeof import('./src/components/RestrictionNotices.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    SelectionBar: typeof import('./src/components/common/SelectionBar.vue')['default']
     SponsorshipPaymentDialog: typeof import('./src/components/SponsorshipPaymentDialog.vue')['default']
     SuccessMessage: typeof import('./src/components/SuccessMessage.vue')['default']
     TeamMembersTable: typeof import('./src/components/dashboard/teams/TeamMembersTable.vue')['default']

--- a/dashboard/src/components/common/SelectionBar.vue
+++ b/dashboard/src/components/common/SelectionBar.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { Button } from "frappe-ui"
+
+/** The bar a list shows while rows are selected: what is selected, and what can be done. */
+defineProps<{ count: number; label: string }>()
+defineEmits<{ clear: [] }>()
+</script>
+
+<template>
+	<Transition name="bar">
+		<div
+			v-if="count"
+			role="toolbar"
+			:aria-label="label"
+			class="flex flex-wrap items-center gap-2 rounded-6 border border-outline-gray-2 bg-surface-gray-1 px-3 py-2"
+		>
+			<span class="text-sm text-ink-gray-7">{{ label }}</span>
+
+			<div class="ml-auto flex items-center gap-2">
+				<slot />
+
+				<Button variant="ghost" :label="__('Clear selection')" @click="$emit('clear')">
+					<template #icon>
+						<span class="lucide-x size-4" />
+					</template>
+				</Button>
+			</div>
+		</div>
+	</Transition>
+</template>
+
+<style scoped>
+.bar-enter-active,
+.bar-leave-active {
+	transition:
+		opacity 120ms cubic-bezier(0.23, 1, 0.32, 1),
+		transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.bar-enter-from,
+.bar-leave-to {
+	opacity: 0;
+	transform: translateY(-4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.bar-enter-from,
+	.bar-leave-to {
+		transform: none;
+	}
+}
+</style>

--- a/dashboard/src/components/common/SelectionBar.vue
+++ b/dashboard/src/components/common/SelectionBar.vue
@@ -8,45 +8,39 @@ defineEmits<{ clear: [] }>()
 
 <template>
 	<Transition name="bar">
-		<div
-			v-if="count"
-			role="toolbar"
-			:aria-label="label"
-			class="flex flex-wrap items-center gap-2 rounded-6 border border-outline-gray-2 bg-surface-gray-1 px-3 py-2"
-		>
-			<span class="text-sm text-ink-gray-7">{{ label }}</span>
+		<!-- The sticky box carries no height of its own, so a selection floats the bar over the
+		     rows at the top of the view instead of pushing the whole list down. -->
+		<div v-if="count" class="sticky top-2 z-20 h-0">
+			<div
+				role="toolbar"
+				:aria-label="__('Bulk actions')"
+				class="mx-auto flex w-max max-w-full flex-wrap items-center justify-center gap-3 rounded-6 bg-surface-base px-4 py-2 shadow-2xl"
+			>
+				<span class="text-sm text-ink-gray-7">{{ label }}</span>
 
-			<div class="ml-auto flex items-center gap-2">
-				<slot />
+				<div class="flex items-center gap-2">
+					<slot />
 
-				<Button variant="ghost" :label="__('Clear selection')" @click="$emit('clear')">
-					<template #icon>
-						<span class="lucide-x size-4" />
-					</template>
-				</Button>
+					<Button variant="ghost" :label="__('Clear selection')" @click="$emit('clear')">
+						<template #icon>
+							<span class="lucide-x size-4" />
+						</template>
+					</Button>
+				</div>
 			</div>
 		</div>
 	</Transition>
 </template>
 
 <style scoped>
+/* Opacity alone: the bar stays pinned while the rows move, so it has nowhere to slide from. */
 .bar-enter-active,
 .bar-leave-active {
-	transition:
-		opacity 120ms cubic-bezier(0.23, 1, 0.32, 1),
-		transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
+	transition: opacity 150ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .bar-enter-from,
 .bar-leave-to {
 	opacity: 0;
-	transform: translateY(-4px);
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.bar-enter-from,
-	.bar-leave-to {
-		transform: none;
-	}
 }
 </style>

--- a/dashboard/src/components/dashboard/teams/ChangeRoleDialog.vue
+++ b/dashboard/src/components/dashboard/teams/ChangeRoleDialog.vue
@@ -2,54 +2,76 @@
 import { Button, Dialog, ErrorMessage, FormControl, toast } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 
-import { useChangeRole } from "@/data/teams"
+import { useChangeRoles } from "@/data/teams"
 import type { TeamMember } from "@/types"
 import { ASSIGNABLE_TEAM_ROLES } from "@/utils/teamRoles"
 
-const props = defineProps<{ team: string; member: TeamMember | null }>()
+// A selection of one is how a single row's action arrives, so there is one dialog.
+const props = defineProps<{ team: string; members: TeamMember[] }>()
 const isOpen = defineModel<boolean>({ required: true })
 const emit = defineEmits<{ success: [] }>()
 
-const changeRole = useChangeRole()
+const changeRoles = useChangeRoles()
 const role = ref("")
 // `useCall`'s own reset only drops the submitted params, so a failure would otherwise still
 // be on screen the next time the dialog opens.
 const errorMessage = ref("")
 
-const name = computed(() => props.member?.full_name || props.member?.user || "")
+const only = computed(() => (props.members.length === 1 ? props.members[0] : null))
+
+const name = computed(() => only.value?.full_name || only.value?.user || "")
+
+const description = computed(() =>
+	only.value
+		? __("{0} keeps their place on the team, with a different set of permissions.", [name.value])
+		: __("All {0} keep their place on the team, with a different set of permissions.", [
+				props.members.length,
+			]),
+)
 
 // The panel's role legend explains the roles; this only guards a pointless save.
-const unchanged = computed(() => !props.member || role.value === props.member.team_role)
+const unchanged = computed(
+	() => !props.members.length || props.members.every((member) => member.team_role === role.value),
+)
 
-// The member arrives with the dialog, so the select is seeded on open rather than on mount.
+// The selection arrives with the dialog, so the select is seeded on open rather than on mount.
 watch(isOpen, (open) => {
 	if (!open) return
-	role.value = props.member?.team_role ?? ""
+	role.value = sharedRole()
 	errorMessage.value = ""
 })
 
-async function submit() {
-	if (!props.member || unchanged.value) return
+// A mixed selection has no role to show, so it starts blank rather than on someone's.
+function sharedRole() {
+	const roles = new Set(props.members.map((member) => member.team_role))
+	return roles.size === 1 ? [...roles][0] : ""
+}
 
-	await changeRole.submit({ team: props.team, user: props.member.user, team_role: role.value })
+async function submit() {
+	if (unchanged.value) return
+
+	const users = props.members.map((member) => member.user)
+	await changeRoles.submit({ team: props.team, users, team_role: role.value })
 	// useCall settles either way, so the failure has to be read off the composable.
-	if (changeRole.error) {
-		errorMessage.value = changeRole.error.message
+	if (changeRoles.error) {
+		errorMessage.value = changeRoles.error.message
 		return
 	}
 
+	const done = only.value
+		? __("{0} is now {1}.", [name.value, role.value])
+		: __("{0} members are now {1}.", [users.length, role.value])
+
 	emit("success")
 	isOpen.value = false
-	toast.success(__("{0} is now {1}.", [name.value, role.value]))
+	toast.success(done)
 }
 </script>
 
 <template>
 	<Dialog v-model="isOpen" :title="__('Change role')">
 		<div class="space-y-3">
-			<p class="text-base text-ink-gray-5">
-				{{ __("{0} keeps their place on the team, with a different set of permissions.", [name]) }}
-			</p>
+			<p class="text-base text-ink-gray-5">{{ description }}</p>
 
 			<FormControl
 				v-model="role"
@@ -66,7 +88,7 @@ async function submit() {
 				<Button
 					variant="solid"
 					:label="__('Save')"
-					:loading="changeRole.loading"
+					:loading="changeRoles.loading"
 					:disabled="unchanged"
 					@click="submit"
 				/>

--- a/dashboard/src/components/dashboard/teams/ChangeRoleDialog.vue
+++ b/dashboard/src/components/dashboard/teams/ChangeRoleDialog.vue
@@ -31,7 +31,10 @@ const description = computed(() =>
 
 // The panel's role legend explains the roles; this only guards a pointless save.
 const unchanged = computed(
-	() => !props.members.length || props.members.every((member) => member.team_role === role.value),
+	() =>
+		!props.members.length ||
+		!role.value ||
+		props.members.every((member) => member.team_role === role.value),
 )
 
 // The selection arrives with the dialog, so the select is seeded on open rather than on mount.

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -51,16 +51,6 @@ const selectedMembers = computed(() =>
 	props.team.members.filter((member) => selection.isSelected(member.user)),
 )
 
-const visibleSelectableKeys = computed(() =>
-	visibleRows.value.filter(isSelectable).map((row) => row.key),
-)
-
-const allVisibleSelected = computed(
-	() =>
-		visibleSelectableKeys.value.length > 0 &&
-		visibleSelectableKeys.value.every(selection.isSelected),
-)
-
 // A row joins a selection only if both group actions apply to it, so an invitation —
 // which is resent or retracted, never re-roled — stays on its own menu.
 function isSelectable(row: RosterRow) {
@@ -72,12 +62,6 @@ function isSelectable(row: RosterRow) {
 function canAdminister(member: TeamMember) {
 	if (!canManage.value) return false
 	return member.team_role !== "Owner" && member.user !== session.user
-}
-
-// Select-all covers what the search has left on screen; clearing covers everything.
-function toggleAllVisible() {
-	if (allVisibleSelected.value) selection.clear()
-	else selection.select(visibleSelectableKeys.value)
 }
 
 // An invitation is resent or retracted; a member is re-roled or removed.
@@ -130,19 +114,22 @@ function refreshed() {
 
 <template>
 	<div class="flex flex-col gap-4">
-		<div class="flex flex-col gap-3">
-			<FormControl
-				v-model="search"
-				type="text"
-				class="max-w-xs"
-				:placeholder="__('Search members')"
-				:aria-label="__('Search members')"
-			>
-				<template #prefix>
-					<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
-				</template>
-			</FormControl>
+		<FormControl
+			v-model="search"
+			type="text"
+			class="max-w-xs"
+			:placeholder="__('Search members')"
+			:aria-label="__('Search members')"
+		>
+			<template #prefix>
+				<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
+			</template>
+		</FormControl>
 
+		<!-- relative: the roster is what the selection bar floats over. -->
+		<div class="relative">
+			<!-- Sticky at the top of the list rather than after it: a selection made at the top
+			     of a long roster has to stay in reach while the rows scroll under it. -->
 			<SelectionBar
 				:count="selectedMembers.length"
 				:label="__('{0} selected', [selectedMembers.length])"
@@ -160,18 +147,9 @@ function refreshed() {
 					@click="actions.confirmRemove(selectedMembers)"
 				/>
 			</SelectionBar>
-		</div>
 
-		<div>
 			<div :class="columns" class="pb-2 text-sm text-ink-gray-5">
-				<Checkbox
-					v-if="canManage"
-					:model-value="allVisibleSelected"
-					:indeterminate="!allVisibleSelected && selectedMembers.length > 0"
-					:disabled="!visibleSelectableKeys.length"
-					:aria-label="__('Select all members')"
-					@update:model-value="toggleAllVisible"
-				/>
+				<span v-if="canManage" />
 				<span />
 				<span />
 				<span>{{ __("Role") }}</span>
@@ -189,13 +167,16 @@ function refreshed() {
 					:class="columns"
 					class="-mx-2 rounded-4 px-2 py-2 transition-colors duration-150 hover:bg-surface-gray-1"
 				>
+					<!-- An invitation is never part of a selection, so it carries no checkbox at
+					     all; a member who cannot be acted on carries a disabled one. -->
 					<Checkbox
-						v-if="canManage"
+						v-if="canManage && row.member"
 						:model-value="selection.isSelected(row.key)"
 						:disabled="!isSelectable(row)"
 						:aria-label="__('Select {0}', [row.name])"
 						@update:model-value="selection.toggle(row.key)"
 					/>
+					<span v-else-if="canManage" />
 
 					<div class="flex min-w-0 items-center gap-3">
 						<Avatar :image="row.image" :label="row.name" size="lg" />

--- a/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
+++ b/dashboard/src/components/dashboard/teams/TeamMembersTable.vue
@@ -1,63 +1,70 @@
 <script setup lang="ts">
-import { Avatar, Badge, Button, Dropdown, dialog, toast } from "frappe-ui"
+import { Avatar, Badge, Button, Checkbox, Dropdown, FormControl } from "frappe-ui"
 import { computed, ref } from "vue"
 
+import SelectionBar from "@/components/common/SelectionBar.vue"
 import ChangeRoleDialog from "@/components/dashboard/teams/ChangeRoleDialog.vue"
+import { useRosterActions } from "@/composables/useRosterActions"
+import { useRowSelection } from "@/composables/useRowSelection"
 import { session } from "@/data/session"
-import { removeMember, useResendInvite, useRetractInvite } from "@/data/teams"
-import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
+import type { TeamMember, TeamOverview } from "@/types"
 import { canManageMembers } from "@/utils/teamRoles"
+import { matchesQuery, rosterRows, type RosterRow } from "@/utils/teamRoster"
 
 const props = defineProps<{ team: TeamOverview }>()
-// One event for both actions: the roster is reloaded either way.
+// One event for every action: the roster is reloaded either way.
 const emit = defineEmits<{ changed: [] }>()
 
-// Header and rows share one grid so the columns line up without a table element.
+// Header and rows share one grid so the columns line up without a table element. Spelled
+// out twice rather than composed: Tailwind only generates classes it can read in the source.
 const COLUMNS = "grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4"
-
-interface Row {
-	key: string
-	name: string
-	email: string
-	role: string
-	image?: string
-	member?: TeamMember
-}
+const SELECTABLE_COLUMNS =
+	"grid grid-cols-[1.25rem_minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)_2rem] items-center gap-4"
 
 const canManage = computed(() => canManageMembers(props.team.my_role))
 
-const changing = ref<TeamMember | null>(null)
+// The checkbox column only exists for someone who can act on a selection.
+const columns = computed(() => (canManage.value ? SELECTABLE_COLUMNS : COLUMNS))
+
+const search = ref("")
+
+const changing = ref<TeamMember[]>([])
 const isChangingRole = ref(false)
 
-const resendInvite = useResendInvite()
-const retractInvite = useRetractInvite()
+const actions = useRosterActions(() => props.team.name, refreshed)
 
-// Members and pending invitations share one list so the table reads as the whole team,
-// with the people who have not accepted yet at the bottom.
-const rows = computed<Row[]>(() => [
-	...props.team.members.map(memberRow),
-	...props.team.invites.map(inviteRow),
-])
+const rows = computed(() => rosterRows(props.team))
 
-function memberRow(member: TeamMember): Row {
-	return {
-		key: member.user,
-		name: member.full_name ?? member.user,
-		email: member.user,
-		role: member.team_role,
-		image: member.user_image ?? undefined,
-		member,
-	}
-}
+const visibleRows = computed(() => {
+	const query = search.value.trim().toLowerCase()
+	if (!query) return rows.value
+	return rows.value.filter((row) => matchesQuery(row, query))
+})
 
-// There is no user yet, so no name and no image — the address stands in for both.
-function inviteRow(invite: TeamInvite): Row {
-	return {
-		key: `invite:${invite.email}`,
-		name: invite.email,
-		email: invite.email,
-		role: invite.team_role,
-	}
+// Held against the whole roster, not the filtered view, so a search narrows what is on
+// screen without quietly dropping what is already selected.
+const selectableKeys = computed(() => rows.value.filter(isSelectable).map((row) => row.key))
+
+const selection = useRowSelection(selectableKeys)
+
+const selectedMembers = computed(() =>
+	props.team.members.filter((member) => selection.isSelected(member.user)),
+)
+
+const visibleSelectableKeys = computed(() =>
+	visibleRows.value.filter(isSelectable).map((row) => row.key),
+)
+
+const allVisibleSelected = computed(
+	() =>
+		visibleSelectableKeys.value.length > 0 &&
+		visibleSelectableKeys.value.every(selection.isSelected),
+)
+
+// A row joins a selection only if both group actions apply to it, so an invitation —
+// which is resent or retracted, never re-roled — stays on its own menu.
+function isSelectable(row: RosterRow) {
+	return Boolean(row.member && canAdminister(row.member))
 }
 
 // The owner is locked server-side, and changing your own standing on a team — leaving it,
@@ -67,8 +74,14 @@ function canAdminister(member: TeamMember) {
 	return member.team_role !== "Owner" && member.user !== session.user
 }
 
+// Select-all covers what the search has left on screen; clearing covers everything.
+function toggleAllVisible() {
+	if (allVisibleSelected.value) selection.clear()
+	else selection.select(visibleSelectableKeys.value)
+}
+
 // An invitation is resent or retracted; a member is re-roled or removed.
-function actionsFor(row: Row) {
+function actionsFor(row: RosterRow) {
 	const member = row.member
 	if (!member) return canManage.value ? inviteActions(row) : []
 	if (!canAdminister(member)) return []
@@ -76,128 +89,150 @@ function actionsFor(row: Row) {
 		{
 			label: __("Change role"),
 			icon: "lucide-refresh-ccw",
-			onClick: () => openRoleChange(member),
+			onClick: () => openRoleChange([member]),
 		},
 		{
 			label: __("Remove"),
 			icon: "lucide-trash-2",
 			theme: "red" as const,
-			onClick: () => confirmRemove(row),
+			onClick: () => actions.confirmRemove([member]),
 		},
 	]
 }
 
-function openRoleChange(member: TeamMember) {
-	changing.value = member
-	isChangingRole.value = true
-}
-
-function inviteActions(row: Row) {
+function inviteActions(row: RosterRow) {
 	return [
 		{
 			label: __("Resend"),
 			icon: "lucide-arrow-up-from-line",
-			onClick: () => resend(row),
+			onClick: () => actions.resend(row),
 		},
 		{
 			label: __("Retract"),
 			icon: "lucide-shredder",
 			theme: "red" as const,
-			onClick: () => confirmRetract(row),
+			onClick: () => actions.confirmRetract(row),
 		},
 	]
 }
 
-// Nothing the table shows changes, so the overview is left alone.
-async function resend(row: Row) {
-	await resendInvite.submit({ team: props.team.name, email: row.email })
-	if (resendInvite.error) return toast.error(resendInvite.error.message)
-	toast.success(__("Invitation resent to {0}.", [row.email]))
+function openRoleChange(members: TeamMember[]) {
+	changing.value = members
+	isChangingRole.value = true
 }
 
-function confirmRemove(row: Row) {
-	dialog.confirm({
-		title: __("Remove member"),
-		message: __("{0} will lose access to this team.", [row.name]),
-		theme: "red",
-		confirmLabel: __("Remove"),
-		// A rejected promise renders inline in the dialog, so failures need no branch here.
-		onConfirm: async () => {
-			await removeMember.submit({ team: props.team.name, user: row.email })
-			emit("changed")
-			toast.success(__("{0} was removed from the team.", [row.name]))
-		},
-	})
-}
-
-function confirmRetract(row: Row) {
-	dialog.confirm({
-		title: __("Retract invitation"),
-		message: __("{0} will be told the invitation was withdrawn, and the link will stop working.", [
-			row.email,
-		]),
-		theme: "red",
-		confirmLabel: __("Retract"),
-		onConfirm: async () => {
-			await retractInvite.submit({ team: props.team.name, email: row.email })
-			// useCall settles either way, so the failure has to be rethrown to reach the dialog.
-			if (retractInvite.error) throw retractInvite.error
-			emit("changed")
-			toast.success(__("The invitation to {0} was retracted.", [row.email]))
-		},
-	})
+// A selection is spent once it has been acted on, and the roster is reloaded under it.
+function refreshed() {
+	selection.clear()
+	emit("changed")
 }
 </script>
 
 <template>
-	<div>
-		<div :class="COLUMNS" class="pb-2 text-sm text-ink-gray-5">
-			<span />
-			<span />
-			<span>{{ __("Role") }}</span>
+	<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-3">
+			<FormControl
+				v-model="search"
+				type="text"
+				class="max-w-xs"
+				:placeholder="__('Search members')"
+				:aria-label="__('Search members')"
+			>
+				<template #prefix>
+					<span class="lucide-search size-4 text-ink-gray-5" aria-hidden="true" />
+				</template>
+			</FormControl>
+
+			<SelectionBar
+				:count="selectedMembers.length"
+				:label="__('{0} selected', [selectedMembers.length])"
+				@clear="selection.clear()"
+			>
+				<Button
+					icon-left="lucide-refresh-ccw"
+					:label="__('Change role')"
+					@click="openRoleChange(selectedMembers)"
+				/>
+				<Button
+					theme="red"
+					icon-left="lucide-trash-2"
+					:label="__('Remove')"
+					@click="actions.confirmRemove(selectedMembers)"
+				/>
+			</SelectionBar>
 		</div>
 
-		<!-- Removing a row would otherwise snap the rest of the list upwards. -->
-		<TransitionGroup tag="ul" name="member" :aria-label="__('Team members')" class="relative">
-			<li
-				v-for="row in rows"
-				:key="row.key"
-				:class="COLUMNS"
-				class="-mx-2 rounded-4 px-2 py-2 transition-colors duration-150 hover:bg-surface-gray-1"
-			>
-				<div class="flex min-w-0 items-center gap-3">
-					<Avatar :image="row.image" :label="row.name" size="lg" />
-					<span class="truncate text-base text-ink-gray-8">{{ row.name }}</span>
-				</div>
+		<div>
+			<div :class="columns" class="pb-2 text-sm text-ink-gray-5">
+				<Checkbox
+					v-if="canManage"
+					:model-value="allVisibleSelected"
+					:indeterminate="!allVisibleSelected && selectedMembers.length > 0"
+					:disabled="!visibleSelectableKeys.length"
+					:aria-label="__('Select all members')"
+					@update:model-value="toggleAllVisible"
+				/>
+				<span />
+				<span />
+				<span>{{ __("Role") }}</span>
+			</div>
 
-				<!-- An invite has only an address, already shown as its name, so the cell
-				     carries its pending state instead. -->
-				<span class="flex min-w-0 items-center">
-					<span v-if="row.member" class="truncate text-base text-ink-gray-6">{{ row.email }}</span>
-					<Badge v-else size="sm" variant="outline" :label="__('Invited')" />
-				</span>
+			<p v-if="!visibleRows.length" class="py-3 text-base text-ink-gray-5">
+				{{ __("No members found") }}
+			</p>
 
-				<span class="truncate text-base font-medium text-ink-gray-8">{{ row.role }}</span>
+			<!-- Removing a row would otherwise snap the rest of the list upwards. -->
+			<TransitionGroup tag="ul" name="member" :aria-label="__('Team members')" class="relative">
+				<li
+					v-for="row in visibleRows"
+					:key="row.key"
+					:class="columns"
+					class="-mx-2 rounded-4 px-2 py-2 transition-colors duration-150 hover:bg-surface-gray-1"
+				>
+					<Checkbox
+						v-if="canManage"
+						:model-value="selection.isSelected(row.key)"
+						:disabled="!isSelectable(row)"
+						:aria-label="__('Select {0}', [row.name])"
+						@update:model-value="selection.toggle(row.key)"
+					/>
 
-				<Dropdown v-if="actionsFor(row).length" :options="actionsFor(row)" align="end">
-					<!-- label is the accessible name here: an icon slot makes it icon-only. -->
-					<Button
-						variant="ghost"
-						:label="row.member ? __('Member actions') : __('Invitation actions')"
-					>
-						<template #icon>
-							<span class="lucide-ellipsis size-4" />
-						</template>
-					</Button>
-				</Dropdown>
-			</li>
-		</TransitionGroup>
+					<div class="flex min-w-0 items-center gap-3">
+						<Avatar :image="row.image" :label="row.name" size="lg" />
+						<span class="truncate text-base text-ink-gray-8">{{ row.name }}</span>
+					</div>
+
+					<!-- An invite has only an address, already shown as its name, so the cell
+					     carries its pending state instead. -->
+					<span class="flex min-w-0 items-center">
+						<span v-if="row.member" class="truncate text-base text-ink-gray-6">{{
+							row.email
+						}}</span>
+						<Badge v-else size="sm" variant="outline" :label="__('Invited')" />
+					</span>
+
+					<span class="truncate text-base font-medium text-ink-gray-8">{{ row.role }}</span>
+
+					<Dropdown v-if="actionsFor(row).length" :options="actionsFor(row)" align="end">
+						<!-- label is the accessible name here: an icon slot makes it icon-only. -->
+						<Button
+							variant="ghost"
+							:label="row.member ? __('Member actions') : __('Invitation actions')"
+						>
+							<template #icon>
+								<span class="lucide-ellipsis size-4" />
+							</template>
+						</Button>
+					</Dropdown>
+				</li>
+			</TransitionGroup>
+		</div>
 
 		<ChangeRoleDialog
 			v-model="isChangingRole"
 			:team="team.name"
-			:member="changing"
-			@success="emit('changed')"
+			:members="changing"
+			@success="refreshed"
 		/>
 	</div>
 </template>

--- a/dashboard/src/composables/useRosterActions.ts
+++ b/dashboard/src/composables/useRosterActions.ts
@@ -1,0 +1,73 @@
+import { dialog, toast } from "frappe-ui"
+
+import { useRemoveMembers, useResendInvite, useRetractInvite } from "@/data/teams"
+import type { TeamMember } from "@/types"
+import type { RosterRow } from "@/utils/teamRoster"
+
+/**
+ * What the roster does to a member or an invitation, with the confirmation each one needs.
+ * `onDone` reloads the roster behind them.
+ */
+export function useRosterActions(team: () => string, onDone: () => void) {
+	const removeMembers = useRemoveMembers()
+	const resendInvite = useResendInvite()
+	const retractInvite = useRetractInvite()
+
+	// Nothing the roster shows changes, so it is not reloaded.
+	async function resend(row: RosterRow) {
+		await resendInvite.submit({ team: team(), email: row.email })
+		if (resendInvite.error) return toast.error(resendInvite.error.message)
+		toast.success(__("Invitation resent to {0}.", [row.email]))
+	}
+
+	// A single row's action is a selection of one, so both paths land here.
+	function confirmRemove(members: TeamMember[]) {
+		const only = members.length === 1 ? members[0] : null
+		const name = only?.full_name || only?.user || ""
+
+		dialog.confirm({
+			title: only ? __("Remove member") : __("Remove members"),
+			message: only
+				? __("{0} will lose access to this team.", [name])
+				: __("{0} people will lose access to this team.", [members.length]),
+			theme: "red",
+			confirmLabel: __("Remove"),
+			onConfirm: async () => {
+				const users = members.map((member) => member.user)
+				await removeMembers.submit({ team: team(), users })
+				// useCall settles either way, so the failure has to be rethrown to reach the dialog.
+				if (removeMembers.error) throw removeMembers.error
+
+				done(
+					only
+						? __("{0} was removed from the team.", [name])
+						: __("{0} people were removed from the team.", [users.length]),
+				)
+			},
+		})
+	}
+
+	function confirmRetract(row: RosterRow) {
+		dialog.confirm({
+			title: __("Retract invitation"),
+			message: __(
+				"{0} will be told the invitation was withdrawn, and the link will stop working.",
+				[row.email],
+			),
+			theme: "red",
+			confirmLabel: __("Retract"),
+			onConfirm: async () => {
+				await retractInvite.submit({ team: team(), email: row.email })
+				if (retractInvite.error) throw retractInvite.error
+				done(__("The invitation to {0} was retracted.", [row.email]))
+			},
+		})
+	}
+
+	function done(message: string) {
+		onDone()
+		toast.success(message)
+	}
+
+	return { resend, confirmRemove, confirmRetract }
+}

--- a/dashboard/src/composables/useRowSelection.test.ts
+++ b/dashboard/src/composables/useRowSelection.test.ts
@@ -30,7 +30,8 @@ test("a key that stops being selectable leaves the selection", () => {
 	const selectable = keys()
 	const selection = useRowSelection(selectable)
 
-	selection.select(["a", "c"])
+	selection.toggle("a")
+	selection.toggle("c")
 	selectable.value = ["a", "b"]
 
 	assert.deepEqual(selection.selected.value, ["a"])
@@ -39,7 +40,8 @@ test("a key that stops being selectable leaves the selection", () => {
 test("clearing empties the selection", () => {
 	const selection = useRowSelection(keys())
 
-	selection.select(["a", "b"])
+	selection.toggle("a")
+	selection.toggle("b")
 	selection.clear()
 
 	assert.deepEqual(selection.selected.value, [])

--- a/dashboard/src/composables/useRowSelection.test.ts
+++ b/dashboard/src/composables/useRowSelection.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { ref } from "vue"
+
+import { useRowSelection } from "./useRowSelection.ts"
+
+const keys = () => ref(["a", "b", "c"])
+
+test("a key toggles into and out of the selection", () => {
+	const selection = useRowSelection(keys())
+
+	selection.toggle("b")
+	assert.deepEqual(selection.selected.value, ["b"])
+
+	selection.toggle("b")
+	assert.deepEqual(selection.selected.value, [])
+})
+
+test("the selection keeps the order of the list, not the order it was picked in", () => {
+	const selection = useRowSelection(keys())
+
+	selection.toggle("c")
+	selection.toggle("a")
+
+	assert.deepEqual(selection.selected.value, ["a", "c"])
+})
+
+test("a key that stops being selectable leaves the selection", () => {
+	const selectable = keys()
+	const selection = useRowSelection(selectable)
+
+	selection.select(["a", "c"])
+	selectable.value = ["a", "b"]
+
+	assert.deepEqual(selection.selected.value, ["a"])
+})
+
+test("clearing empties the selection", () => {
+	const selection = useRowSelection(keys())
+
+	selection.select(["a", "b"])
+	selection.clear()
+
+	assert.deepEqual(selection.selected.value, [])
+})

--- a/dashboard/src/composables/useRowSelection.ts
+++ b/dashboard/src/composables/useRowSelection.ts
@@ -1,0 +1,30 @@
+import { computed, ref, type Ref } from "vue"
+
+/** Multi-select for a keyed list, held against the keys that are selectable right now. */
+export function useRowSelection(selectableKeys: Ref<string[]>) {
+	const chosen = ref(new Set<string>())
+
+	// Intersected rather than read straight off the set, so a row a reload took away
+	// cannot stay selected out of sight.
+	const selected = computed(() => selectableKeys.value.filter((key) => chosen.value.has(key)))
+
+	function isSelected(key: string) {
+		return chosen.value.has(key)
+	}
+
+	function toggle(key: string) {
+		const next = new Set(chosen.value)
+		if (!next.delete(key)) next.add(key)
+		chosen.value = next
+	}
+
+	function select(keys: string[]) {
+		chosen.value = new Set(keys)
+	}
+
+	function clear() {
+		chosen.value = new Set()
+	}
+
+	return { selected, isSelected, toggle, select, clear }
+}

--- a/dashboard/src/composables/useRowSelection.ts
+++ b/dashboard/src/composables/useRowSelection.ts
@@ -18,13 +18,9 @@ export function useRowSelection(selectableKeys: Ref<string[]>) {
 		chosen.value = next
 	}
 
-	function select(keys: string[]) {
-		chosen.value = new Set(keys)
-	}
-
 	function clear() {
 		chosen.value = new Set()
 	}
 
-	return { selected, isSelected, toggle, select, clear }
+	return { selected, isSelected, toggle, clear }
 }

--- a/dashboard/src/data/teams.ts
+++ b/dashboard/src/data/teams.ts
@@ -12,6 +12,11 @@ interface InviteAction {
 	email: string
 }
 
+interface MemberBatch {
+	team: string
+	users: string[]
+}
+
 const selectedTeamName = ref(localStorage.getItem(STORAGE_KEY) || "")
 
 const teamsResource = createResource<TeamOption[]>({
@@ -52,10 +57,6 @@ export function useTeamOverview(team: string) {
 	})
 }
 
-export const removeMember = createResource({
-	url: "buzz.api.teams.remove_member",
-})
-
 export const inviteMembers = createResource<InviteOutcome[]>({
 	url: "buzz.api.teams.invite_members",
 })
@@ -86,9 +87,18 @@ export function useRetractInvite() {
 	})
 }
 
-export function useChangeRole() {
-	return useCall<null, { team: string; user: string; team_role: string }>({
-		url: "/api/v2/method/buzz.api.teams.change_role",
+// Batched: the roster acts on a selection, and a single row is a selection of one.
+export function useRemoveMembers() {
+	return useCall<null, MemberBatch>({
+		url: "/api/v2/method/buzz.api.teams.remove_members",
+		method: "POST",
+		immediate: false,
+	})
+}
+
+export function useChangeRoles() {
+	return useCall<null, MemberBatch & { team_role: string }>({
+		url: "/api/v2/method/buzz.api.teams.change_roles",
 		method: "POST",
 		immediate: false,
 	})

--- a/dashboard/src/utils/teamRoles.ts
+++ b/dashboard/src/utils/teamRoles.ts
@@ -17,3 +17,12 @@ export function canManageMembers(teamRole: string | undefined): boolean {
 // Mirrors the membership doctype's Select options, minus Owner. The server rejects anything
 // outside this set, so a drift here fails loudly rather than silently.
 export const ASSIGNABLE_TEAM_ROLES = ["Admin", "Manager", "Frontdesk", "Viewer"]
+
+// Most authority first, which is the order the roster lists people in.
+const TEAM_ROLE_ORDER = ["Owner", ...ASSIGNABLE_TEAM_ROLES]
+
+/** Where a role sits in the roster. An unknown role sorts last rather than first. */
+export function teamRoleRank(teamRole: string): number {
+	const rank = TEAM_ROLE_ORDER.indexOf(teamRole)
+	return rank === -1 ? TEAM_ROLE_ORDER.length : rank
+}

--- a/dashboard/src/utils/teamRoster.test.ts
+++ b/dashboard/src/utils/teamRoster.test.ts
@@ -16,12 +16,70 @@ const grace: TeamInvite = { email: "grace@example.com", team_role: "Viewer" }
 
 const team = { members: [ada], invites: [grace] }
 
+const member = (user: string, team_role: string, full_name: string): TeamMember => ({
+	user,
+	full_name,
+	team_role,
+	user_image: null,
+})
+
 test("members come first, with pending invitations after them", () => {
 	const rows = rosterRows(team)
 
 	assert.deepEqual(
 		rows.map((row) => row.key),
 		["ada@example.com", "invite:grace@example.com"],
+	)
+})
+
+test("each group runs from the most authority to the least", () => {
+	const rows = rosterRows({
+		members: [
+			member("viewer@example.com", "Viewer", "Viewer"),
+			member("owner@example.com", "Owner", "Owner"),
+			member("desk@example.com", "Frontdesk", "Frontdesk"),
+			member("admin@example.com", "Admin", "Admin"),
+			member("manager@example.com", "Manager", "Manager"),
+		],
+		invites: [
+			{ email: "invited-viewer@example.com", team_role: "Viewer" },
+			{ email: "invited-admin@example.com", team_role: "Admin" },
+		],
+	})
+
+	assert.deepEqual(
+		rows.map((row) => row.role),
+		["Owner", "Admin", "Manager", "Frontdesk", "Viewer", "Admin", "Viewer"],
+	)
+})
+
+test("people sharing a role are listed alphabetically", () => {
+	const rows = rosterRows({
+		members: [
+			member("zoe@example.com", "Manager", "Zoe"),
+			member("abe@example.com", "Manager", "Abe"),
+		],
+		invites: [],
+	})
+
+	assert.deepEqual(
+		rows.map((row) => row.name),
+		["Abe", "Zoe"],
+	)
+})
+
+test("an unknown role sorts last rather than first", () => {
+	const rows = rosterRows({
+		members: [
+			member("overlord@example.com", "Overlord", "Overlord"),
+			member("viewer@example.com", "Viewer", "Viewer"),
+		],
+		invites: [],
+	})
+
+	assert.deepEqual(
+		rows.map((row) => row.role),
+		["Viewer", "Overlord"],
 	)
 })
 

--- a/dashboard/src/utils/teamRoster.test.ts
+++ b/dashboard/src/utils/teamRoster.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { TeamInvite, TeamMember } from "@/types"
+
+import { matchesQuery, rosterRows } from "./teamRoster.ts"
+
+const ada: TeamMember = {
+	user: "ada@example.com",
+	full_name: "Ada Lovelace",
+	team_role: "Owner",
+	user_image: null,
+}
+
+const grace: TeamInvite = { email: "grace@example.com", team_role: "Viewer" }
+
+const team = { members: [ada], invites: [grace] }
+
+test("members come first, with pending invitations after them", () => {
+	const rows = rosterRows(team)
+
+	assert.deepEqual(
+		rows.map((row) => row.key),
+		["ada@example.com", "invite:grace@example.com"],
+	)
+})
+
+test("an invitation shows its address as its name and carries no member", () => {
+	const [, invite] = rosterRows(team)
+
+	assert.equal(invite.name, "grace@example.com")
+	assert.equal(invite.member, undefined)
+})
+
+test("a search matches a name, an address or a role", () => {
+	const [row] = rosterRows(team)
+
+	assert.ok(matchesQuery(row, "lovelace"))
+	assert.ok(matchesQuery(row, "ada@"))
+	assert.ok(matchesQuery(row, "owner"))
+	assert.ok(!matchesQuery(row, "grace"))
+})

--- a/dashboard/src/utils/teamRoster.ts
+++ b/dashboard/src/utils/teamRoster.ts
@@ -1,0 +1,45 @@
+import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
+
+/** One line of the roster: a member, or an invitation still waiting on its recipient. */
+export interface RosterRow {
+	key: string
+	name: string
+	email: string
+	role: string
+	image?: string
+	member?: TeamMember
+}
+
+/**
+ * Members and pending invitations as one list, so the roster reads as the whole team,
+ * with the people who have not accepted yet at the bottom.
+ */
+export function rosterRows(team: Pick<TeamOverview, "members" | "invites">): RosterRow[] {
+	return [...team.members.map(memberRow), ...team.invites.map(inviteRow)]
+}
+
+/** Whether a row answers a search, matched against everything the row shows. */
+export function matchesQuery(row: RosterRow, query: string): boolean {
+	return [row.name, row.email, row.role].some((field) => field.toLowerCase().includes(query))
+}
+
+function memberRow(member: TeamMember): RosterRow {
+	return {
+		key: member.user,
+		name: member.full_name ?? member.user,
+		email: member.user,
+		role: member.team_role,
+		image: member.user_image ?? undefined,
+		member,
+	}
+}
+
+// There is no user yet, so no name and no image — the address stands in for both.
+function inviteRow(invite: TeamInvite): RosterRow {
+	return {
+		key: `invite:${invite.email}`,
+		name: invite.email,
+		email: invite.email,
+		role: invite.team_role,
+	}
+}

--- a/dashboard/src/utils/teamRoster.ts
+++ b/dashboard/src/utils/teamRoster.ts
@@ -1,5 +1,7 @@
 import type { TeamInvite, TeamMember, TeamOverview } from "@/types"
 
+import { teamRoleRank } from "./teamRoles.ts"
+
 /** One line of the roster: a member, or an invitation still waiting on its recipient. */
 export interface RosterRow {
 	key: string
@@ -12,15 +14,23 @@ export interface RosterRow {
 
 /**
  * Members and pending invitations as one list, so the roster reads as the whole team,
- * with the people who have not accepted yet at the bottom.
+ * with the people who have not accepted yet at the bottom. Each group runs from the most
+ * authority to the least, and alphabetically inside a role.
  */
 export function rosterRows(team: Pick<TeamOverview, "members" | "invites">): RosterRow[] {
-	return [...team.members.map(memberRow), ...team.invites.map(inviteRow)]
+	return [...byRole(team.members.map(memberRow)), ...byRole(team.invites.map(inviteRow))]
+}
+
+function byRole(rows: RosterRow[]): RosterRow[] {
+	return rows.toSorted(
+		(one, other) =>
+			teamRoleRank(one.role) - teamRoleRank(other.role) || one.name.localeCompare(other.name),
+	)
 }
 
 /** Whether a row answers a search, matched against everything the row shows. */
-export function matchesQuery(row: RosterRow, query: string): boolean {
-	return [row.name, row.email, row.role].some((field) => field.toLowerCase().includes(query))
+export function matchesQuery(row: RosterRow, loweredQuery: string): boolean {
+	return [row.name, row.email, row.role].some((field) => field.toLowerCase().includes(loweredQuery))
 }
 
 function memberRow(member: TeamMember): RosterRow {

--- a/e2e/tests/user-settings.spec.ts
+++ b/e2e/tests/user-settings.spec.ts
@@ -89,4 +89,25 @@ test.describe("User settings", () => {
 		await panel.getByRole("button", { name: "Back to teams" }).click()
 		await expect(panel.getByRole("heading", { name: "Your Teams" })).toBeVisible()
 	})
+
+	test("searches the roster of a team", async ({ page }) => {
+		const panel = settings(page)
+
+		await panel.getByRole("tab", { name: "Teams" }).click()
+		const teams = panel.getByRole("list", { name: "Your teams" }).getByRole("listitem")
+		await expect(teams.first()).toContainText("members", { timeout: 15000 })
+		await teams.first().getByRole("button").click()
+
+		const members = panel.getByRole("list", { name: "Team members" }).getByRole("listitem")
+		await expect(members.first()).toContainText("Owner", { timeout: 15000 })
+
+		const search = panel.getByPlaceholder("Search members")
+		await search.fill(SETTINGS_EMAIL)
+		await expect(members).toHaveCount(1)
+		await expect(members.first()).toContainText(SETTINGS_EMAIL)
+
+		await search.fill("nobody-on-this-team")
+		await expect(members).toHaveCount(0)
+		await expect(panel.getByText("No members found")).toBeVisible()
+	})
 })


### PR DESCRIPTION
## What changed

- Search the roster by name, address or role; a selection survives the search that hides it.
- Multi-select with a floating bar, sticky at the top of the list and styled after frappe-ui's `ListSelectBanner`.
- `remove_member`/`change_role` become `remove_members`/`change_roles`; one request is one transaction, so a batch never lands half-applied.
- Roster runs Owner to Viewer, alphabetical within a role, invitations last; rank comes from the doctype's own options.
- Owner rows and your own row stay unselectable, and an invitation carries no checkbox at all.
- `ListView` itself is not adopted: unstable per its own export comment, and it models neither the mixed member/invite list nor a filter that outlives a selection.

## Demo

Roster in role order, invitations last:

![Team roster ordered by role, invitations last](https://github.com/user-attachments/assets/f18127b2-a4eb-4561-8493-f3653db05041)

Bar pinned at the top of the list, over the rows rather than above them:

![Three members selected, bar pinned at the top of the list](https://github.com/user-attachments/assets/67cb593f-98ec-4436-aca5-80922cc2f5c0)

Search holds the selection — two of the three are behind the filter:

![Roster filtered to one row with three members still selected](https://github.com/user-attachments/assets/29499f5d-85f1-44db-9114-1ee28023f09b)

## Testing

- Server tests for batch removal and batch role change, on top of the existing permission and owner-lock cases.
- Unit tests for `useRowSelection` and `teamRoster` (rows, search, role ordering, unknown role last).
- E2E case for roster search; `user-settings-chromium` 7/7 locally.
- Checked against a seeded 26-row roster: first row's `offsetTop` unchanged by selecting, and the bar pins below the panel header.
